### PR TITLE
Fix ServiceNow credentials doc link

### DIFF
--- a/docs/nodes/credentials/ServiceNow/README.md
+++ b/docs/nodes/credentials/ServiceNow/README.md
@@ -1,5 +1,5 @@
 ---
-permalink: /credentials/servicenow
+permalink: /credentials/serviceNow
 description: Learn to configure credentials for the ServiceNow node in n8n
 ---
 


### PR DESCRIPTION
This PR fixes the link for the ServiceNow credential documentation. The node in n8n refers to the link with a capitalized N (serviceNow) and that results in a 404.

![Screenshot 2021-07-23 at 11 31 08 AM](https://user-images.githubusercontent.com/18901032/126763541-4ab7f0a8-0299-4a2f-b88f-c4a535b75b72.png)
