### PR TITLE
Update docker-compose to pass timezone env variable

### DIFF
--- a/docs/reference/server-setup.md
+++ b/docs/reference/server-setup.md
@@ -119,6 +119,7 @@ services:
       - N8N_PROTOCOL=https
       - NODE_ENV=production
       - WEBHOOK_TUNNEL_URL=https://${SUBDOMAIN}.${DOMAIN_NAME}/
+      - GENERIC_TIMEZONE=${GENERIC_TIMEZONE}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${DATA_FOLDER}/.n8n:/home/node/.n8n


### PR DESCRIPTION
GENERIC_TIMEZONE is added in the sample .env file but not passed to the docker container through the sample docker-compose.yml