### PR TITLE
Removing old link update and inserting Raspberry PI post reference in correct community section

### DIFF
--- a/docs/getting-started/tutorials.md
+++ b/docs/getting-started/tutorials.md
@@ -26,6 +26,7 @@
 
 ## Community tutorials
 
+- [Install n8n in Raspberry PI and Create your First Workflow Monitoring CPU Temperature With Email Alerts](https://peppe8o.com/how-to-use-n8n-and-raspberry-pi-to-create-workflows-and-automate-apis/)
 - [n8n basics 1/3 - Getting Started](https://www.youtube.com/watch?v=JIaxjH2CyFc)
 - [n8n basics 2/3 - Simple Workflow](https://www.youtube.com/watch?v=ovlxledZfM4)
 - [n8n basics 3/3 - Transforming JSON](https://www.youtube.com/watch?v=wGAEAcfwV8w)

--- a/docs/getting-started/tutorials.md
+++ b/docs/getting-started/tutorials.md
@@ -12,6 +12,7 @@
 - [Database Monitoring and Alerting with n8n 📡](https://medium.com/n8n-io/database-monitoring-and-alerting-with-n8n-f5082df7bdb2)
 - [Effortless video collaboration with Whereby, Mattermost, and n8n 📹](https://medium.com/n8n-io/effortless-video-collaboration-with-whereby-mattermost-and-n8n-8fc397feb9cb)
 - [Giving kudos to contributors with GitHub, Slack, and n8n 👏](https://medium.com/n8n-io/effortless-video-collaboration-with-whereby-mattermost-and-n8n-8fc397feb9cb)
+- [Install n8n in Raspberry PI and Create your First Workflow Monitoring CPU Temperature With Email Alerts](https://peppe8o.com/how-to-use-n8n-and-raspberry-pi-to-create-workflows-and-automate-apis/)
 - [HTTP Request Node — The Swiss Army Knife](https://medium.com/n8n-io/http-request-node-the-swiss-army-knife-b14e22283383)
 - [Smart Factory Automation using IoT and Sensor Data with n8n 🏭](https://medium.com/n8n-io/smart-factory-automation-using-iot-and-sensor-data-with-n8n-27675de9943b)
 - [Tracking Time Spent in Meetings With Google Calendar, Twilio, and n8n 🗓](https://medium.com/n8n-io/tracking-time-spent-in-meetings-with-google-calendar-twilio-and-n8n-a5d00f77da8c)

--- a/docs/getting-started/tutorials.md
+++ b/docs/getting-started/tutorials.md
@@ -12,7 +12,6 @@
 - [Database Monitoring and Alerting with n8n 📡](https://medium.com/n8n-io/database-monitoring-and-alerting-with-n8n-f5082df7bdb2)
 - [Effortless video collaboration with Whereby, Mattermost, and n8n 📹](https://medium.com/n8n-io/effortless-video-collaboration-with-whereby-mattermost-and-n8n-8fc397feb9cb)
 - [Giving kudos to contributors with GitHub, Slack, and n8n 👏](https://medium.com/n8n-io/effortless-video-collaboration-with-whereby-mattermost-and-n8n-8fc397feb9cb)
-- [Install n8n in Raspberry PI and Create your First Workflow Monitoring CPU Temperature With Email Alerts](https://peppe8o.com/how-to-use-n8n-and-raspberry-pi-to-create-workflows-and-automate-apis/)
 - [HTTP Request Node — The Swiss Army Knife](https://medium.com/n8n-io/http-request-node-the-swiss-army-knife-b14e22283383)
 - [Smart Factory Automation using IoT and Sensor Data with n8n 🏭](https://medium.com/n8n-io/smart-factory-automation-using-iot-and-sensor-data-with-n8n-27675de9943b)
 - [Tracking Time Spent in Meetings With Google Calendar, Twilio, and n8n 🗓](https://medium.com/n8n-io/tracking-time-spent-in-meetings-with-google-calendar-twilio-and-n8n-a5d00f77da8c)


### PR DESCRIPTION
Remove old link from blogposts section and moving it to community section