### PR TITLE
Update README.md of FunctionItem & function-nodes.md

### DIFF
--- a/docs/nodes/nodes-library/core-nodes/FunctionItem/README.md
+++ b/docs/nodes/nodes-library/core-nodes/FunctionItem/README.md
@@ -34,7 +34,11 @@ return item;
 ### Method: getBinaryData()
 
 Returns all the binary data (all keys) of the item which gets currently processed.
-
+```json
+// Makes a copy of <attachment_0>'s filename and attaches it to the "json" data.
+item.filename = getBinaryData().attachment_0.fileName;
+return item;
+```
 
 ### Method: setBinaryData(binaryData)
 

--- a/docs/reference/function-nodes.md
+++ b/docs/reference/function-nodes.md
@@ -22,3 +22,9 @@ possible via the methods `getBinaryData` and `setBinaryData`.
 
 Both nodes support promises. So instead of returning the item or items directly, it is also possible to
 return a promise which resolves accordingly.
+
+__Comparison__
+| Data to access ...          | Function               | FunctionItem     |
+| :-------------------------- | :--------------------- | :--------------- |
+| JSON-Data                   | items\[_index_\].json    | item             |
+| Binary-Data                 | items\[_index_\].binary  | getBinaryData()  |


### PR DESCRIPTION
I fully understood the FuntionItem node in the end from checking the source code, but the documentation was confusing for me in several ways. That's because Function and FunctionItem have different styles. Function gives access to the whole items array and the structure is transparently available with json/binary.
In case of FunctionItem. The item is not item, it's item.json. You can't access item.binary cause of this, as it would be intuitive to do so, if you worked with Function before.
At first an update to the documentation to guide new users hopefully in the right direction. 

It should be also considered that Function and FunctionItem behave the same, e.g. item.json and item.binary should exists. The variable might also called itemjson instead of item.