### PR TITLE
Highlight limitations of getWorkflowStaticData

### DIFF
--- a/docs/nodes/nodes-library/core-nodes/FunctionItem/README.md
+++ b/docs/nodes/nodes-library/core-nodes/FunctionItem/README.md
@@ -54,10 +54,17 @@ set on that object. When the workflow execution succeeds, n8n will check automat
 has changed and will save it, if necessary.
 
 There are two types of static data. The "global" and the "node" one. Global static data is the
-same in the whole workflow. And every node in the workflow can access it. The node static data
-, however, is different for every node and only the node which set it can retrieve it again.
+same in the whole workflow. And every node in the workflow can access it. The node static data,
+however, is different for every node and only the node which set it can retrieve it again.
 
-Example:
+#### Limitations
+
+It is important to know that the static data can not be read and written when testing via the UI.
+The data there will always be empty and the changes will not persist. Only when a workflow
+is active and it gets called by a Trigger or Webhook, the static data will be saved.
+This works in the same way as in the Function node.
+
+#### Example
 
 ```javascript
 // Get the global workflow static data
@@ -74,8 +81,3 @@ staticData.lastExecution = new Date().getTime();
 // Delete data
 delete staticData.lastExecution;
 ```
-
-It is important to know that the static data can not be read and written when testing via the UI.
-The data there will always be empty and the changes will not persist. Only when a workflow
-is active and it gets called by a Trigger or Webhook, the static data will be saved.
-This works in the same way as in the Function node.


### PR DESCRIPTION
Below the example it tends to be overlooked. By moving it above and give it a heading it is more clear.