### PR TITLE
Updating OpenWeatherMap API Instructions

### DIFF
--- a/docs/getting-started/create-your-first-workflow/daily-weather-notifications/README.md
+++ b/docs/getting-started/create-your-first-workflow/daily-weather-notifications/README.md
@@ -53,6 +53,7 @@ Here's a GIF of me following the steps mentioned above.
 
 ![Creating the OpenWeatherMap node](./images/creating-the-openweathermap-node.gif)
 
+Note: If you receive a 401 error when executing your node, your API key may not have been activated yet. API keys are activated automatically between 10 minutes and 2 hours after successful registration on OpenWeatherMap.
 
 ### 3. IF node
 


### PR DESCRIPTION
Added a note about OpenWeatherMap's API key activation being 10 min to 2 hours after a successful registration. 
Users could become frustrated after following the steps and getting an error (including me, which is why I sought to update the docs).

See: https://openweathermap.org/faq#notes_block:~:text=Do%20I%20need%20to%20activate%20my%20API%20key%3F