### PR TITLE
Fix failing redirects

### DIFF
--- a/docs/nodes/credentials/AMQP/README.md
+++ b/docs/nodes/credentials/AMQP/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/amqp
 description: Learn to configure credentials for the AMQP node in n8n
 ---
 

--- a/docs/nodes/credentials/AWS/README.md
+++ b/docs/nodes/credentials/AWS/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/aws
 description: Learn to configure credentials for the AWS nodes in n8n
 ---
 

--- a/docs/nodes/credentials/ActiveCampaign/README.md
+++ b/docs/nodes/credentials/ActiveCampaign/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/activeCampaign
 description: Learn to configure credentials for the ActiveCampaign node in n8n
 ---
 

--- a/docs/nodes/credentials/AcuityScheduling/README.md
+++ b/docs/nodes/credentials/AcuityScheduling/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/acuityScheduling
 description: Learn to configure credentials for the AcuityScheduling node in n8n
 ---
 

--- a/docs/nodes/credentials/Affinity/README.md
+++ b/docs/nodes/credentials/Affinity/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/affinity
 description: Learn to configure credentials for the Affinity node in n8n
 ---
 

--- a/docs/nodes/credentials/AgileCrm/README.md
+++ b/docs/nodes/credentials/AgileCrm/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/agileCrm
 description: Learn to configure credentials for the Agile CRM node in n8n
 ---
 

--- a/docs/nodes/credentials/Airtable/README.md
+++ b/docs/nodes/credentials/Airtable/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/airtable
 description: Learn to configure credentials for the Airtable node in n8n
 ---
 

--- a/docs/nodes/credentials/Asana/README.md
+++ b/docs/nodes/credentials/Asana/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/asana
 description: Learn to configure credentials for the Asana node in n8n
 ---
 

--- a/docs/nodes/credentials/Automizy/README.md
+++ b/docs/nodes/credentials/Automizy/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/automizy
 description: Learn to configure credentials for the Automizy node in n8n
 ---
 

--- a/docs/nodes/credentials/Bannerbear/README.md
+++ b/docs/nodes/credentials/Bannerbear/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/bannerbear
 description: Learn to configure credentials for the Bannerbear node in n8n
 ---
 

--- a/docs/nodes/credentials/Bitbucket/README.md
+++ b/docs/nodes/credentials/Bitbucket/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/bitbucket
 description: Learn to configure credentials for the Bitbucket node in n8n
 ---
 

--- a/docs/nodes/credentials/Bitly/README.md
+++ b/docs/nodes/credentials/Bitly/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/bitly
 description: Learn to configure credentials for the Bitly node in n8n
 ---
 

--- a/docs/nodes/credentials/Box/README.md
+++ b/docs/nodes/credentials/Box/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/box
 description: Learn to configure credentials for the Box node in n8n
 ---
 

--- a/docs/nodes/credentials/Brandfetch/README.md
+++ b/docs/nodes/credentials/Brandfetch/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/brandfetch
 description: Learn to configure credentials for the Brandfetch node in n8n
 ---
 

--- a/docs/nodes/credentials/Calendly/README.md
+++ b/docs/nodes/credentials/Calendly/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/calendly
 description: Learn to configure credentials for the Calendly node in n8n
 ---
 

--- a/docs/nodes/credentials/Chargebee/README.md
+++ b/docs/nodes/credentials/Chargebee/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/chargebee
 description: Learn to configure credentials for the Chargebee node in n8n
 ---
 

--- a/docs/nodes/credentials/CircleCI/README.md
+++ b/docs/nodes/credentials/CircleCI/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/circleCi
 description: Learn to configure credentials for the CircleCI node in n8n
 ---
 
@@ -11,7 +10,7 @@ You can use these credentials to authenticate the following nodes with CircleCI.
 
 ## Prerequisites
 
