### PR TITLE
Minor clarification in server-setup.md

### DIFF
--- a/docs/reference/server-setup.md
+++ b/docs/reference/server-setup.md
@@ -60,7 +60,15 @@ IP address: <IP_OF_YOUR_SERVER>
 
 Save this file as `docker-compose.yml`
 
-Normally no changes should be needed.
+Normally no changes should be needed, but if you are planning on reading/writing local files with n8n (e.g. by using the write binary files integration), you will need to configure a data directory for those files here. If you are running n8n as a root user, add this under ``volumes`` for the n8n service:
+
+      - /local-files:/files
+
+If you are running n8n as a non-root user, add this under ``volumes`` for the n8n service:
+
+      - /home/<YOUR USERNAME>/n8n-local-files:/files``
+
+Then, you will be able to write files to the ``/files`` directory in n8n and they will appear on your server in either ``/local-files`` or ``/home/<YOUR USERNAME>/n8n-local-files``, respectively.
 
 ```yaml
 version: "3"


### PR DESCRIPTION
This pull request makes a minor clarification to the server setup documentation to show what changes users need to make to their docker-compose.yml file to allow n8n to read/write files in a local directory.

See https://github.com/n8n-io/n8n/pull/688 for additional context.