### PR TITLE
Add link from dev docs to create-nodes docs

### DIFF
--- a/docs/reference/development.md
+++ b/docs/reference/development.md
@@ -1,3 +1,5 @@
 # Development
 
 Have you found a bug :bug:? Or maybe you have a nice feature :sparkles: to contribute? The [CONTRIBUTING guide](https://github.com/n8n-io/n8n/blob/master/CONTRIBUTING.md) will help you get your development environment ready in minutes.
+
+If you are interested in creating or extending nodes please go to the [create-node](../nodes/creating-nodes/create-node.html) section.


### PR DESCRIPTION
I sometimes had trouble finding the correct docs as are multiple pages on the topic. Maybe even more links from one doc to another could be helpful.

https://github.com/n8n-io/n8n/blob/master/CONTRIBUTING.md
https://github.com/n8n-io/n8n/tree/master/packages/node-dev

https://docs.n8n.io/reference/development.html
https://docs.n8n.io/nodes/creating-nodes/create-node.html