### PR TITLE
Update docker-compose to fix LetsEncrypt config

### DIFF
--- a/docs/reference/server-setup.md
+++ b/docs/reference/server-setup.md
@@ -95,11 +95,15 @@ services:
       - "--api.insecure=true"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
       - "--entrypoints.websecure.address=:443"
       - "--certificatesresolvers.mytlschallenge.acme.tlschallenge=true"
       - "--certificatesresolvers.mytlschallenge.acme.email=${SSL_EMAIL}"
       - "--certificatesresolvers.mytlschallenge.acme.storage=/letsencrypt/acme.json"
     ports:
+      - "80:80"
       - "443:443"
     volumes:
       - ${DATA_FOLDER}/letsencrypt:/letsencrypt
@@ -114,7 +118,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.n8n.rule=Host(`${SUBDOMAIN}.${DOMAIN_NAME}`)
       - traefik.http.routers.n8n.tls=true
-      - traefik.http.routers.n8n.entrypoints=websecure
+      - traefik.http.routers.n8n.entrypoints=web,websecure
       - traefik.http.routers.n8n.tls.certresolver=mytlschallenge
       - traefik.http.middlewares.n8n.headers.SSLRedirect=true
       - traefik.http.middlewares.n8n.headers.STSSeconds=315360000


### PR DESCRIPTION
This PR updates [the docker tutorial](https://docs.n8n.io/reference/server-setup.html#_5-create-docker-compose-file). Expose port 80 so LetsEncrypt doesn't fail, but redirect it to port 443.

It looks like the current docker-compose setup doesn't correctly enable LetsEncrypt for multiple users. [There's a forum thread about this.](https://community.n8n.io/t/ssl-and-security/346/16?u=janbaykara)