### PR TITLE
describe how to start webhook processors correctly

### DIFF
--- a/docs/reference/scaling-n8n.md
+++ b/docs/reference/scaling-n8n.md
@@ -94,6 +94,11 @@ If you want to migrate data from one database to another, you can use the Export
 Webhook processors are another layer of scaling in n8n. Configuring the webhook processor is optional. Webhook processors allow you to scale the incoming webhook requests.
 
 Webhook processes rely on Redis too. Follow the steps mentioned above to [configure the workers](#configuring-workers).
+Finally start the processors with: 
+
+```
+./packages/cli/bin/n8n webhook
+```
 
 This method allows n8n to process a huge number of parallel requests. All you have to do is add more webhook processes and workers accordingly, as long as the database and Redis are provisioned correctly.
 


### PR DESCRIPTION
I've followed this step by step guide, but noticed a problem afterwards using cron-triggered jobs. I started the webhook processors like described in this guide as "n8n workers", but instead I had to start it with "n8n webhook". This should be clearly stated in the docs, as it seems like a common pitfall. Maybe my brain-power was too low at that time, too :sweat_smile: