### PR TITLE
Fix link to workflow creation overview section

### DIFF
--- a/docs/nodes/nodes-library/core-nodes/Cron/README.md
+++ b/docs/nodes/nodes-library/core-nodes/Cron/README.md
@@ -12,7 +12,7 @@ The Cron node is useful to schedule the workflows to run periodically at fixed d
 2. Make sure that the timezone is set correctly for the n8n instance (or the workflow).
 :::
 
-You can find the example usage of the Cron node in the [Creating Your First Workflow](../../../../getting-started/creating-your-first-workflow.md) guide.
+You can find the example usage of the Cron node in the [Creating Your First Workflow](../../../../getting-started/create-your-first-workflow/create-your-first-workflow/README.md) guide.
 
 
 ## Node Reference


### PR DESCRIPTION
At the [Cron page](https://docs.n8n.io/nodes/n8n-nodes-base.cron/), the link [Creating Your First Workflow](https://docs.n8n.io/getting-started/creating-your-first-workflow.html) gives a 404.