-Create a [CircleCI](https://circleci.com/) account. 
+Create a [CircleCI](https://circleci.com/) account.
 
 ## Using Access Token
 

--- a/docs/nodes/credentials/Clearbit/README.md
+++ b/docs/nodes/credentials/Clearbit/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/clearbit
 description: Learn to configure credentials for the Clearbit node in n8n
 ---
 

--- a/docs/nodes/credentials/Clickup/README.md
+++ b/docs/nodes/credentials/Clickup/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/clickUp
 description: Learn to configure credentials for the ClickUp node in n8n
 ---
 

--- a/docs/nodes/credentials/Clockify/README.md
+++ b/docs/nodes/credentials/Clockify/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/clockify
 description: Learn to configure credentials for the Clockify node in n8n
 ---
 

--- a/docs/nodes/credentials/Cockpit/README.md
+++ b/docs/nodes/credentials/Cockpit/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/cockpit
 description: Learn to configure credentials for the Cockpit node in n8n
 ---
 

--- a/docs/nodes/credentials/Coda/README.md
+++ b/docs/nodes/credentials/Coda/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/coda
 description: Learn to configure credentials for the Coda node in n8n
 ---
 

--- a/docs/nodes/credentials/Contentful/README.md
+++ b/docs/nodes/credentials/Contentful/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/contentful
 description: Learn to configure credentials for the Contentful node in n8n
 ---
 

--- a/docs/nodes/credentials/ConvertKit/README.md
+++ b/docs/nodes/credentials/ConvertKit/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/convertKit
 description: Learn to configure credentials for the ConvertKit node in n8n
 ---
 

--- a/docs/nodes/credentials/Copper/README.md
+++ b/docs/nodes/credentials/Copper/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/copper
 description: Learn to configure credentials for the Copper node in n8n
 ---
 

--- a/docs/nodes/credentials/Cortex/README.md
+++ b/docs/nodes/credentials/Cortex/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/cortex
 description: Learn to configure credentials for the Cortex node in n8n
 ---
 # Cortex

--- a/docs/nodes/credentials/CrateDB/README.md
+++ b/docs/nodes/credentials/CrateDB/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/crateDb
 description: Learn to configure credentials for the CrateDB node in n8n
 ---
 
@@ -10,7 +9,7 @@ You can use these credentials to authenticate the following nodes with CrateDB.
 
 ## Prerequisites
 
-An available instance of CrateDB. 
+An available instance of CrateDB.
 
 ## Using Database Connection
 

--- a/docs/nodes/credentials/CustomerIo/README.md
+++ b/docs/nodes/credentials/CustomerIo/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/customerIo
 description: Learn to configure credentials for the Customer.io node in n8n
 ---
 

--- a/docs/nodes/credentials/Discord/README.md
+++ b/docs/nodes/credentials/Discord/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/discord
 description: Learn to configure credentials for the Discord node in n8n
 ---
 

--- a/docs/nodes/credentials/Disqus/README.md
+++ b/docs/nodes/credentials/Disqus/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/disqus
 description: Learn to configure credentials for the Disqus node in n8n
 ---
 

--- a/docs/nodes/credentials/Drift/README.md
+++ b/docs/nodes/credentials/Drift/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/drift
 description: Learn to configure credentials for the Drift node in n8n
 ---
 

--- a/docs/nodes/credentials/Dropbox/README.md
+++ b/docs/nodes/credentials/Dropbox/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/dropbox
 description: Learn to configure credentials for the Dropbox node in n8n
 ---
 

--- a/docs/nodes/credentials/EGoi/README.md
+++ b/docs/nodes/credentials/EGoi/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/egoi
 description: Learn to configure credentials for the E-goi node in n8n
 ---
 

--- a/docs/nodes/credentials/Eventbrite/README.md
+++ b/docs/nodes/credentials/Eventbrite/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/eventbrite
 description: Learn to configure credentials for the Eventbrite node in n8n
 ---
 

--- a/docs/nodes/credentials/FTP/README.md
+++ b/docs/nodes/credentials/FTP/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/ftp
 description: Learn to configure credentials for the FTP node in n8n
 ---
 
@@ -10,7 +9,7 @@ You can use these credentials to authenticate the following nodes with FTP.
 
 ## Prerequisites
 
-Create an account on an FTP server. 
+Create an account on an FTP server.
 
 ## Using FTP/SFTP
 

--- a/docs/nodes/credentials/FacebookApp/README.md
+++ b/docs/nodes/credentials/FacebookApp/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/facebookGraphApp
 description: Learn to configure credentials for the Facebook Trigger node in n8n
 ---
 

--- a/docs/nodes/credentials/FacebookGraphAPI/README.md
+++ b/docs/nodes/credentials/FacebookGraphAPI/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/facebookGraph
 description: Learn to configure credentials for the Facebook node in n8n
 ---
 

--- a/docs/nodes/credentials/FileMaker/README.md
+++ b/docs/nodes/credentials/FileMaker/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/fileMaker
 description: Learn to configure credentials for the FileMaker node in n8n
 ---
 
@@ -10,7 +9,7 @@ You can use these credentials to authenticate the following nodes with FileMaker
 
 ## Prerequisites
 
-Create an user account on a FileMaker server. 
+Create an user account on a FileMaker server.
 
 ## Using Database Connection
 

--- a/docs/nodes/credentials/Flow/README.md
+++ b/docs/nodes/credentials/Flow/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/flow
 description: Learn to configure credentials for the Flow node in n8n
 ---
 

--- a/docs/nodes/credentials/Freshdesk/README.md
+++ b/docs/nodes/credentials/Freshdesk/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/freshdesk
 description: Learn to configure credentials for the Freshdesk node in n8n
 ---
 

--- a/docs/nodes/credentials/GetResponse/README.md
+++ b/docs/nodes/credentials/GetResponse/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/getResponse
 description: Learn to configure credentials for the GetResponse node in n8n
 ---
 

--- a/docs/nodes/credentials/Ghost/README.md
+++ b/docs/nodes/credentials/Ghost/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/ghost
 description: Learn to configure credentials for the Ghost node in n8n
 ---
 

--- a/docs/nodes/credentials/Github/README.md
+++ b/docs/nodes/credentials/Github/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/github
 description: Learn to configure credentials for the GitHub node in n8n
 ---
 

--- a/docs/nodes/credentials/Gitlab/README.md
+++ b/docs/nodes/credentials/Gitlab/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/gitlab
 description: Learn to configure credentials for the GitLab node in n8n
 ---
 

--- a/docs/nodes/credentials/Google/README.md
+++ b/docs/nodes/credentials/Google/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/google
 description: Learn to configure credentials for the nodes based on Google services in n8n
 ---
 

--- a/docs/nodes/credentials/Gotify/README.md
+++ b/docs/nodes/credentials/Gotify/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/gotify
 description: Learn to configure credentials for the Gotify node in n8n
 ---
 

--- a/docs/nodes/credentials/Gumroad/README.md
+++ b/docs/nodes/credentials/Gumroad/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/gumroad
 description: Learn to configure credentials for the Gumroad node in n8n
 ---
 

--- a/docs/nodes/credentials/Harvest/README.md
+++ b/docs/nodes/credentials/Harvest/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/harvest
 description: Learn to configure credentials for the Harvest node in n8n
 ---
 

--- a/docs/nodes/credentials/HelpScout/README.md
+++ b/docs/nodes/credentials/HelpScout/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/helpScout
 description: Learn to configure credentials for the Help Scout node in n8n
 ---
 

--- a/docs/nodes/credentials/Hubspot/README.md
+++ b/docs/nodes/credentials/Hubspot/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/hubspot
 description: Learn to configure credentials for the HubSpot node in n8n
 ---
 

--- a/docs/nodes/credentials/HumanticAI/README.md
+++ b/docs/nodes/credentials/HumanticAI/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/humanticAi
 description: Learn to configure credentials for the Humantic AI node in n8n
 ---
 

--- a/docs/nodes/credentials/Hunter/README.md
+++ b/docs/nodes/credentials/Hunter/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/hunter
 description: Learn to configure credentials for the Hunter node in n8n
 ---
 

--- a/docs/nodes/credentials/IMAP/README.md
+++ b/docs/nodes/credentials/IMAP/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/imap
 description: Learn to configure credentials for the IMAP node in n8n
 ---
 

--- a/docs/nodes/credentials/Intercom/README.md
+++ b/docs/nodes/credentials/Intercom/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/intercom
 description: Learn to configure credentials for the Intercom node in n8n
 ---
 

--- a/docs/nodes/credentials/InvoiceNinja/README.md
+++ b/docs/nodes/credentials/InvoiceNinja/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/invoiceNinja
 description: Learn to configure credentials for the Invoice Ninja node in n8n
 ---
 

--- a/docs/nodes/credentials/Iterable/README.md
+++ b/docs/nodes/credentials/Iterable/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/iterable
 description: Learn to configure credentials for the Iterable node in n8n
 ---
 

--- a/docs/nodes/credentials/JIRA/README.md
+++ b/docs/nodes/credentials/JIRA/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/jira
 description: Learn to configure credentials for the Jira node in n8n
 ---
 

--- a/docs/nodes/credentials/JotForm/README.md
+++ b/docs/nodes/credentials/JotForm/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/jotForm
 description: Learn to configure credentials for the JotForm node in n8n
 ---
 

--- a/docs/nodes/credentials/Kafka/README.md
+++ b/docs/nodes/credentials/Kafka/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/kafka
 description: Learn to configure credentials for the Kafka node in n8n
 ---
 

--- a/docs/nodes/credentials/Keap/README.md
+++ b/docs/nodes/credentials/Keap/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/keap
 description: Learn to configure credentials for the Keap node in n8n
 ---
 

--- a/docs/nodes/credentials/Line/README.md
+++ b/docs/nodes/credentials/Line/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/line
 description: Learn to configure credentials for the Line node in n8n
 ---
 

--- a/docs/nodes/credentials/LingvaNex/README.md
+++ b/docs/nodes/credentials/LingvaNex/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/lingvaNex
 description: Learn to configure credentials for the LingvaNex node in n8n
 ---
 

--- a/docs/nodes/credentials/LinkedIn/README.md
+++ b/docs/nodes/credentials/LinkedIn/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/linkedIn
 description: Learn to configure credentials for the LinkedIn node in n8n
 ---
 

--- a/docs/nodes/credentials/MQTT/README.md
+++ b/docs/nodes/credentials/MQTT/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/mqtt
 description: Learn to configure credentials for the MQTT node in n8n
 ---
 

--- a/docs/nodes/credentials/MSG91/README.md
+++ b/docs/nodes/credentials/MSG91/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/msg91
 description: Learn to configure credentials for the MSG91 node in n8n
 ---
 

--- a/docs/nodes/credentials/MailChimp/README.md
+++ b/docs/nodes/credentials/MailChimp/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/mailchimp
 description: Learn to configure credentials for the Mailchimp node in n8n
 ---
 

--- a/docs/nodes/credentials/MailerLite/README.md
+++ b/docs/nodes/credentials/MailerLite/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/mailerLite
 description: Learn to configure credentials for the MailerLite node in n8n
 ---
 

--- a/docs/nodes/credentials/Mailgun/README.md
+++ b/docs/nodes/credentials/Mailgun/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/mailgun
 description: Learn to configure credentials for the Mailgun node in n8n
 ---
 

--- a/docs/nodes/credentials/Mailjet/README.md
+++ b/docs/nodes/credentials/Mailjet/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/mailjet
 description: Learn to configure credentials for the Mailjet node in n8n
 ---
 

--- a/docs/nodes/credentials/Mandrill/README.md
+++ b/docs/nodes/credentials/Mandrill/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/mandrill
 description: Learn to configure credentials for the Mandrill node in n8n
 ---
 

--- a/docs/nodes/credentials/Matrix/README.md
+++ b/docs/nodes/credentials/Matrix/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/matrix
 description: Learn to configure credentials for the Matrix node in n8n
 ---
 

--- a/docs/nodes/credentials/Mattermost/README.md
+++ b/docs/nodes/credentials/Mattermost/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/mattermost
 description: Learn to configure credentials for the Mattermost node in n8n
 ---
 

--- a/docs/nodes/credentials/Mautic/README.md
+++ b/docs/nodes/credentials/Mautic/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/mautic
 description: Learn to configure credentials for the Mautic node in n8n
 ---
 

--- a/docs/nodes/credentials/Medium/README.md
+++ b/docs/nodes/credentials/Medium/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/medium
 description: Learn to configure credentials for the Medium node in n8n
 ---
 

--- a/docs/nodes/credentials/MessageBird/README.md
+++ b/docs/nodes/credentials/MessageBird/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/messageBird
 description: Learn to configure credentials for the MessageBird node in n8n
 ---
 
@@ -10,7 +9,7 @@ You can use these credentials to authenticate the following nodes with MessageBi
 
 ## Prerequisites
 
-Create a [MessageBird](https://www.messagebird.com/en/) account. 
+Create a [MessageBird](https://www.messagebird.com/en/) account.
 
 ## Using Access Token
 

--- a/docs/nodes/credentials/Microsoft/README.md
+++ b/docs/nodes/credentials/Microsoft/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/microsoft
 description: Learn to configure credentials for the nodes based on Microsoft services in n8n
 ---
 

--- a/docs/nodes/credentials/MicrosoftSQL/README.md
+++ b/docs/nodes/credentials/MicrosoftSQL/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/microsoftSql
 description: Learn to configure credentials for the Microsoft SQL node in n8n
 ---
 
@@ -10,7 +9,7 @@ You can use these credentials to authenticate the following nodes with Microsoft
 
 ## Prerequisites
 
-Create an user account on a Microsoft SQL server. 
+Create an user account on a Microsoft SQL server.
 
 ## Using Database Connection
 

--- a/docs/nodes/credentials/Mindee/README.md
+++ b/docs/nodes/credentials/Mindee/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/mindee
 description: Learn to configure credentials for the Mindee node in n8n
 ---
 

--- a/docs/nodes/credentials/Mocean/README.md
+++ b/docs/nodes/credentials/Mocean/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/mocean
 description: Learn to configure credentials for the Mocean node in n8n
 ---
 

--- a/docs/nodes/credentials/Mondaycom/README.md
+++ b/docs/nodes/credentials/Mondaycom/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/mondayCom
 description: Learn to configure credentials for the monday.com node in n8n
 ---
 

--- a/docs/nodes/credentials/MongoDB/README.md
+++ b/docs/nodes/credentials/MongoDB/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/mongoDb
 description: Learn to configure credentials for the MongoDB node in n8n
 ---
 

--- a/docs/nodes/credentials/MySQL/README.md
+++ b/docs/nodes/credentials/MySQL/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/mySql
 description: Learn to configure credentials for the MySQL node in n8n
 ---
 
@@ -10,7 +9,7 @@ You can use these credentials to authenticate the following nodes with MySQL.
 
 ## Prerequisites
 
-Create an user account on a MySQL server. 
+Create an user account on a MySQL server.
 
 ## Using Database Connection
 

--- a/docs/nodes/credentials/NASA/README.md
+++ b/docs/nodes/credentials/NASA/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/nasa
 description: Learn to configure credentials for the NASA node in n8n
 ---
 

--- a/docs/nodes/credentials/NextCloud/README.md
+++ b/docs/nodes/credentials/NextCloud/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/nextCloud
 description: Learn to configure credentials for the Nextcloud node in n8n
 ---
 

--- a/docs/nodes/credentials/OpenWeatherMap/README.md
+++ b/docs/nodes/credentials/OpenWeatherMap/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/openWeatherMap
 description: Learn to configure credentials for the OpenWeatherMap node in n8n
 ---
 
@@ -10,7 +9,7 @@ You can use these credentials to authenticate the following nodes with OpenWeath
 
 ## Prerequisites
 
-Create a [OpenWeatherMap](https://openweathermap.org/) account. 
+Create a [OpenWeatherMap](https://openweathermap.org/) account.
 
 ## Using Access Token
 

--- a/docs/nodes/credentials/Orbit/README.md
+++ b/docs/nodes/credentials/Orbit/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/orbit
 description: Learn to configure credentials for the Orbite node in n8n
 ---
 

--- a/docs/nodes/credentials/Paddle/README.md
+++ b/docs/nodes/credentials/Paddle/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/paddle
 description: Learn to configure credentials for the Paddle node in n8n
 ---
 

--- a/docs/nodes/credentials/PagerDuty/README.md
+++ b/docs/nodes/credentials/PagerDuty/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/pagerDuty
 description: Learn to configure credentials for the PagerDuty node in n8n
 ---
 

--- a/docs/nodes/credentials/PayPal/README.md
+++ b/docs/nodes/credentials/PayPal/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/payPal
 description: Learn to configure credentials for the PayPal node in n8n
 ---
 

--- a/docs/nodes/credentials/PhilipsHue/README.md
+++ b/docs/nodes/credentials/PhilipsHue/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/philipsHue
 description: Learn to configure credentials for the Philips Hue node in n8n
 ---
 

--- a/docs/nodes/credentials/PipeDrive/README.md
+++ b/docs/nodes/credentials/PipeDrive/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/pipedrive
 description: Learn to configure credentials for the Pipedrive node in n8n
 ---
 

--- a/docs/nodes/credentials/Postgres/README.md
+++ b/docs/nodes/credentials/Postgres/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/postgres
 description: Learn to configure credentials for the Postgres node in n8n
 ---
 
@@ -10,7 +9,7 @@ You can use these credentials to authenticate the following nodes with Postgres.
 
 ## Prerequisites
 
-Create an user account on a Postgres server. 
+Create an user account on a Postgres server.
 
 ## Using Database Connection
 

--- a/docs/nodes/credentials/Postmark/README.md
+++ b/docs/nodes/credentials/Postmark/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/postmark
 description: Learn to configure credentials for the Postmark node in n8n
 ---
 

--- a/docs/nodes/credentials/ProfitWell/README.md
+++ b/docs/nodes/credentials/ProfitWell/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/profitWell
 description: Learn to configure credentials for the ProfitWell node in n8n
 ---
 

--- a/docs/nodes/credentials/Pushbullet/README.md
+++ b/docs/nodes/credentials/Pushbullet/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/pushbullet
 description: Learn to configure credentials for the Pushbullet node in n8n
 ---
 

--- a/docs/nodes/credentials/Pushcut/README.md
+++ b/docs/nodes/credentials/Pushcut/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/pushcut
 description: Learn to configure credentials for the Pushcut node in n8n
 ---
 

--- a/docs/nodes/credentials/Pushover/README.md
+++ b/docs/nodes/credentials/Pushover/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/pushover
 description: Learn to configure credentials for the Pushover node in n8n
 ---
 

--- a/docs/nodes/credentials/QuestDB/README.md
+++ b/docs/nodes/credentials/QuestDB/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/questDb
 description: Learn to configure credentials for the QuestDB node in n8n
 ---
 
@@ -10,7 +9,7 @@ You can use these credentials to authenticate the following nodes with QuestDB.
 
 ## Prerequisites
 
-An available instance of QuestDB. 
+An available instance of QuestDB.
 
 ## Using Database Connection
 

--- a/docs/nodes/credentials/QuickBase/README.md
+++ b/docs/nodes/credentials/QuickBase/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/quickbase
 description: Learn to configure credentials for the Quick Base node in n8n
 ---
 

--- a/docs/nodes/credentials/RabbitMQ/README.md
+++ b/docs/nodes/credentials/RabbitMQ/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/rabbitmq
 description: Learn to configure credentials for the RabbitMQ node in n8n
 ---
 

--- a/docs/nodes/credentials/Redis/README.md
+++ b/docs/nodes/credentials/Redis/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/redis
 description: Learn to configure credentials for the Redis node in n8n
 ---
 
@@ -10,7 +9,7 @@ You can use these credentials to authenticate the following nodes with Redis.
 
 ## Prerequisites
 
-Create an user account on a Redis server. 
+Create an user account on a Redis server.
 
 ## Using Database Connection
 

--- a/docs/nodes/credentials/RocketChat/README.md
+++ b/docs/nodes/credentials/RocketChat/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/rocketchat
 description: Learn to configure credentials for the Rocket.Chat node in n8n
 ---
 

--- a/docs/nodes/credentials/Rundeck/README.md
+++ b/docs/nodes/credentials/Rundeck/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/rundeck
 description: Learn to configure credentials for the Rundeck node in n8n
 ---
 

--- a/docs/nodes/credentials/S3/README.md
+++ b/docs/nodes/credentials/S3/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/s3
 description: Learn to configure credentials for the S3 node in n8n
 ---
 

--- a/docs/nodes/credentials/SIGNL4/README.md
+++ b/docs/nodes/credentials/SIGNL4/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/signl4
 description: Learn to configure credentials for the SIGNL4 node in n8n
 ---
 

--- a/docs/nodes/credentials/Salesforce/README.md
+++ b/docs/nodes/credentials/Salesforce/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/salesforce
 description: Learn to configure credentials for the Salesforce node in n8n
 ---
 

--- a/docs/nodes/credentials/Salesmate/README.md
+++ b/docs/nodes/credentials/Salesmate/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/salesmate
 description: Learn to configure credentials for the Salesmate node in n8n
 ---
 

--- a/docs/nodes/credentials/Segment/README.md
+++ b/docs/nodes/credentials/Segment/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/segment
 description: Learn to configure credentials for the Segment node in n8n
 ---
 

--- a/docs/nodes/credentials/SendEmail/README.md
+++ b/docs/nodes/credentials/SendEmail/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/smtp
 description: Learn to configure credentials for the Send Email node in n8n
 ---
 
@@ -10,7 +9,7 @@ You can use these credentials to authenticate the following nodes with SMTP.
 
 ## Prerequisites
 
-Create an email account on a service with SMTP support. 
+Create an email account on a service with SMTP support.
 
 ## Using SMTP
 

--- a/docs/nodes/credentials/Sendy/README.md
+++ b/docs/nodes/credentials/Sendy/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/sendy
 description: Learn to configure credentials for the Sendy node in n8n
 ---
 

--- a/docs/nodes/credentials/SentryIo/README.md
+++ b/docs/nodes/credentials/SentryIo/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/sentryIo
 description: Learn to configure credentials for the Sentry.io node in n8n
 ---
 

--- a/docs/nodes/credentials/Shopify/README.md
+++ b/docs/nodes/credentials/Shopify/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/shopify
 description: Learn to configure credentials for the Shopify node in n8n
 ---
 

--- a/docs/nodes/credentials/Slack/README.md
+++ b/docs/nodes/credentials/Slack/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/slack
 description: Learn to configure credentials for the Slack node in n8n
 ---
 

--- a/docs/nodes/credentials/Sms77/README.md
+++ b/docs/nodes/credentials/Sms77/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/sms77
 description: Learn to configure credentials for the sms77 node in n8n
 ---
 

--- a/docs/nodes/credentials/Snowflake/README.md
+++ b/docs/nodes/credentials/Snowflake/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/snowflake
 description: Learn to configure credentials for the Snowflake node in n8n
 ---
 

--- a/docs/nodes/credentials/Spontit/README.md
+++ b/docs/nodes/credentials/Spontit/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/spontit
 description: Learn to configure credentials for the Spontit node in n8n
 ---
 

--- a/docs/nodes/credentials/Spotify/README.md
+++ b/docs/nodes/credentials/Spotify/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/spotify
 description: Learn to configure credentials for the Spotify node in n8n
 ---
 

--- a/docs/nodes/credentials/Storyblok/README.md
+++ b/docs/nodes/credentials/Storyblok/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/storyblok
 description: Learn to configure credentials for the Storyblok node in n8n
 ---
 

--- a/docs/nodes/credentials/Strapi/README.md
+++ b/docs/nodes/credentials/Strapi/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/strapi
 description: Learn to configure credentials for the Strapi node in n8n
 ---
 

--- a/docs/nodes/credentials/Strava/README.md
+++ b/docs/nodes/credentials/Strava/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/strava
 description: Learn to configure credentials for the Strava node and the Strava Trigger node in n8n
 ---
 

--- a/docs/nodes/credentials/Stripe/README.md
+++ b/docs/nodes/credentials/Stripe/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/stripe
 description: Learn to configure credentials for the Stripe node in n8n
 ---
 

--- a/docs/nodes/credentials/SurveyMonkey/README.md
+++ b/docs/nodes/credentials/SurveyMonkey/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/surveyMonkey
 description: Learn to configure credentials for the SurveyMonkey node in n8n
 ---
 

--- a/docs/nodes/credentials/Taiga/README.md
+++ b/docs/nodes/credentials/Taiga/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/taiga
 description: Learn to configure credentials for the Taiga node in n8n
 ---
 

--- a/docs/nodes/credentials/Telegram/README.md
+++ b/docs/nodes/credentials/Telegram/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/telegram
 description: Learn to configure credentials for the Telegram node in n8n
 ---
 

--- a/docs/nodes/credentials/TheHive/README.md
+++ b/docs/nodes/credentials/TheHive/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/theHive
 description: Learn to configure credentials for TheHive node in n8n
 ---
 

--- a/docs/nodes/credentials/Todoist/README.md
+++ b/docs/nodes/credentials/Todoist/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/todoist
 description: Learn to configure credentials for the Todoist node in n8n
 ---
 

--- a/docs/nodes/credentials/Toggl/README.md
+++ b/docs/nodes/credentials/Toggl/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/toggl
 description: Learn to configure credentials for the Toggl node in n8n
 ---
 

--- a/docs/nodes/credentials/TravisCI/README.md
+++ b/docs/nodes/credentials/TravisCI/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/travisCi
 description: Learn to configure credentials for the Travis CI node in n8n
 ---
 

--- a/docs/nodes/credentials/Trello/README.md
+++ b/docs/nodes/credentials/Trello/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/trello
 description: Learn to configure credentials for the Trello node in n8n
 ---
 

--- a/docs/nodes/credentials/Twake/README.md
+++ b/docs/nodes/credentials/Twake/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/twake
 description: Learn to configure credentials for the Twake node in n8n
 ---
 

--- a/docs/nodes/credentials/Twilio/README.md
+++ b/docs/nodes/credentials/Twilio/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/twilio
 description: Learn to configure credentials for the Twilio node in n8n
 ---
 

--- a/docs/nodes/credentials/Twist/README.md
+++ b/docs/nodes/credentials/Twist/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/twist
 description: Learn to configure credentials for the Twist node in n8n
 ---
 

--- a/docs/nodes/credentials/Twitter/README.md
+++ b/docs/nodes/credentials/Twitter/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/twitter
 description: Learn to configure credentials for the Twitter node in n8n
 ---
 

--- a/docs/nodes/credentials/Typeform/README.md
+++ b/docs/nodes/credentials/Typeform/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/typeform
 description: Learn to configure credentials for the Typeform node in n8n
 ---
 

--- a/docs/nodes/credentials/UnleashedSoftware/README.md
+++ b/docs/nodes/credentials/UnleashedSoftware/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/unleashedSoftware
 description: Learn to configure credentials for the Unleashed Software node in n8n
 ---
 

--- a/docs/nodes/credentials/Uplead/README.md
+++ b/docs/nodes/credentials/Uplead/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/uplead
 description: Learn to configure credentials for the UpLead node in n8n
 ---
 

--- a/docs/nodes/credentials/Vero/README.md
+++ b/docs/nodes/credentials/Vero/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/vero
 description: Learn to configure credentials for the Vero node in n8n
 ---
 

--- a/docs/nodes/credentials/Vonage/README.md
+++ b/docs/nodes/credentials/Vonage/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/vonage
 description: Learn to configure credentials for the Vonage node in n8n
 ---
 

--- a/docs/nodes/credentials/Webflow/README.md
+++ b/docs/nodes/credentials/Webflow/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/webflow
 description: Learn to configure credentials for the Webflow node in n8n
 ---
 

--- a/docs/nodes/credentials/Wekan/README.md
+++ b/docs/nodes/credentials/Wekan/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/wekan
 description: Learn to configure credentials for the Wekan node in n8n
 ---
 

--- a/docs/nodes/credentials/WooCommerce/README.md
+++ b/docs/nodes/credentials/WooCommerce/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/wooCommerce
 description: Learn to configure credentials for the WooCommerce node in n8n
 ---
 

--- a/docs/nodes/credentials/WordPress/README.md
+++ b/docs/nodes/credentials/WordPress/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/wordpress
 description: Learn to configure credentials for the WordPress node in n8n
 ---
 

--- a/docs/nodes/credentials/Wufoo/README.md
+++ b/docs/nodes/credentials/Wufoo/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/wufoo
 description: Learn to configure credentials for the Wufoo Trigger node in n8n
 ---
 

--- a/docs/nodes/credentials/Xero/README.md
+++ b/docs/nodes/credentials/Xero/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/xero
 description: Learn to configure credentials for the Xero node in n8n
 ---
 

--- a/docs/nodes/credentials/Yourls/README.md
+++ b/docs/nodes/credentials/Yourls/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/yourls
 description: Learn to configure credentials for the Yourls node in n8n
 ---
 

--- a/docs/nodes/credentials/Zendesk/README.md
+++ b/docs/nodes/credentials/Zendesk/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/zendesk
 description: Learn to configure credentials for the Zendesk node in n8n
 ---
 

--- a/docs/nodes/credentials/Zoho/README.md
+++ b/docs/nodes/credentials/Zoho/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/zoho
 description: Learn to configure credentials for the Zoho node in n8n
 ---
 

--- a/docs/nodes/credentials/Zoom/README.md
+++ b/docs/nodes/credentials/Zoom/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/zoom
 description: Learn to configure credentials for the Zoom node in n8n
 ---
 

--- a/docs/nodes/credentials/Zulip/README.md
+++ b/docs/nodes/credentials/Zulip/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/zulip
 description: Learn to configure credentials for the Zulip node in n8n
 ---
 

--- a/docs/nodes/credentials/uProc/README.md
+++ b/docs/nodes/credentials/uProc/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /credentials/uProc
 description: Learn to configure credentials for the uProc node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/Cron/README.md
+++ b/docs/nodes/nodes-library/core-nodes/Cron/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.cron
 description: Learn how to use the Cron node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/Crypto/README.md
+++ b/docs/nodes/nodes-library/core-nodes/Crypto/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.crypto
 description: Learn how to use the Crypto node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/DateTime/README.md
+++ b/docs/nodes/nodes-library/core-nodes/DateTime/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.dateTime
 description: Learn how to use the Date & Time node in n8n
 ---
 
@@ -53,7 +52,7 @@ The start node exists by default when you create a new workflow.
 ### 2. Date & Time node
 
 1. Enter the date that you want to convert in the *Value* field.
-2. Click on the *Add Option* dropdown. 
+2. Click on the *Add Option* dropdown.
 3. Click on the *From Format* option, and enter the format of the input date.
 4. Select the format you want to convert it to from the *To Format* dropdown list.
 5. Click on *Execute Node* to run the workflow.

--- a/docs/nodes/nodes-library/core-nodes/EditImage/README.md
+++ b/docs/nodes/nodes-library/core-nodes/EditImage/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.editImage
 description: Learn how to use the Edit Image node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/ErrorTrigger/README.md
+++ b/docs/nodes/nodes-library/core-nodes/ErrorTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.errorTrigger
 description: Learn how to use the Error Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/ExecuteCommand/README.md
+++ b/docs/nodes/nodes-library/core-nodes/ExecuteCommand/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.executeCommand
 description: Learn how to use the Execute Command node in n8n
 ---
 
@@ -121,7 +120,7 @@ ls
 
 You can also use the [HTTP Request](../../core-nodes/HTTPRequest/README.md) node to make a cURL request.
 
-If you want to run the curl command in the Execute Command node, you will have to build a Docker image based on the existing n8n image. The default n8n Docker image uses Alpine Linux. You will have to install the curl package. 
+If you want to run the curl command in the Execute Command node, you will have to build a Docker image based on the existing n8n image. The default n8n Docker image uses Alpine Linux. You will have to install the curl package.
 1. Create a file named Dockerfile.
 2. Add the below code snippet to the Dockerfile.
 ```

--- a/docs/nodes/nodes-library/core-nodes/ExecuteWorkflow/README.md
+++ b/docs/nodes/nodes-library/core-nodes/ExecuteWorkflow/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.executeWorkflow
 description: Learn how to use the Execute Workflow node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/FTP/README.md
+++ b/docs/nodes/nodes-library/core-nodes/FTP/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.ftp
 description: Learn how to use the FTP node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/Function/README.md
+++ b/docs/nodes/nodes-library/core-nodes/Function/README.md
@@ -1,11 +1,10 @@
 ---
-permalink: /nodes/n8n-nodes-base.function
 description: Learn how to use the Function node in n8n
 ---
 
 # Function
 
-The Function node is used to add custom snippets to JavaScript code to transform data from the other nodes or if you want to implement some custom functionality that n8n doesn’t support yet. 
+The Function node is used to add custom snippets to JavaScript code to transform data from the other nodes or if you want to implement some custom functionality that n8n doesn’t support yet.
 
 ::: tip 💡 Keep in mind
 Please note that the Function node is different from the [Function Item](../FunctionItem/README.md) node. Check out [this](../../../../reference/function-nodes.md) page to learn about the difference between the Function and Function Item nodes.

--- a/docs/nodes/nodes-library/core-nodes/FunctionItem/README.md
+++ b/docs/nodes/nodes-library/core-nodes/FunctionItem/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.functionItem
 description: Learn how to use the Function Item node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/GraphQL/README.md
+++ b/docs/nodes/nodes-library/core-nodes/GraphQL/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.graphql
 description: Learn how to use the GraphQL node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/HTMLExtract/README.md
+++ b/docs/nodes/nodes-library/core-nodes/HTMLExtract/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.htmlExtract
 description: Learn how to use the HTML Extract node in n8n
 ---
 
@@ -12,8 +11,8 @@ The HTML Extract node is useful to extract the HTML content of a webpage.
 - **Source Data:** This field specifies if HTML should be read from binary or JSON data. In this dropdown list, there are two options.
 	- Binary
 	- JSON
-- ***JSON Property:*** The name of the JSON property in which the HTML (from which to extract the data) can be found. This field is displayed when 'JSON' is selected in the ***Source Data*** field. 
-- ***Binary Property:*** The name of the binary property in which the HTML (from which to extract the data) can be found. This field is displayed when 'Binary' is selected in the ***Source Data*** field. 
+- ***JSON Property:*** The name of the JSON property in which the HTML (from which to extract the data) can be found. This field is displayed when 'JSON' is selected in the ***Source Data*** field.
+- ***Binary Property:*** The name of the binary property in which the HTML (from which to extract the data) can be found. This field is displayed when 'Binary' is selected in the ***Source Data*** field.
 The property can either contain a string or an array of strings.
 - ***Extraction Values:***
 	- ***Key:*** The key under which the extracted value should be saved.

--- a/docs/nodes/nodes-library/core-nodes/HTTPRequest/README.md
+++ b/docs/nodes/nodes-library/core-nodes/HTTPRequest/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.httpRequest
 description: Learn how to use the HTTP Request node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/IMAPEmail/README.md
+++ b/docs/nodes/nodes-library/core-nodes/IMAPEmail/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.emailReadImap
 description: Learn how to use the IMAP node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/If/README.md
+++ b/docs/nodes/nodes-library/core-nodes/If/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.if
 description: Learn how to use the IF node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/Interval/README.md
+++ b/docs/nodes/nodes-library/core-nodes/Interval/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.interval
 description: Learn how to use the Interval node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/Merge/README.md
+++ b/docs/nodes/nodes-library/core-nodes/Merge/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.merge
 description: Learn how to use the Merge node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/MoveBinaryData/README.md
+++ b/docs/nodes/nodes-library/core-nodes/MoveBinaryData/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.moveBinaryData
 description: Learn how to use the Move Binary Data node in n8n
 ---
 
@@ -12,10 +11,10 @@ The Move Binary Data node is useful to move data between binary and JSON propert
 - ***Mode:*** This field specifies from where and to the data should be moved.
     - Binary to JSON
     - JSON to Binary
-- ***Set all Data:*** If set to active, all JSON data is replaced with the data retrieved from binary key. If it is not set to active, the data will be written to a single key. This field is displayed when 'Binary to JSON' is selected from the ***Mode*** dropdown list. 
+- ***Set all Data:*** If set to active, all JSON data is replaced with the data retrieved from binary key. If it is not set to active, the data will be written to a single key. This field is displayed when 'Binary to JSON' is selected from the ***Mode*** dropdown list.
 - ***Source Key:*** The name of the binary key to get data from. It is also possible to define deep keys by using dot-notation. For example, "level1.level2.currentKey". This field is displayed when 'Binary to JSON' is selected from the ***Mode*** dropdown list.
 - ***Destination Key:*** The name the JSON key to copy data to. It is also possible to define deep keys by using dot-notation. For example, "level1.level2.newKey". This field is displayed when 'Binary to JSON' is selected from the ***Mode*** dropdown list.
-- ***Convert all Data:*** If set to active all JSON data will be converted to binary. If it is not set to active only the data with one key will be converted. This field is displayed when 'JSON to Binary' is selected from the ***Mode*** dropdown list. 
+- ***Convert all Data:*** If set to active all JSON data will be converted to binary. If it is not set to active only the data with one key will be converted. This field is displayed when 'JSON to Binary' is selected from the ***Mode*** dropdown list.
 - ***Destination Key:*** The name of the binary key to copy data to. It is also possible to define deep keys by using dot-notation. For example, "level1.level2.newKey". This field is displayed when 'JSON to Binary' is selected from the ***Mode*** dropdown list.
 
 - ***Options***

--- a/docs/nodes/nodes-library/core-nodes/NoOperationDoNothing/README.md
+++ b/docs/nodes/nodes-library/core-nodes/NoOperationDoNothing/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.noOp
 description: Learn how to use the No Operation, do nothing node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/RSSRead/README.md
+++ b/docs/nodes/nodes-library/core-nodes/RSSRead/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.rssFeedRead
 description: Learn how to use the RSS Read node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/ReadBinaryFile/README.md
+++ b/docs/nodes/nodes-library/core-nodes/ReadBinaryFile/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.readBinaryFile
 description: Learn how to use the Read Binary File node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/ReadBinaryFiles/README.md
+++ b/docs/nodes/nodes-library/core-nodes/ReadBinaryFiles/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.readBinaryFiles
 description: Learn how to use the Read Binary Files node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/ReadPDF/README.md
+++ b/docs/nodes/nodes-library/core-nodes/ReadPDF/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.readPDF
 description: Learn how to use the Read PDF node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/RenameKeys/README.md
+++ b/docs/nodes/nodes-library/core-nodes/RenameKeys/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.renameKeys
 description: Learn how to use the Rename Keys node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/SSETrigger/README.md
+++ b/docs/nodes/nodes-library/core-nodes/SSETrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.sseTrigger
 description: Learn how to use the SSE Trigger node in n8n
 ---
 
@@ -23,5 +22,5 @@ The final workflow should look like the following image.
 
 ### 1. SSE Trigger node
 
-1. Enter the URL in the ***URL*** field. 
+1. Enter the URL in the ***URL*** field.
 2. Click on ***Execute Node*** to run the node.

--- a/docs/nodes/nodes-library/core-nodes/SendEmail/README.md
+++ b/docs/nodes/nodes-library/core-nodes/SendEmail/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.emailSend
 description: Learn how to use the Send Email node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/Set/README.md
+++ b/docs/nodes/nodes-library/core-nodes/Set/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.set
 description: Learn how to use the Set node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/SplitInBatches/README.md
+++ b/docs/nodes/nodes-library/core-nodes/SplitInBatches/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.splitInBatches
 description: Learn how to use the Split In Batches node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/SpreadsheetFile/README.md
+++ b/docs/nodes/nodes-library/core-nodes/SpreadsheetFile/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.spreadsheetFile
 description: Learn how to use the Spreadsheet File node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/Start/README.md
+++ b/docs/nodes/nodes-library/core-nodes/Start/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.start
 description: Learn how to use the Start node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/Switch/README.md
+++ b/docs/nodes/nodes-library/core-nodes/Switch/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.switch
 description: Learn how to use the Switch node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/Webhook/README.md
+++ b/docs/nodes/nodes-library/core-nodes/Webhook/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.webhook
 description: Learn how to use the Webhook node in n8n
 ---
 

--- a/docs/nodes/nodes-library/core-nodes/WriteBinaryFile/README.md
+++ b/docs/nodes/nodes-library/core-nodes/WriteBinaryFile/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.writeBinaryFile
 description: Learn how to use the Write Binary File node in n8n
 ---
 
@@ -37,7 +36,7 @@ The start node exists by default when you create a new workflow.
 ### 2. HTTP Request node
 
 1. Enter `https://docs.n8n.io/assets/img/n8n-logo.png` in the ***URL*** field.
-2. Select the 'File' option from the ***Response Format*** dropdown list. 
+2. Select the 'File' option from the ***Response Format*** dropdown list.
 3. Click on ***Execute Node*** to run the node.
 
 ![Using the HTTP Request node to get an image](./HTTPRequest_node.png)

--- a/docs/nodes/nodes-library/core-nodes/XML/README.md
+++ b/docs/nodes/nodes-library/core-nodes/XML/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.xml
 description: Learn how to use the XML node in n8n
 ---
 
@@ -12,7 +11,7 @@ The XML node is useful to convert data from and to XML.
 - **Mode:** The format the data should be converted from and to.
 	- ***JSON to XML:*** Converts data from JSON to XML
     - ***XML to JSON:*** Converts data from XML to JSON
-- ***Property Name:*** The name of the property which contains the data to convert. 
+- ***Property Name:*** The name of the property which contains the data to convert.
 - ***Options***
 	- ***Allow Surrogate Chars:*** Allows using characters from the Unicode surrogate blocks. This field is displayed when 'JSON to XML' is selected from the ***Mode*** dropdown list.
     - ***cdata:***  Wrap text nodes instead of escaping when necessary. This field is displayed when 'JSON to XML' is selected from the ***Mode*** dropdown list.

--- a/docs/nodes/nodes-library/nodes/AMQPSender/README.md
+++ b/docs/nodes/nodes-library/nodes/AMQPSender/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.amqp
 description: Learn how to use the AMQP Sender node in n8n
 ---
 
@@ -44,7 +43,7 @@ In the screenshot below, you will notice that the Cron node is configured to tri
 
 This node will make a GET request to the API `https://api.wheretheiss.at/v1/satellites/25544/positions` to fetch the position of the ISS. This information gets passed on to the next node in the workflow.
 ::: v-pre
-1. Enter `https://api.wheretheiss.at/v1/satellites/25544/positions` in the ***URL*** field. 
+1. Enter `https://api.wheretheiss.at/v1/satellites/25544/positions` in the ***URL*** field.
 2. Click on the ***Add Parameter*** button in the ***Query Parameters*** section.
 3. Enter `timestamps` in the ***Name*** field.
 4. Click on the gears icon next to the ***Value*** field and click on ***Add Expression***.

--- a/docs/nodes/nodes-library/nodes/AWSLambda/README.md
+++ b/docs/nodes/nodes-library/nodes/AWSLambda/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.awsLambda
 description: Learn how to use the AWS Lambda node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/AWSRekognition/README.md
+++ b/docs/nodes/nodes-library/nodes/AWSRekognition/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.awsRekognition
 description: Learn how to use the AWS Rekognition node in n8n
 ---
 
@@ -45,7 +44,7 @@ In the screenshot below, you will notice that the HTTP Request node fetches the 
 
 ![Using the HTTP Request node to fetch an image from a URL](./HTTPRequest_node.png)
 
-  
+
 ### 3. AWS Rekognition node (analyze: image)
 
 This node will detect faces in the image that we fetched in the previous node. You can also use this node to analyze an image stored in your AWS Bucket.

--- a/docs/nodes/nodes-library/nodes/AWSS3/README.md
+++ b/docs/nodes/nodes-library/nodes/AWSS3/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.awsS3
 description: Learn how to use the AWS S3 node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/AWSSES/README.md
+++ b/docs/nodes/nodes-library/nodes/AWSSES/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.awsSes
 description: Learn how to use the AWS SES node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/AWSSNS/README.md
+++ b/docs/nodes/nodes-library/nodes/AWSSNS/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.awsSns
 description: Learn how to use the AWS SNS node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/ActiveCampaign/README.md
+++ b/docs/nodes/nodes-library/nodes/ActiveCampaign/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.activeCampaign
 description: Learn how to use the ActiveCampaign node in n8n
 ---
 
@@ -79,7 +78,7 @@ The start node exists by default when you create a new workflow.
 1. First of all, you'll have to enter credentials for the ActiveCampaign node. You can find out how to do that [here](../../../credentials/ActiveCampaign/README.md).
 2. Enter the email of the contact in the *Email* field.
 3. Toggle the *Update if exists* option to yes.
-4. Under the *Additional Fields* section, click on the *Add Field* button and select *First Name*. 
+4. Under the *Additional Fields* section, click on the *Add Field* button and select *First Name*.
 5. Enter the first name of the contact in the *First Name* field.
 6. Click on *Add Field* again and select *Last Name*.
 7. Enter the last name of the contact in the *Last name* field.

--- a/docs/nodes/nodes-library/nodes/Affinity/README.md
+++ b/docs/nodes/nodes-library/nodes/Affinity/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.affinity
 description: Learn how to use the Affinity node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/AgileCRM/README.md
+++ b/docs/nodes/nodes-library/nodes/AgileCRM/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.agileCrm
 description: Learn how to use the Agile CRM node in n8n
 ---
 
@@ -56,7 +55,7 @@ The start node exists by default when you create a new workflow.
 
 1. First of all, you'll have to enter credentials for the Agile CRM node. You can find out how to do that [here](../../../credentials/AgileCRM/README.md).
 2. Select the 'Create' option from the *Operation* dropdown list.
-3. Under the *Additional Fields* section, click on the *Add Field* button and select *First Name*. 
+3. Under the *Additional Fields* section, click on the *Add Field* button and select *First Name*.
 5. Enter the first name of the contact in the *First Name* field.
 6. Click on *Add Field* again and select *Last Name*.
 7. Enter the last name of the contact in the *Last name* field.

--- a/docs/nodes/nodes-library/nodes/Airtable/README.md
+++ b/docs/nodes/nodes-library/nodes/Airtable/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.airtable
 description: Learn how to use the Airtable node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Asana/README.md
+++ b/docs/nodes/nodes-library/nodes/Asana/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.asana
 description: Learn how to use the Asana node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Automizy/README.md
+++ b/docs/nodes/nodes-library/nodes/Automizy/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.automizy
 description: Learn how to use the Automizy node in n8n
 ---
 
@@ -48,7 +47,7 @@ The Start node exists by default when you create a new workflow.
 
 This node will create a new list called `n8n-docs` in Automizy.
 
-1. First of all, you'll have to enter credentials for the Automizy node. You can find out how to do that [here](../../../credentials/Automizy/README.md). 
+1. First of all, you'll have to enter credentials for the Automizy node. You can find out how to do that [here](../../../credentials/Automizy/README.md).
 2. Select 'List' from the ***Resource*** dropdown list.
 3. Enter `n8n-docs` in the ***Name*** field.
 4. Click on ***Execute Node*** to run the node.

--- a/docs/nodes/nodes-library/nodes/Bannerbear/README.md
+++ b/docs/nodes/nodes-library/nodes/Bannerbear/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.bannerbear
 description: Learn how to use the Bannerbear node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Bitly/README.md
+++ b/docs/nodes/nodes-library/nodes/Bitly/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.bitly
 description: Learn how to use the Bitly node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Box/README.md
+++ b/docs/nodes/nodes-library/nodes/Box/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.box
 description: Learn how to use the Box node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Brandfetch/README.md
+++ b/docs/nodes/nodes-library/nodes/Brandfetch/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.Brandfetch
 description: Learn how to use the Brandfetch node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Chargebee/README.md
+++ b/docs/nodes/nodes-library/nodes/Chargebee/README.md
@@ -1,11 +1,10 @@
 ---
-permalink: /nodes/n8n-nodes-base.chargebee
 description: Learn how to use the Chargebee node in n8n
 ---
 
 # Chargebee
 
-[Chargebee](https://www.chargebee.com/) is a billing platform for subscription based SaaS and eCommerce businesses. Chargebee integrates with payment gateways to let you automate recurring payment collection along with invoicing, taxes, accounting, email notifications, SaaS Metrics and customer management. 
+[Chargebee](https://www.chargebee.com/) is a billing platform for subscription based SaaS and eCommerce businesses. Chargebee integrates with payment gateways to let you automate recurring payment collection along with invoicing, taxes, accounting, email notifications, SaaS Metrics and customer management.
 
 ::: tip 🔑 Credentials
 You can find authentication information for this node [here](../../../credentials/Chargebee/README.md).
@@ -45,7 +44,7 @@ The start node exists by default when you create a new workflow.
 
 1. First of all, you'll have to enter credentials for the Chargebee node. You can find out how to do that [here](../../../credentials/Chargebee/README.md).
 2. Select the 'Customer' option from the *Resource* dropdown list.
-3. Under the *Properties* section, click on the *Add Property* button and select *First Name*. 
+3. Under the *Properties* section, click on the *Add Property* button and select *First Name*.
 5. Enter the first name of the contact in the *First Name* field.
 6. Click on *Add Property* again and select *Last Name*.
 7. Enter the last name of the contact in the *Last name* field.

--- a/docs/nodes/nodes-library/nodes/CircleCI/README.md
+++ b/docs/nodes/nodes-library/nodes/CircleCI/README.md
@@ -1,11 +1,10 @@
 ---
-permalink: /nodes/n8n-nodes-base.circleCi
 description: Learn how to use the CircleCI node in n8n
 ---
 
 # CircleCI
 
-[CircleCI](https://circleci.com/) is a continuous integration and delivery platform helps teams release quality code, faster. 
+[CircleCI](https://circleci.com/) is a continuous integration and delivery platform helps teams release quality code, faster.
 
 ::: tip 🔑 Credentials
 You can find authentication information for this node [here](../../../credentials/CircleCI/README.md).

--- a/docs/nodes/nodes-library/nodes/Clearbit/README.md
+++ b/docs/nodes/nodes-library/nodes/Clearbit/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.clearbit
 description: Learn how to use the Clearbit node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/ClickUp/README.md
+++ b/docs/nodes/nodes-library/nodes/ClickUp/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.clickUp
 description: Learn how to use the ClickUp node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Clockify/README.md
+++ b/docs/nodes/nodes-library/nodes/Clockify/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.clockify
 description: Learn how to use the Clockify node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Cockpit/README.md
+++ b/docs/nodes/nodes-library/nodes/Cockpit/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.cockpit
 description: Learn how to use the Cockpit node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Coda/README.md
+++ b/docs/nodes/nodes-library/nodes/Coda/README.md
@@ -1,11 +1,10 @@
 ---
-permalink: /nodes/n8n-nodes-base.coda
 description: Learn how to use the Coda node in n8n
 ---
 
 # Coda
 
-[Coda](https://coda.io/) is a new type of document that blends the flexibility of documents, the power of spreadsheets, and the utility of applications into a single new canvas. 
+[Coda](https://coda.io/) is a new type of document that blends the flexibility of documents, the power of spreadsheets, and the utility of applications into a single new canvas.
 
 ::: tip 🔑 Credentials
 You can find authentication information for this node [here](../../../credentials/Coda/README.md).
@@ -63,7 +62,7 @@ The start node exists by default when you create a new workflow.
 1. Click on the *Add Value* button and select 'String' from the dropdown list.
 2. Enter `Column 1`in the *Name* field.
 3. Enter the value for the first column in the *Value* field.
-4. Repeat the first three steps of all the columns that you have in your Coda table. 
+4. Repeat the first three steps of all the columns that you have in your Coda table.
 
 **Note:** Here, we've used the default table in Coda, which has three columns namely Column 1, Column 2, and Column 3. Please make sure that the column names in the *Name* field matches the names of the table columns in Coda.
 

--- a/docs/nodes/nodes-library/nodes/CoinGecko/README.md
+++ b/docs/nodes/nodes-library/nodes/CoinGecko/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.coinGecko
 description: Learn how to use the CoinGecko node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Contentful/README.md
+++ b/docs/nodes/nodes-library/nodes/Contentful/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.contentful
 description: Learn how to use the Contentful node in n8n
 ---
 
@@ -9,7 +8,7 @@ description: Learn how to use the Contentful node in n8n
 
 ::: tip 🔑 Credentials
 You can find authentication information for this node [here](../../../credentials/Contentful/README.md).
-:::	
+:::
 
 ## Basic Operations
 

--- a/docs/nodes/nodes-library/nodes/ConvertKit/README.md
+++ b/docs/nodes/nodes-library/nodes/ConvertKit/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.convertKit
 description: Learn how to use the ConvertKit node in n8n
 ---
 
@@ -9,7 +8,7 @@ description: Learn how to use the ConvertKit node in n8n
 
 ::: tip 🔑 Credentials
 You can find authentication information for this node [here](../../../credentials/ConvertKit/README.md).
-:::	
+:::
 
 ## Basic Operations
 

--- a/docs/nodes/nodes-library/nodes/Cortex/README.md
+++ b/docs/nodes/nodes-library/nodes/Cortex/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.cortex
 description: Learn how to use the Cortex node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/CrateDB/README.md
+++ b/docs/nodes/nodes-library/nodes/CrateDB/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.crateDb
 description: Learn how to use the CrateDB node in n8n
 ---
 
@@ -9,7 +8,7 @@ description: Learn how to use the CrateDB node in n8n
 
 ::: tip 🔑 Credentials
 You can find authentication information for this node [here](../../../credentials/CrateDB/README.md).
-:::	
+:::
 
 ## Basic Operations
 

--- a/docs/nodes/nodes-library/nodes/CustomerIo/README.md
+++ b/docs/nodes/nodes-library/nodes/CustomerIo/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.customerIo
 description: Learn how to use the Customer.io node in n8n
 ---
 
@@ -9,7 +8,7 @@ description: Learn how to use the Customer.io node in n8n
 
 ::: tip 🔑 Credentials
 You can find authentication information for this node [here](../../../credentials/CustomerIo/README.md).
-:::	
+:::
 
 ## Basic Operations
 

--- a/docs/nodes/nodes-library/nodes/Discord/README.md
+++ b/docs/nodes/nodes-library/nodes/Discord/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.discord
 description: Learn how to use the Discord node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Disqus/README.md
+++ b/docs/nodes/nodes-library/nodes/Disqus/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.disqus
 description: Learn how to use the Disqus node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Drift/README.md
+++ b/docs/nodes/nodes-library/nodes/Drift/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.drift
 description: Learn how to use the Drift node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Dropbox/README.md
+++ b/docs/nodes/nodes-library/nodes/Dropbox/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.dropbox
 description: Learn how to use the Dropbox node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Egoi/README.md
+++ b/docs/nodes/nodes-library/nodes/Egoi/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.egoi
 description: Learn how to use the E-goi node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/FacebookGraphAPI/README.md
+++ b/docs/nodes/nodes-library/nodes/FacebookGraphAPI/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.facebookGraphApi
 description: Learn how to use the Facebook Graph API node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Flow/README.md
+++ b/docs/nodes/nodes-library/nodes/Flow/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.flow
 description: Learn how to use the Flow node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Freshdesk/README.md
+++ b/docs/nodes/nodes-library/nodes/Freshdesk/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.freshdesk
 description: Learn how to use the Freshdesk node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/GSuiteAdmin/README.md
+++ b/docs/nodes/nodes-library/nodes/GSuiteAdmin/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.gSuiteAdmin
 description: Learn how to use the G Suite Admin node in n8n
 ---
 
@@ -42,7 +41,7 @@ The final workflow should look like the following image.
 ### 1. Start node
 
 The Start node exists by default when you create a new workflow.
-  
+
 ### 2. G Suite Admin node (create: user)
 
 This node will create a user in G Suite with the following information:  first name, last name, password, domain, and username.
@@ -73,7 +72,7 @@ This node will get the User ID from the previous node and update the user's last
 7. Click on ***Execute Node*** to run the workflow.
 :::
 
-In the screenshot below, you will notice that the node has updated the last name of the user that we created in the previous node. 
+In the screenshot below, you will notice that the node has updated the last name of the user that we created in the previous node.
 
 ![Using the G Suite Admin node to update the last name of the user](./GSuiteAdmin1_node.png)
 
@@ -89,7 +88,7 @@ This node will get the information of the user we created in the G Suite Admin n
 5. Click on ***Execute Node*** to run the workflow.
 :::
 
-In the screenshot below, you will notice that the node returns the information of the user we created in the G Suite Admin node. 
+In the screenshot below, you will notice that the node returns the information of the user we created in the G Suite Admin node.
 
 ![Using the G Suite Admin node to get the information of the user](./GSuiteAdmin2_node.png)
 

--- a/docs/nodes/nodes-library/nodes/GetResponse/README.md
+++ b/docs/nodes/nodes-library/nodes/GetResponse/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.getResponse
 description: Learn how to use the GetResponse node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Ghost/README.md
+++ b/docs/nodes/nodes-library/nodes/Ghost/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.ghost
 description: Learn how to use the Ghost node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/GitHub/README.md
+++ b/docs/nodes/nodes-library/nodes/GitHub/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.github
 description: Learn how to use the GitHub node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/GitLab/README.md
+++ b/docs/nodes/nodes-library/nodes/GitLab/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.gitlab
 description: Learn how to use the GitLab node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Gmail/README.md
+++ b/docs/nodes/nodes-library/nodes/Gmail/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.gmail
 description: Learn how to use the Gmail node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/GoogleBooks/README.md
+++ b/docs/nodes/nodes-library/nodes/GoogleBooks/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.googleBooks
 description: Learn how to use the Google Books node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/GoogleCalendar/README.md
+++ b/docs/nodes/nodes-library/nodes/GoogleCalendar/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.googleCalendar
 description: Learn how to use the Google Calendar node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/GoogleCloudFirestore/README.md
+++ b/docs/nodes/nodes-library/nodes/GoogleCloudFirestore/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.googleFirebaseCloudFirestore
 description: Learn how to use the Google Cloud Firestore node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/GoogleCloudNaturalLanguage/README.md
+++ b/docs/nodes/nodes-library/nodes/GoogleCloudNaturalLanguage/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.googleCloudNaturalLanguage
 description: Learn how to use the Google Cloud Natural Language node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/GoogleCloudRealtimeDatabase/README.md
+++ b/docs/nodes/nodes-library/nodes/GoogleCloudRealtimeDatabase/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.googleFirebaseRealtimeDatabase
 description: Learn how to use the Google Cloud Realtime Database node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/GoogleContacts/README.md
+++ b/docs/nodes/nodes-library/nodes/GoogleContacts/README.md
@@ -1,10 +1,9 @@
 ---
-permalink: /nodes/n8n-nodes-base.googleContacts
 description: Learn how to use the Google Contacts node in n8n
 ---
 
 # Google Contacts
- 
+
 [Google Contacts](https://contacts.google.com/) is Google's contact management tool that is available in its free email service Gmail, as a standalone service, and as a part of Google's business-oriented suite of web apps Google Apps.
 
 ::: tip 🔑 Credentials

--- a/docs/nodes/nodes-library/nodes/GoogleDrive/README.md
+++ b/docs/nodes/nodes-library/nodes/GoogleDrive/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.googleDrive
 description: Learn how to use the Google Drive node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/GoogleSheets/README.md
+++ b/docs/nodes/nodes-library/nodes/GoogleSheets/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.googleSheets
 description: Learn how to use the Google Sheets node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/GoogleTasks/README.md
+++ b/docs/nodes/nodes-library/nodes/GoogleTasks/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.googleTasks
 description: Learn how to use the Google Tasks node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/GoogleTranslate/README.md
+++ b/docs/nodes/nodes-library/nodes/GoogleTranslate/README.md
@@ -1,11 +1,10 @@
 ---
-permalink: /nodes/n8n-nodes-base.googleTranslate
 description: Learn how to use the Google Translate node in n8n
 ---
 
 # Google Translate
 
-[Google Translate](https://translate.google.com/) is a free multilingual translation service developed by Google to translate text and websites from one language into another. 
+[Google Translate](https://translate.google.com/) is a free multilingual translation service developed by Google to translate text and websites from one language into another.
 
 ::: tip 🔑 Credentials
 You can find authentication information for this node [here](../../../credentials/Google/README.md).
@@ -35,7 +34,7 @@ The start node exists by default when you create a new workflow.
 
 This node will translate the text `Hello from n8n!` to German. You can enter a different text as well as select another language to translate the text to.
 
-1. Select 'OAuth2' from the ***Authentication*** dropdown list. 
+1. Select 'OAuth2' from the ***Authentication*** dropdown list.
 2. Next, you'll have to enter credentials for the Google Translate node. You can find out how to enter credentials for this node [here](../../../credentials/Google/README.md).
 3. Enter the text `Hello from n8n!` in the ***Text*** field.
 4. Select 'DE' from the ***Translate To*** dropdown list. DE is the language code for German. You can refer to [Language Support](https://cloud.google.com/translate/docs/languages) to view the list of all supported languages and their corresponding language codes.

--- a/docs/nodes/nodes-library/nodes/Gotify/README.md
+++ b/docs/nodes/nodes-library/nodes/Gotify/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.gotify
 description: Learn how to use the Gotify node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/HackerNews/README.md
+++ b/docs/nodes/nodes-library/nodes/HackerNews/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.hackerNews
 description: Learn how to use the Hacker News node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Harvest/README.md
+++ b/docs/nodes/nodes-library/nodes/Harvest/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.harvest
 description: Learn how to use the Harvest node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/HelpScout/README.md
+++ b/docs/nodes/nodes-library/nodes/HelpScout/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.helpScout
 description: Learn how to use the Help Scout node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/HubSpot/README.md
+++ b/docs/nodes/nodes-library/nodes/HubSpot/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.hubspot
 description: Learn how to use the HubSpot node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/HumanticAi/README.md
+++ b/docs/nodes/nodes-library/nodes/HumanticAi/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.humanticAi
 description: Learn how to use the Humantic AI node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Hunter/README.md
+++ b/docs/nodes/nodes-library/nodes/Hunter/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.hunter
 description: Learn how to use the Hunter node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Intercom/README.md
+++ b/docs/nodes/nodes-library/nodes/Intercom/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.intercom
 description: Learn how to use the Intercom node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/InvoiceNinja/README.md
+++ b/docs/nodes/nodes-library/nodes/InvoiceNinja/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.invoiceNinja
 description: Learn how to use the Invoice Ninja node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Iterable/README.md
+++ b/docs/nodes/nodes-library/nodes/Iterable/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.iterable
 description: Learn how to use the Iterable node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Jira/README.md
+++ b/docs/nodes/nodes-library/nodes/Jira/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.jira
 description: Learn how to use the Jira node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Kafka/README.md
+++ b/docs/nodes/nodes-library/nodes/Kafka/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.kafka
 description: Learn how to use the Kafka node in n8n
 ---
 
@@ -43,7 +42,7 @@ In the screenshot below, you will notice that the Cron node is configured to tri
 
 This node will make a GET request to the API `https://api.wheretheiss.at/v1/satellites/25544/positions` to fetch the position of the ISS. This information gets passed on to the next node in the workflow.
 ::: v-pre
-1. Enter `https://api.wheretheiss.at/v1/satellites/25544/positions` in the ***URL*** field. 
+1. Enter `https://api.wheretheiss.at/v1/satellites/25544/positions` in the ***URL*** field.
 2. Click on the ***Add Parameter*** button in the ***Query Parameters*** section.
 3. Enter `timestamps` in the ***Name*** field.
 4. Click on the gears icon next to the ***Value*** field and click on ***Add Expression***.

--- a/docs/nodes/nodes-library/nodes/Keap/README.md
+++ b/docs/nodes/nodes-library/nodes/Keap/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.keap
 description: Learn how to use the Keap node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Line/README.md
+++ b/docs/nodes/nodes-library/nodes/Line/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.line
 description: Learn how to use the Line node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/LingvaNex/README.md
+++ b/docs/nodes/nodes-library/nodes/LingvaNex/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.lingvaNex
 description: Learn how to use the LingvaNex node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/LinkedIn/README.md
+++ b/docs/nodes/nodes-library/nodes/LinkedIn/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.linkedIn
 description: Learn how to use the LinkedIn node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/MSG91/README.md
+++ b/docs/nodes/nodes-library/nodes/MSG91/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.msg91
 description: Learn how to use the MSG91 node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Mailchimp/README.md
+++ b/docs/nodes/nodes-library/nodes/Mailchimp/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.mailchimp
 description: Learn how to use the Mailchimp node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/MailerLite/README.md
+++ b/docs/nodes/nodes-library/nodes/MailerLite/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.mailerLite
 description: Learn how to use the MailerLite node in n8n
 ---
 
@@ -48,7 +47,7 @@ This node will create a new subscriber in MailerLite. We will add the name of th
 In the screenshot below, you will notice that the node creates a new subscriber with their name and email.
 
 ![Using the MailerLite node to create a room](./MailerLite_node.png)
-  
+
 ### 3. MailerLite1 node (update: subscriber)
 
 This node will update the information of the subscriber that we created in the previous node. We will add the information about the city of the subscriber using this node.
@@ -71,7 +70,7 @@ In the screenshot below, you will notice that the node updates the information o
 
 ### 3. MailerLite2 node (get: subscriber)
 
-This node will return the information of the subscriber that we created using the MailerLite node. 
+This node will return the information of the subscriber that we created using the MailerLite node.
 
 ::: v-pre
 1. Select the credentials that you entered in the previous node.

--- a/docs/nodes/nodes-library/nodes/Mailgun/README.md
+++ b/docs/nodes/nodes-library/nodes/Mailgun/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.mailgun
 description: Learn how to use the Mailgun node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Mailjet/README.md
+++ b/docs/nodes/nodes-library/nodes/Mailjet/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.mailjet
 description: Learn how to use the Mailjet node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Mandrill/README.md
+++ b/docs/nodes/nodes-library/nodes/Mandrill/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.mandrill
 description: Learn how to use the Mandrill node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Matrix/README.md
+++ b/docs/nodes/nodes-library/nodes/Matrix/README.md
@@ -1,11 +1,10 @@
 ---
-permalink: /nodes/n8n-nodes-base.matrix
 description: Learn how to use the Matrix node in n8n
 ---
 
 # Matrix
 
-[Matrix](https://matrix.org) is an open standard for interoperable, decentralized, real-time communication over IP. 
+[Matrix](https://matrix.org) is an open standard for interoperable, decentralized, real-time communication over IP.
 
 ::: tip 🔑 Credentials
 You can find authentication information for this node [here](../../../credentials/Matrix/README.md).
@@ -72,7 +71,7 @@ This node will create a new room called `n8n` on the Matrix server.
 In the screenshot below, you will notice that the node creates a room `n8n` with an alias `#discussion-n8n:matrix.org`.
 
 ![Using the Matrix node to create a room](./Matrix_node.png)
-  
+
 ### 3. Matrix1 node (me: account)
 
 This node will get your account information from the Matrix server. We are doing this because Matrix will send an invite to all members of the room, including you. Since you are already a member of the room, you will get an error. We will use the data from this node later on to make sure that you don't send an invite to yourself.
@@ -89,7 +88,7 @@ In the screenshot below, you will notice that the node returns your user ID.
 
 ### 3. Matrix2 node (getAll: roomMember)
 
-This node will return the information of all the members in a room. 
+This node will return the information of all the members in a room.
 
 ::: v-pre
 1. Select the credentials that you entered in the previous node.

--- a/docs/nodes/nodes-library/nodes/Mattermost/README.md
+++ b/docs/nodes/nodes-library/nodes/Mattermost/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.mattermost
 description: Learn how to use the Mattermost node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Mautic/README.md
+++ b/docs/nodes/nodes-library/nodes/Mautic/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.mautic
 description: Learn how to use the Mautic node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Medium/README.md
+++ b/docs/nodes/nodes-library/nodes/Medium/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.medium
 description: Learn how to use the Medium node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/MessageBird/README.md
+++ b/docs/nodes/nodes-library/nodes/MessageBird/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.messageBird
 description: Learn how to use the MessageBird node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/MicrosoftExcel/README.md
+++ b/docs/nodes/nodes-library/nodes/MicrosoftExcel/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.microsoftExcel
 description: Learn how to use the Microsoft Excel node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/MicrosoftOneDrive/README.md
+++ b/docs/nodes/nodes-library/nodes/MicrosoftOneDrive/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.microsoftOneDrive
 description: Learn how to use the Microsoft OneDrive node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/MicrosoftOutlook/README.md
+++ b/docs/nodes/nodes-library/nodes/MicrosoftOutlook/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.microsoftOutlook
 description: Learn how to use the Microsoft Outlook node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/MicrosoftSQL/README.md
+++ b/docs/nodes/nodes-library/nodes/MicrosoftSQL/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.microsoftSql
 description: Learn how to use the Microsoft SQL node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/MicrosoftTeams/README.md
+++ b/docs/nodes/nodes-library/nodes/MicrosoftTeams/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.microsoftTeams
 description: Learn how to use the Microsoft Teams node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Mindee/README.md
+++ b/docs/nodes/nodes-library/nodes/Mindee/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.mindee
 description: Learn how to use the Mindee node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Mocean/README.md
+++ b/docs/nodes/nodes-library/nodes/Mocean/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.mocean
 description: Learn how to use the Mocean node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Mondaycom/README.md
+++ b/docs/nodes/nodes-library/nodes/Mondaycom/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.mondayCom
 description: Learn how to use the monday.com node in n8n
 ---
 
@@ -33,7 +32,7 @@ You can find authentication information for this node [here](../../../credential
 
 ::: details Board Item
 - Add an update to an item
-- Change a column value for a board item 
+- Change a column value for a board item
 - Change multiple column values for a board item
 - Create an item in a board's group
 - Delete an item

--- a/docs/nodes/nodes-library/nodes/MongoDB/README.md
+++ b/docs/nodes/nodes-library/nodes/MongoDB/README.md
@@ -1,11 +1,10 @@
 ---
-permalink: /nodes/n8n-nodes-base.mongoDb
 description: Learn how to use the MongoDB node in n8n
 ---
 
 # MongoDB
 
-[MongoDB](https://www.mongodb.com/) is a cross-platform document-oriented database program developed by MongoDB Inc. It is classified as a NoSQL database program. MongoDB uses JSON-like documents with optional schemas. 
+[MongoDB](https://www.mongodb.com/) is a cross-platform document-oriented database program developed by MongoDB Inc. It is classified as a NoSQL database program. MongoDB uses JSON-like documents with optional schemas.
 
 ::: tip 🔑 Credentials
 You can find authentication information for this node [here](../../../credentials/MongoDB/README.md).

--- a/docs/nodes/nodes-library/nodes/MySQL/README.md
+++ b/docs/nodes/nodes-library/nodes/MySQL/README.md
@@ -1,11 +1,10 @@
 ---
-permalink: /nodes/n8n-nodes-base.mySql
 description: Learn how to use the MySQL node in n8n
 ---
 
 # MySQL
 
-[MySQL](https://www.mysql.com/) is an open-source relational database management system. MySQL has stand-alone clients that allow users to interact directly with a MySQL database using SQL, but more often MySQL is used with other programs to implement applications that need relational database capability. 
+[MySQL](https://www.mysql.com/) is an open-source relational database management system. MySQL has stand-alone clients that allow users to interact directly with a MySQL database using SQL, but more often MySQL is used with other programs to implement applications that need relational database capability.
 
 ::: tip 🔑 Credentials
 You can find authentication information for this node [here](../../../credentials/MySQL/README.md).

--- a/docs/nodes/nodes-library/nodes/NASA/README.md
+++ b/docs/nodes/nodes-library/nodes/NASA/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.nasa
 description: Learn how to use the NASA node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Nextcloud/README.md
+++ b/docs/nodes/nodes-library/nodes/Nextcloud/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.nextCloud
 description: Learn how to use the Nextcloud node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/OpenThesaurus/README.md
+++ b/docs/nodes/nodes-library/nodes/OpenThesaurus/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.openThesaurus
 description: Learn how to use the OpenThesaurus node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/OpenWeatherMap/README.md
+++ b/docs/nodes/nodes-library/nodes/OpenWeatherMap/README.md
@@ -1,11 +1,10 @@
 ---
-permalink: /nodes/n8n-nodes-base.openWeatherMap
 description: Learn how to use the OpenWeatherMap node in n8n
 ---
 
 # OpenWeatherMap
 
-[OpenWeatherMap](https://openweathermap.org/) is an online service that provides weather data. It provides current weather data, forecasts, and historical data. 
+[OpenWeatherMap](https://openweathermap.org/) is an online service that provides weather data. It provides current weather data, forecasts, and historical data.
 
 ::: tip 🔑 Credentials
 You can find authentication information for this node [here](../../../credentials/OpenWeatherMap/README.md).

--- a/docs/nodes/nodes-library/nodes/Orbit/README.md
+++ b/docs/nodes/nodes-library/nodes/Orbit/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.orbit
 description: Learn how to use the Orbit node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Paddle/README.md
+++ b/docs/nodes/nodes-library/nodes/Paddle/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.paddle
 description: Learn how to use the Paddle node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/PagerDuty/README.md
+++ b/docs/nodes/nodes-library/nodes/PagerDuty/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.pagerDuty
 description: Learn how to use the PagerDuty node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/PayPal/README.md
+++ b/docs/nodes/nodes-library/nodes/PayPal/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.payPal
 description: Learn how to use the PayPal node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/PhilipsHue/README.md
+++ b/docs/nodes/nodes-library/nodes/PhilipsHue/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.philipsHue
 description: Learn how to use the Philips Hue node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Pipedrive/README.md
+++ b/docs/nodes/nodes-library/nodes/Pipedrive/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.pipedrive
 description: Learn how to use the Pipedrive node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Postgres/README.md
+++ b/docs/nodes/nodes-library/nodes/Postgres/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.postgres
 description: Learn how to use the Postgres node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/ProfitWell/README.md
+++ b/docs/nodes/nodes-library/nodes/ProfitWell/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.profitWell
 description: Learn how to use the ProfitWell node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Pushbullet/README.md
+++ b/docs/nodes/nodes-library/nodes/Pushbullet/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.pushbullet
 description: Learn how to use the Pushbullet node in n8n
 ---
 
@@ -47,7 +46,7 @@ In the screenshot below, you will notice that the Cron node is configured to tri
 
 This node will return data about the current weather in Berlin. To get the weather updates for your city, you can enter the name of your city instead.
 
-1. First of all, you'll have to enter credentials for the OpenWeatherMap node. You can find out how to do that [here](../../../credentials/OpenWeatherMap/README.md). 
+1. First of all, you'll have to enter credentials for the OpenWeatherMap node. You can find out how to do that [here](../../../credentials/OpenWeatherMap/README.md).
 2. Enter `berlin` in the ***City*** field.
 3. Click on ***Execute Node*** to run the node.
 

--- a/docs/nodes/nodes-library/nodes/Pushcut/README.md
+++ b/docs/nodes/nodes-library/nodes/Pushcut/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.pushcut
 description: Learn how to use the Pushcut node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Pushover/README.md
+++ b/docs/nodes/nodes-library/nodes/Pushover/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.pushover
 description: Learn how to use the Pushover node in n8n
 ---
 
@@ -44,7 +43,7 @@ In the screenshot below, you will notice that the Cron node is configured to tri
 
 This node will return data about the current weather in Berlin. To get the weather updates for your city, you can enter the name of your city instead.
 
-1. First of all, you'll have to enter credentials for the OpenWeatherMap node. You can find out how to do that [here](../../../credentials/OpenWeatherMap/README.md). 
+1. First of all, you'll have to enter credentials for the OpenWeatherMap node. You can find out how to do that [here](../../../credentials/OpenWeatherMap/README.md).
 2. Enter `berlin` in the ***City*** field.
 3. Click on ***Execute Node*** to run the node.
 

--- a/docs/nodes/nodes-library/nodes/QuestDB/README.md
+++ b/docs/nodes/nodes-library/nodes/QuestDB/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.questDb
 description: Learn how to use the QuestDB node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/QuickBase/README.md
+++ b/docs/nodes/nodes-library/nodes/QuickBase/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.quickbase
 description: Learn how to use the Quick Base node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/RabbitMQ/README.md
+++ b/docs/nodes/nodes-library/nodes/RabbitMQ/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.rabbitmq
 description: Learn how to use the RabbitMQ node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Redis/README.md
+++ b/docs/nodes/nodes-library/nodes/Redis/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.redis
 description: Learn how to use the Redis node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/RocketChat/README.md
+++ b/docs/nodes/nodes-library/nodes/RocketChat/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.rocketchat
 description: Learn how to use the Rocket.Chat node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Rundeck/README.md
+++ b/docs/nodes/nodes-library/nodes/Rundeck/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.rundeck
 description: Learn how to use the Rundeck node in n8n
 ---
 
@@ -48,4 +47,4 @@ The start node exists by default when you create a new workflow.
 3. In the sidebar, click on 'JOBS'.
 4. Under 'All Jobs', click on the name of the job you want to use with n8n.
 5. In the top left corner, under the name of the job, copy the string that is displayed in smaller font below the job name. This is your job ID.
-6. Paste this job ID in the `Job Id` field in n8n. 
+6. Paste this job ID in the `Job Id` field in n8n.

--- a/docs/nodes/nodes-library/nodes/S3/README.md
+++ b/docs/nodes/nodes-library/nodes/S3/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.s3
 description: Learn how to use the S3 node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/SIGNL4/README.md
+++ b/docs/nodes/nodes-library/nodes/SIGNL4/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.signl4
 description: Learn how to use the SIGNL4 node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Salesforce/README.md
+++ b/docs/nodes/nodes-library/nodes/Salesforce/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.salesforce
 description: Learn how to use the Salesforce node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Salesmate/README.md
+++ b/docs/nodes/nodes-library/nodes/Salesmate/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.salesmate
 description: Learn how to use the Salesmate node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Segment/README.md
+++ b/docs/nodes/nodes-library/nodes/Segment/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.segment
 description: Learn how to use the Segment node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Sendy/README.md
+++ b/docs/nodes/nodes-library/nodes/Sendy/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.sendy
 description: Learn how to use the Sendy node in n8n
 ---
 
@@ -57,7 +56,7 @@ In the screenshot below, you will notice that the node adds a subscriber with th
 
 ### 3. Sendy1 node (create: campaign)
 
-This node will create a campaign with the title 'Welcome to n8n' and send it to the subscribers of the list that we specify. 
+This node will create a campaign with the title 'Welcome to n8n' and send it to the subscribers of the list that we specify.
 ::: v-pre
 1. Select the credentials that you entered in the previous node.
 2. Select 'Campaign' from the ***Resource*** dropdown list.

--- a/docs/nodes/nodes-library/nodes/SentryIo/README.md
+++ b/docs/nodes/nodes-library/nodes/SentryIo/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.sentryIo
 description: Learn how to use the Sentry.io node in n8n
 ---
 
@@ -68,7 +67,7 @@ The start node exists by default when you create a new workflow.
 2. Select 'Release' from the ***Resource*** dropdown list.
 3. Select 'Create' from the ***Operation*** dropdown list.
 4. Select the organization from the ***Organization Slug*** dropdown list.
-5. Enter the version in the ***Version*** field. 
+5. Enter the version in the ***Version*** field.
 6. Enter the URL that points to the release in the ***URL*** field.
 7. Select the project from ***Projects*** dropdown list.
 8. Click on ***Execute Node*** to run the node.
@@ -83,7 +82,7 @@ The start node exists by default when you create a new workflow.
 2. Select 'Release' from the ***Resource*** dropdown list.
 3. Select 'Get All' from the ***Operation*** dropdown list.
 4. Select the organization from the ***Organization Slug*** dropdown list.
-5. Toggle ***Return All*** to true. 
+5. Toggle ***Return All*** to true.
 6. Click on ***Execute Node*** to run the node.
 :::
 

--- a/docs/nodes/nodes-library/nodes/Shopify/README.md
+++ b/docs/nodes/nodes-library/nodes/Shopify/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.shopify
 description: Learn how to use the Shopify node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Slack/README.md
+++ b/docs/nodes/nodes-library/nodes/Slack/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.slack
 description: Learn how to use the Slack node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Snowflake/README.md
+++ b/docs/nodes/nodes-library/nodes/Snowflake/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.snowflake
 description: Learn how to use the Snowflake node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Spontit/README.md
+++ b/docs/nodes/nodes-library/nodes/Spontit/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.spontit
 description: Learn how to use the Spontit node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Spotify/README.md
+++ b/docs/nodes/nodes-library/nodes/Spotify/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.spotify
 description: Learn how to use the Spotify node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Storyblok/README.md
+++ b/docs/nodes/nodes-library/nodes/Storyblok/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.storyblok
 description: Learn how to use the Storyblok node in n8n
 ---
 
@@ -44,7 +43,7 @@ The start node exists by default when you create a new workflow.
 
 ### 2. Storyblok node (getAll: story)
 
-This node will get all the stories that have a slug starting with `release`. 
+This node will get all the stories that have a slug starting with `release`.
 
 1. Select 'Management API' from the ***Source*** dropdown list.
 2. You'll have to enter credentials for the Storyblok node. You can find out how to do that [here](../../../credentials/Storyblok/README.md).

--- a/docs/nodes/nodes-library/nodes/Strapi/README.md
+++ b/docs/nodes/nodes-library/nodes/Strapi/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.strapi
 description: Learn how to use the Strapi node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Strava/README.md
+++ b/docs/nodes/nodes-library/nodes/Strava/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.strava
 description: Learn how to use the Strava node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Taiga/README.md
+++ b/docs/nodes/nodes-library/nodes/Taiga/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.taiga
 description: Learn how to use the Taiga node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Telegram/README.md
+++ b/docs/nodes/nodes-library/nodes/Telegram/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.telegram
 description: Learn how to use the Telegram node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/TheHive/README.md
+++ b/docs/nodes/nodes-library/nodes/TheHive/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.theHive
 description: Learn how to use the TheHive node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Todoist/README.md
+++ b/docs/nodes/nodes-library/nodes/Todoist/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.todoist
 description: Learn how to use the Todoist node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/TravisCI/README.md
+++ b/docs/nodes/nodes-library/nodes/TravisCI/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.travisCi
 description: Learn how to use the Travis CI node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Trello/README.md
+++ b/docs/nodes/nodes-library/nodes/Trello/README.md
@@ -1,11 +1,10 @@
 ---
-permalink: /nodes/n8n-nodes-base.trello
 description: Learn how to use the Trello node in n8n
 ---
 
 # Trello
 
-[Trello](https://trello.com/) is a web-based Kanban-style list-making application which is a subsidiary of Atlassian. Users can create their task boards with different columns and move the tasks between them. 
+[Trello](https://trello.com/) is a web-based Kanban-style list-making application which is a subsidiary of Atlassian. Users can create their task boards with different columns and move the tasks between them.
 
 ::: tip 🔑 Credentials
 You can find authentication information for this node [here](../../../credentials/Trello/README.md).

--- a/docs/nodes/nodes-library/nodes/Twake/README.md
+++ b/docs/nodes/nodes-library/nodes/Twake/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.twake
 description: Learn how to use the Twake node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Twilio/README.md
+++ b/docs/nodes/nodes-library/nodes/Twilio/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.twilio
 description: Learn how to use the Twilio node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Twist/README.md
+++ b/docs/nodes/nodes-library/nodes/Twist/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.twist
 description: Learn how to use the Twist node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Twitter/README.md
+++ b/docs/nodes/nodes-library/nodes/Twitter/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.twitter
 description: Learn how to use the Twitter node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/UnleashedSoftware/README.md
+++ b/docs/nodes/nodes-library/nodes/UnleashedSoftware/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.unleashedSoftware
 description: Learn how to use the Unleashed Software node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/UpLead/README.md
+++ b/docs/nodes/nodes-library/nodes/UpLead/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.uplead
 description: Learn how to use the UpLead node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Vero/README.md
+++ b/docs/nodes/nodes-library/nodes/Vero/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.vero
 description: Learn how to use the Vero node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Vonage/README.md
+++ b/docs/nodes/nodes-library/nodes/Vonage/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.vonage
 description: Learn how to use the Vonage node in n8n
 ---
 
@@ -44,7 +43,7 @@ In the screenshot below, you will notice that the Cron node is configured to tri
 
 This node will return data about the current weather in Berlin. To get the weather updates for your city, you can enter the name of your city instead.
 
-1. First of all, you'll have to enter credentials for the OpenWeatherMap node. You can find out how to do that [here](../../../credentials/OpenWeatherMap/README.md). 
+1. First of all, you'll have to enter credentials for the OpenWeatherMap node. You can find out how to do that [here](../../../credentials/OpenWeatherMap/README.md).
 2. Enter `berlin` in the ***City*** field.
 3. Click on ***Execute Node*** to run the node.
 

--- a/docs/nodes/nodes-library/nodes/Wekan/README.md
+++ b/docs/nodes/nodes-library/nodes/Wekan/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.wekan
 description: Learn how to use the Wekan node in n8n
 ---
 
@@ -62,7 +61,7 @@ This workflow allows you to create a board and two lists called `To Do` and `Don
 
 The final workflow should look like the following image.
 
-![A workflow with the Wekan node](./workflow.png) 
+![A workflow with the Wekan node](./workflow.png)
 
 ::: v-pre
 ### 1. Start node

--- a/docs/nodes/nodes-library/nodes/WooCommerce/README.md
+++ b/docs/nodes/nodes-library/nodes/WooCommerce/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.wooCommerce
 description: Learn how to use the WooCommerce node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/WordPress/README.md
+++ b/docs/nodes/nodes-library/nodes/WordPress/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.wordpress
 description: Learn how to use the WordPress node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Xero/README.md
+++ b/docs/nodes/nodes-library/nodes/Xero/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.xero
 description: Learn how to use the Xero node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/YouTube/README.md
+++ b/docs/nodes/nodes-library/nodes/YouTube/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.youTube
 description: Learn how to use the YouTube node in n8n
 ---
 
@@ -65,7 +64,7 @@ The start node exists by default when you create a new workflow.
 
 ### 2. Read Binary File node
 
-1. Enter the path to the video file you want to upload in the ***File Path*** field. 
+1. Enter the path to the video file you want to upload in the ***File Path*** field.
 2. Click on ***Execute Node*** to run the node.
 
 ![Using the Read Binary File node to get the video](./ReadBinaryFile_node.png)
@@ -77,7 +76,7 @@ The start node exists by default when you create a new workflow.
 1. First of all, you'll have to enter credentials for the YouTube node. You can find out how to do that [here](../../../credentials/Google/README.md).
 2. Select 'Video' from the ***Resource*** dropdown list.
 3. Select 'Upload' from the ***Operation*** dropdown list.
-4. Enter the title of the video in the ***Title*** field. 
+4. Enter the title of the video in the ***Title*** field.
 5. Select the region code from ***Region Code*** dropdown list.
 6. Select the video category from the ***Category ID*** dropdown list.
 7. Click on ***Execute Node*** to run the node.

--- a/docs/nodes/nodes-library/nodes/Yourls/README.md
+++ b/docs/nodes/nodes-library/nodes/Yourls/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.yourls
 description: Learn how to use the Yourls node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Zendesk/README.md
+++ b/docs/nodes/nodes-library/nodes/Zendesk/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.zendesk
 description: Learn how to use the Zendesk node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/ZohoCRM/README.md
+++ b/docs/nodes/nodes-library/nodes/ZohoCRM/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.zohoCrm
 description: Learn how to use the Zoho CRM node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Zoom/README.md
+++ b/docs/nodes/nodes-library/nodes/Zoom/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.zoom
 description: Learn how to use the Zoom node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/Zulip/README.md
+++ b/docs/nodes/nodes-library/nodes/Zulip/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.zulip
 description: Learn how to use the Zulip node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/sms77/README.md
+++ b/docs/nodes/nodes-library/nodes/sms77/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.sms77
 description: Learn how to use the sms77 node in n8n
 ---
 

--- a/docs/nodes/nodes-library/nodes/uProc/README.md
+++ b/docs/nodes/nodes-library/nodes/uProc/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.uproc
 description: Learn how to use the uProc node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/AMQPTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/AMQPTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.amqpTrigger
 description: Learn how to use the AMQP Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/AWSSNSTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/AWSSNSTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.awsSnsTrigger
 description: Learn how to use the AWS SNS Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/ActiveCampaignTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/ActiveCampaignTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.activeCampaignTrigger
 description: Learn how to use the ActiveCampaign Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/AcuitySchedulingTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/AcuitySchedulingTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.acuitySchedulingTrigger
 description: Learn how to use the Acuity Scheduling Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/AffinityTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/AffinityTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.affinityTrigger
 description: Learn how to use the Affinity Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/AirtableTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/AirtableTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.airtableTrigger
 description: Learn how to use the Airtable Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/AsanaTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/AsanaTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.asanaTrigger
 description: Learn how to use the Asana Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/BitbucketTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/BitbucketTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.bitbucketTrigger
 description: Learn how to use the Bitbucket Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/BoxTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/BoxTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.boxTrigger
 description: Learn how to use the Box Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/CalendlyTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/CalendlyTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.calendlyTrigger
 description: Learn how to use the Calendly Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/ChargebeeTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/ChargebeeTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.chargebeeTrigger
 description: Learn how to use the Chargebee Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/ClickUpTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/ClickUpTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.clickUpTrigger
 description: Learn how to use the ClickUp Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/ClockifyTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/ClockifyTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.clockifyTrigger
 description: Learn how to use the Clockify Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/ConvertKitTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/ConvertKitTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.convertKitTrigger
 description: Learn how to use the ConvertKit Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/CopperTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/CopperTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.copperTrigger
 description: Learn how to use the Copper Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/CustomerIoTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/CustomerIoTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.customerIoTrigger
 description: Learn how to use the Customer.io Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/EventbriteTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/EventbriteTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.eventbriteTrigger
 description: Learn how to use the Eventbrite Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/FacebookTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/FacebookTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.facebookTrigger
 description: Learn how to use the Facebook Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/FlowTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/FlowTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.flowTrigger
 description: Learn how to use the Flow Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/GithubTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/GithubTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.githubTrigger
 description: Learn how to use the GitHub Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/GitlabTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/GitlabTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.gitlabTrigger
 description: Learn how to use the GitLab Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/GumroadTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/GumroadTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.gumroadTrigger
 description: Learn how to use the Gumroad Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/HelpScoutTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/HelpScoutTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.helpScoutTrigger
 description: Learn how to use the Help Scout Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/HubSpotTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/HubSpotTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.hubspotTrigger
 description: Learn how to use the HubSpot Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/InvoiceNinjaTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/InvoiceNinjaTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.invoiceNinjaTrigger
 description: Learn how to use the Invoice Ninja Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/JiraTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/JiraTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.jiraTrigger
 description: Learn how to use the Jira Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/JotFormTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/JotFormTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.jotFormTrigger
 description: Learn how to use the JotForm Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/KafkaTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/KafkaTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.kafkaTrigger
 description: Learn how to use the Kafka Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/KeapTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/KeapTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.keapTrigger
 description: Learn how to use the Keap Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/MQTTTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/MQTTTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.mqttTrigger
 description: Learn how to use the MQTT Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/MailchimpTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/MailchimpTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.mailchimpTrigger
 description: Learn how to use the Mailchimp Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/MailerLiteTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/MailerLiteTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.mailerLiteTrigger
 description: Learn how to use the MailerLite Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/MailjetTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/MailjetTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.mailjetTrigger
 description: Learn how to use the Mailjet Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/MauticTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/MauticTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.mauticTrigger
 description: Learn how to use the Mautic Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/PayPalTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/PayPalTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.payPalTrigger
 description: Learn how to use the PayPal Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/PipedriveTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/PipedriveTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.pipedriveTrigger
 description: Learn how to use the Pipedrive Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/PostmarkTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/PostmarkTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.postmarkTrigger
 description: Learn how to use the Postmark Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/PushcutTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/PushcutTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.pushcutTrigger
 description: Learn how to use the Pushcut Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/RabbitMQTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/RabbitMQTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.rabbitmqTrigger
 description: Learn how to use the RabbitMQ Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/ShopifyTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/ShopifyTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.shopifyTrigger
 description: Learn how to use the Shopify Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/StravaTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/StravaTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.stravaTrigger
 description: Learn how to use the Strava Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/StripeTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/StripeTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.stripeTrigger
 description: Learn how to use the Stripe Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/SurveyMonkeyTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/SurveyMonkeyTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.surveyMonkeyTrigger
 description: Learn how to use the SurveyMonkey Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/TaigaTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/TaigaTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.taigaTrigger
 description: Learn how to use the Taiga Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/TelegramTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/TelegramTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.telegramTrigger
 description: Learn how to use the Telegram Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/TheHiveTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/TheHiveTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.theHiveTrigger
 ---
 
 # TheHive Trigger

--- a/docs/nodes/nodes-library/trigger-nodes/TogglTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/TogglTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.togglTrigger
 description: Learn how to use the Toggl Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/TrelloTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/TrelloTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.trelloTrigger
 description: Learn how to use the Trello Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/TypeformTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/TypeformTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.typeformTrigger
 description: Learn how to use the Typeform Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/WebflowTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/WebflowTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.webflowTrigger
 description: Learn how to use the Webflow Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/WooCommerceTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/WooCommerceTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.wooCommerceTrigger
 description: Learn how to use the WooCommerce Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/WufooTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/WufooTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.wufooTrigger
 description: Learn how to use the Wufoo Trigger node in n8n
 ---
 

--- a/docs/nodes/nodes-library/trigger-nodes/ZendeskTrigger/README.md
+++ b/docs/nodes/nodes-library/trigger-nodes/ZendeskTrigger/README.md
@@ -1,5 +1,4 @@
 ---
-permalink: /nodes/n8n-nodes-base.zendeskTrigger
 description: Learn how to use the Zendesk Trigger node in n8n
 ---
 


### PR DESCRIPTION
This PR fixes #359.

## Deployment

Since this bug is reproducible only in Production, the docs need to be built and deployed:

```
npm i anywhere -g
git checkout fix-failing-redirects
npm run build
cd docs/.vuepress/dist
anywhere -h localhost
```

For ease of testing, since building the entire docs repo takes very long, here is a [minimal reproduction repo](https://github.com/ivov/fix-failing-redirects-repro).

## Issue

Vuepress link generation by default [reflects file system structure](https://github.com/vuejs/vuepress/blob/master/packages/%40vuepress/shared-utils/src/fileToPath.ts), unless overriden by permalinks in individual pages.

This line `permalink: /nodes/n8n-nodes-base.cron` in the frontmatter of `docs/nodes/nodes-library/core-nodes/Cron/README.md` generates `docs/.vuepress/dist/nodes/n8n.nodes-base.cron/index.html`. But in other docs pages, any generated links to that file actually point to `nodes/nodes-library/core-nodes/Cron/`, which does not exist in the `/dist` dir.

Left-clicking on those links successfully redirects to the actual location but _middle-clicking_ (or also right-clicking and selecting "Open on new tab") on the link fails to redirect and returns 404. Same with credentials: `permalink: /credentials/activeCampaign` generates `docs/.vuepress/dist/credentials/activeCampaign/index.html` but generated links point to `/nodes/credentials/ActiveCampaign/`, which does not exist in the `/dist` dir.

Why left-clicking and middle-clicking behave differently I cannot explain—possibly related to [an SSR mismatch in how Vuepress handles redirects before rendering](https://github.com/vuejs/vuepress/issues/1382).

## Solution

All permalink overrides were removed, allowing Vuepress to generate links by default, so that all links point to actual file locations, so redirects do not occur. Regexes used for removal: `permalink.*/nodes/n8n-nodes-base\..*\n` and `permalink: /credentials/.*\n` The links referenced in the issue all work, but there might still be other unreported permalinks in need of fixing.

```
permalink: /nodes/n8n-nodes-base.cron 			// pre-removal
permalink: /nodes/nodes-library/core-nodes/Cron		// implied post-removal (Vuepress default)
```

Alternative solutions would be attempting to patch the Vuepress link generation logic to point to the permalinks, or attempting the workaround for the SSR mismatch described above.