### PR TITLE
Fix HomeAsssistant credential ReadMe

### DIFF
--- a/docs/nodes/credentials/HomeAssistant/README.md
+++ b/docs/nodes/credentials/HomeAssistant/README.md
@@ -6,7 +6,7 @@ description: Learn to configure credentials for the Home Assistant node in n8n
 # Home Assistant
 
 You can use these credentials to authenticate the following nodes with Home Assistant.
-- [Home Assistant](https://docs.n8n.io/nodes/n8n-nodes-base.homeAssistant/)
+- [Home Assistant](../../nodes-library/nodes/HomeAssistant/README.md)
 
 ## Prerequisites
 

--- a/docs/nodes/credentials/HomeAssistant/README.md
+++ b/docs/nodes/credentials/HomeAssistant/README.md
@@ -5,8 +5,8 @@ description: Learn to configure credentials for the Home Assistant node in n8n
 
 # Home Assistant
 
-You can use these credentials to authenticate the following nodes with Harvest.
-- [Harvest](../../nodes-library/nodes/Harvest/README.md)
+You can use these credentials to authenticate the following nodes with Home Assistant.
+- [Home Assistant](https://docs.n8n.io/nodes/n8n-nodes-base.homeAssistant/)
 
 ## Prerequisites
 


### PR DESCRIPTION
Fix incorrect link in Home Assistant credential readme. It was linking to Harvest.