### PR TITLE
Clickable sidebar headings

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -170,20 +170,24 @@ module.exports = {
 				{
 					title: '🧠 Nodes Library',
 					sidebarDepth: 3,
+					path: '/nodes/nodes-library',
 					children: [
 						{
 							title: 'Core Nodes',
 							sidebarDepth: 1,
+							path: '/nodes/nodes-library/core-nodes',
 							children: getChildrenFolders('nodes/nodes-library/core-nodes'),
 						},
 						{
 							title: 'Nodes',
 							sidebarDepth: 1,
+							path: '/nodes/nodes-library/nodes',
 							children: getChildrenFolders('nodes/nodes-library/nodes'),
 						},
 						{
 							title: 'Trigger Nodes',
 							sidebarDepth: 1,
+							path: '/nodes/nodes-library/trigger-nodes',
 							children: getChildrenFolders('nodes/nodes-library/trigger-nodes'),
 						},
 					],
@@ -191,6 +195,7 @@ module.exports = {
 				{
 					title: '🔑 Credentials Library',
 					sidebarDepth: 2,
+					path: '/nodes/credentials',
 					children: getChildrenFolders('nodes/credentials'),
 				},
 			],

--- a/docs/nodes/nodes-library/README.md
+++ b/docs/nodes/nodes-library/README.md
@@ -1,0 +1,3 @@
+# Nodes Library
+
+Information about all nodes in n8n.


### PR DESCRIPTION
This PR makes section headings clickable.

1. `git checkout clickable-sidebar-headings`
2. `npm run build && npm run dev`
3. Open browser at `localhost: 8080`
4. Click on "Nodes" on the top right
5. Click on "Nodes Library" on the left → overview shown
6. Click on its three subsections → overviews shown 
7. Click on "Credentials Library" → overview shown

The overviews can be edited at:

- `docs\nodes\credentials\README.md`
- `docs\nodes\nodes-library\README.md`
- `docs\nodes\nodes-library\core-nodes\README.md`
- `docs\nodes\nodes-library\nodes\README.md`
- `docs\nodes\nodes-library\trigger-nodes\README.md`