### PR TITLE
Added migration guide to request lib deprecation

### DIFF
--- a/docs/nodes/creating-nodes/general-guidelines.md
+++ b/docs/nodes/creating-nodes/general-guidelines.md
@@ -53,9 +53,8 @@ Node versioning in a glimpse:
 - The main node file now only contains a base description containing the `defaultVersion` (usually the latest) and a list of versions
 - We recommend you use `v1`, `v2`, etc. for version folder names
 - A new code separation has been created and can be seen in the Mattermost node above. Highlights:  
-    * `actions` folder with the implementation of each action the node can perform  
-    * `description` folder with the node parameters, separated by folders  
+    * `actions` folder with description and implementation of each possible action  
     * `methods` is an optional folder with the loading dynamic parameters' functions  
     * `transport` is a folder with all the communication implementation
 
-**Note:** For both the `actions` and `description` folders we recommend using `resources` as subfolders and `operations` as file names. This make browsing through the code a lot easier. This can be simplified for nodes that have a less complicated structure.
+**Note:** For the `actions` folder we recommend using `resources` and `operations` names as subfolders hierarchically. For the implementation an description you can use separate files. Our recommendation is to use `execute.ts` and `description.ts` as file names. This make browsing through the code a lot easier. This can be simplified for nodes that have a less complicated structure.

--- a/docs/nodes/creating-nodes/general-guidelines.md
+++ b/docs/nodes/creating-nodes/general-guidelines.md
@@ -23,8 +23,10 @@ All code of n8n is written in TypeScript and hence, the nodes should also be wri
 Some third-party services have their own libraries on npm which make it easier to create an integration. It can be quite tempting to use them. The problem with those is that you add another dependency and not only one, you add but also all the dependencies of the dependencies. This means more and more code gets added, has to get loaded, can introduce security vulnerabilities, bugs, and so on. So please use the built-in module which can be used like this:
 
 ```typescript
-const response = await this.helpers.request(options);
+const response = await this.helpers.httpRequest(options);
 ```
+
+The full documentation and migration instructions from the deprecated `this.helpers.request` can be found [installing](making-http-requests.md).
 
 That is using the npm package [`request-promise-native`](https://github.com/request/request-promise-native) which is the basic npm `request` module but with promises. For a full set of `options` consider looking at [the underlying `request` options documentation](https://github.com/request/request#requestoptions-callback).
 
@@ -47,3 +49,22 @@ There is not much of a guideline yet but if your node can do multiple things, ca
 ### Node Icons
 
 Check existing node icons as a reference when you create own ones. The resolution of an icon should be 60x60px and saved as PNG.
+
+### Node versions
+
+n8n now supports node versioning and it's a blast! You can make changes to existing nodes without breaking the existing behavior by introducing a new version. You can check an example of a versioned node by browsing the [Mattermost node](https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/Mattermost/v1/MattermostV1.node.ts).
+
+Node versioning in a glimpse:
+
+- The main node file should now extend `NodeVersionedType` instead of `INodeType`
+- The main node file now only contains a base description containing the `defaultVersion` (usually the latest) and a list of versions
+- We recommend you use `v1`, `v2`, etc. for version folder names
+- A new code separation has been created and can be seen in the Mattermost node above. Highlights:  
+`actions` folder with the implementation of each action the node can perform  
+`description` folder with the node parameters, separated by folders  
+`methods` is an optional folder with the loading dynamic parameters' functions  
+`transport` is a folder with all the communication implementation
+
+**Note:** For both `actions` and `description` folders we recommend using `resources` as subfolders and `operations` as file names. This make browsing through the code a lot easier. This can be simplified for nodes that have a less complicated structure.
+
+

--- a/docs/nodes/creating-nodes/general-guidelines.md
+++ b/docs/nodes/creating-nodes/general-guidelines.md
@@ -1,11 +1,8 @@
-
 # General Guidelines
-
 
 Please make sure that everything works correctly and that no unnecessary code gets added. It is important to follow the following guidelines:
 
-
-### Do not change incoming data
+## Do not change incoming data
 
 Never change the incoming data a node receives (which can be queried with `this.getInputData()`) as it gets shared by all nodes. If data has to get added, changed or deleted it has to be cloned and the new data returned. If that is not done, sibling nodes which execute after the current one will operate on the altered data and would process different data than they were supposed to.
 It is however not needed to always clone all the data. If a node for, example only, changes only the binary data but not the JSON data, a new item can be created which reuses the reference to the JSON item.
@@ -13,12 +10,12 @@ It is however not needed to always clone all the data. If a node for, example on
 An example can be seen in the code of the [ReadBinaryFile-Node](https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/ReadBinaryFile.node.ts#L69-L83).
 
 
-### Write nodes in TypeScript
+## Write nodes in TypeScript
 
 All code of n8n is written in TypeScript and hence, the nodes should also be written in TypeScript. That makes development easier, faster, and avoids at least some bugs.
 
 
-### Use the built in request library
+## Use the built in request library
 
 Some third-party services have their own libraries on npm which make it easier to create an integration. It can be quite tempting to use them. The problem with those is that you add another dependency and not only one, you add but also all the dependencies of the dependencies. This means more and more code gets added, has to get loaded, can introduce security vulnerabilities, bugs, and so on. So please use the built-in module which can be used like this:
 
@@ -26,31 +23,27 @@ Some third-party services have their own libraries on npm which make it easier t
 const response = await this.helpers.httpRequest(options);
 ```
 
-The full documentation and migration instructions from the deprecated `this.helpers.request` can be found [installing](making-http-requests.md).
+The full documentation and migration instructions from the deprecated `this.helpers.request` can be found [here](./making-http-requests.md).
 
 That is using the npm package [`request-promise-native`](https://github.com/request/request-promise-native) which is the basic npm `request` module but with promises. For a full set of `options` consider looking at [the underlying `request` options documentation](https://github.com/request/request#requestoptions-callback).
 
-
-### Reuse parameter names
+## Reuse parameter names
 
 When a node can perform multiple operations like edit and delete some kind of entity, for both operations, it would need an entity-id. Do not call them "editId" and "deleteId", call them "id". n8n can handle multiple parameters with the same name without a problem as long as only one is visible. To make sure that is the case, the "displayOptions" can be used. By keeping the same name, the value can be kept if a user switches the operation from "edit" to "delete".
 
-
-### Create an 'Additional Fields' parameter
+## Create an 'Additional Fields' parameter
 
 Some nodes may need a lot of options. Add only the very important ones to the top level and for all others, create an 'Additional Fields' parameter where they can be added if needed. This ensures that the interface stays clean and does not unnecessarily confuse people. A good example of that would be the XML node.
 
-
-### Follow existing parameter naming guideline
+## Follow existing parameter naming guideline
 
 There is not much of a guideline yet but if your node can do multiple things, call the parameter which sets the behavior either "mode" (like "Merge" and "XML" node) or "operation" like the most other ones. If these operations can be done on different resources (like "User" or "Order) create a "resource" parameter (like "Pipedrive" and "Trello" node).
 
-
-### Node Icons
+## Node icons
 
 Check existing node icons as a reference when you create own ones. The resolution of an icon should be 60x60px and saved as PNG.
 
-### Node versions
+## Node versions
 
 n8n now supports node versioning and it's a blast! You can make changes to existing nodes without breaking the existing behavior by introducing a new version. You can check an example of a versioned node by browsing the [Mattermost node](https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/Mattermost/v1/MattermostV1.node.ts).
 
@@ -60,11 +53,9 @@ Node versioning in a glimpse:
 - The main node file now only contains a base description containing the `defaultVersion` (usually the latest) and a list of versions
 - We recommend you use `v1`, `v2`, etc. for version folder names
 - A new code separation has been created and can be seen in the Mattermost node above. Highlights:  
-`actions` folder with the implementation of each action the node can perform  
-`description` folder with the node parameters, separated by folders  
-`methods` is an optional folder with the loading dynamic parameters' functions  
-`transport` is a folder with all the communication implementation
+    * `actions` folder with the implementation of each action the node can perform  
+    * `description` folder with the node parameters, separated by folders  
+    * `methods` is an optional folder with the loading dynamic parameters' functions  
+    * `transport` is a folder with all the communication implementation
 
-**Note:** For both `actions` and `description` folders we recommend using `resources` as subfolders and `operations` as file names. This make browsing through the code a lot easier. This can be simplified for nodes that have a less complicated structure.
-
-
+**Note:** For both the `actions` and `description` folders we recommend using `resources` as subfolders and `operations` as file names. This make browsing through the code a lot easier. This can be simplified for nodes that have a less complicated structure.

--- a/docs/nodes/creating-nodes/making-http-requests.md
+++ b/docs/nodes/creating-nodes/making-http-requests.md
@@ -1,22 +1,21 @@
 
 # Making HTTP Requests
 
+While creating nodes it is very commonn to call external APIs or make HTTP requests to other services.
 
-While creating nodes, it is very commong to call external APIs or make HTTP requests to other services.
+This plays a major role during node development, maintenance, and improvements.
 
-This plays a major role during node development, maintenance and improvements.
-
-We provide you with a very flexible helper for making HTTP requests that abstracts most of the complexity from you with a simple to use interface.
+We provide a very flexible helper for making HTTP requests that abstracts away most of the complexity with a simple to use interface.
 
 ## How to use
 
-In the node code, inside the `execute` function you can easily call
+In the node code, inside the `execute` function you can easily call:
 
 ```typescript
 const response = await this.helpers.httpRequest(options);
 ```
 
-Where options is an object in this format:
+Where `options` is an object in this format:
 
 ```typescript
 {
@@ -44,8 +43,7 @@ Where options is an object in this format:
 		protocol?: string;
 	};
 	timeout?: number;
-}
-	
+}	
 ```
 
 Where `url` is the only mandatory field. The default method is `GET`.
@@ -54,19 +52,18 @@ Some notes about the possible fields:
 
 - **body**: You can use a regular Javascript Object for JSON payload, a Buffer for file uploads, an instance of FormData for `multipart/form-data` and `URLSearchParams` for `application/x-www-form-urlencoded`.
 - **headers**: A simple key-value pair.  
-If `body` is an instance of `FormData` then `content-type: multipart/form-data` is injected automatically.  
-Similarly, if `body` is an instance of `URLSearchParams`, then `content-type: application/x-www-form-urlencoded` is added.  
-If you wish to override this behavior, you can set any `content-type` header you wish and it won't be overridden.
+	* If `body` is an instance of `FormData` then `content-type: multipart/form-data` is injected automatically.  
+	* If `body` is an instance of `URLSearchParams`, then `content-type: application/x-www-form-urlencoded` is added.  
+	* To override this behavior, you can set any `content-type` header you wish and it won't be overridden.
 - **arrayFormat**: If your query string contains an array of data, let's say `const queryString = {IDs: [15,17]}`, the values set to `arrayFormat` define how it will be sent.  
-`indices` (default): `{ a: ['b', 'c'] }` will be formatted as `a[0]=b&a[1]=c`  
-`brackets`: `{ a: ['b', 'c'] }` will be formatted as `a[]=b&a[]=c`  
-`repeat`: `{ a: ['b', 'c'] }` will be formatted as `a=b&a=c`  
-`comma`: `{ a: ['b', 'c'] }` will be formatted as `a=b,c`
-- **auth**: Used for Basic auth. Provide `username` and ``password`.
+	* `indices` (default): `{ a: ['b', 'c'] }` will be formatted as `a[0]=b&a[1]=c`  
+	* `brackets`: `{ a: ['b', 'c'] }` will be formatted as `a[]=b&a[]=c`  
+	* `repeat`: `{ a: ['b', 'c'] }` will be formatted as `a=b&a=c`  
+	* `comma`: `{ a: ['b', 'c'] }` will be formatted as `a=b,c`
+- **auth**: Used for Basic auth. Provide `username` and `password`.
 - **disableFollowRedirect**: By default, we'll follow redirects. You can set this to false to prevent this from happening
 - **skipSslCertificateValidation**: Used for calling HTTPS services without proper certificate
-- **returnFullResponse**: Instead of returning only the body, returns an object with more data instead in the following format:  
-`{body: body, headers: object, statusCode: 200, statusMessage: 'OK', request: requestObject}`
+- **returnFullResponse**: Instead of returning only the body, returns an object with more data in the following format: `{body: body, headers: object, statusCode: 200, statusMessage: 'OK', request: requestObject}`
 - **encoding**: We usually detect the content type correctly but you can specify `arrayBuffer` to receive a Buffer you can read from and interact with.
 
 ## Deprecation of the previous helper
@@ -75,15 +72,15 @@ The previous helper implementation using `this.helpers.request(options)` used an
 
 In an effort to keep maximum compatibility, we made a transparent conversion to another library called `axios`.
 
-If you are having issues, please report them in our Community Forums or on Github. We'll be glad to fix it.
+If you are having issues, please report them in our [Community Forums](https://community.n8n.io/) or on [Github](https://github.com/n8n-io/n8n/issues).
 
 Also, you can temporarily enable n8n to use the deprecated library by setting the environment variable `N8N_USE_DEPRECATED_REQUEST_LIB=true`.
 
-**Please note:** This behavior is permanent and we will be removing the `request-promise` library entirely in the future (date TBA) so please report any errors you have so we can fix them.
+**Please note:** This behavior is permanent and we will be removing the `request-promise` library entirely in the future so please report any errors you have so we can fix them.
 
-## Migration guide to the new helper {#migration-guide}
+## Migration guide to the new helper
 
-As mentioned above, the previous helper is deprecated and will be replaced in the future. The new helper is much more robust, library agnostic and easier to use.
+As mentioned above, the previous helper is deprecated and will be replaced in the future. The new helper is much more robust, library agnostic, and easier to use.
 
 New nodes should all use the new helper, and if you have built custom nodes we strongly suggest you migrate to the new helper. Here are the main considerations when migrating:
 
@@ -97,4 +94,4 @@ New nodes should all use the new helper, and if you have built custom nodes we s
 
 ## Example
 
-For an example, please check the [Mattermost node](https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/Mattermost/v1/MattermostV1.node.ts)
+For an example, please check the [Mattermost node](https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/Mattermost/v1/MattermostV1.node.ts).

--- a/docs/nodes/creating-nodes/making-http-requests.md
+++ b/docs/nodes/creating-nodes/making-http-requests.md
@@ -1,0 +1,100 @@
+
+# Making HTTP Requests
+
+
+While creating nodes, it is very commong to call external APIs or make HTTP requests to other services.
+
+This plays a major role during node development, maintenance and improvements.
+
+We provide you with a very flexible helper for making HTTP requests that abstracts most of the complexity from you with a simple to use interface.
+
+## How to use
+
+In the node code, inside the `execute` function you can easily call
+
+```typescript
+const response = await this.helpers.httpRequest(options);
+```
+
+Where options is an object in this format:
+
+```typescript
+{
+	url: string;
+	headers?: object;
+	method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'HEAD';
+	body?: FormData | Array | string | number | object | Buffer | URLSearchParams;
+	queryString?: object;
+	arrayFormat?: 'indices' | 'brackets' | 'repeat' | 'comma';
+	auth?: {
+		username: string,
+		password: string,
+	};
+	disableFollowRedirect?: boolean;
+	encoding?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';
+	skipSslCertificateValidation?: boolean;
+	returnFullResponse?: boolean;
+	proxy?: {
+		host: string;
+		port: string | number;
+		auth?: {
+			username: string;
+			password: string;
+		},
+		protocol?: string;
+	};
+	timeout?: number;
+}
+	
+```
+
+Where `url` is the only mandatory field. The default method is `GET`.
+
+Some notes about the possible fields:
+
+- **body**: You can use a regular Javascript Object for JSON payload, a Buffer for file uploads, an instance of FormData for `multipart/form-data` and `URLSearchParams` for `application/x-www-form-urlencoded`.
+- **headers**: A simple key-value pair.  
+If `body` is an instance of `FormData` then `content-type: multipart/form-data` is injected automatically.  
+Similarly, if `body` is an instance of `URLSearchParams`, then `content-type: application/x-www-form-urlencoded` is added.  
+If you wish to override this behavior, you can set any `content-type` header you wish and it won't be overridden.
+- **arrayFormat**: If your query string contains an array of data, let's say `const queryString = {IDs: [15,17]}`, the values set to `arrayFormat` define how it will be sent.  
+`indices` (default): `{ a: ['b', 'c'] }` will be formatted as `a[0]=b&a[1]=c`  
+`brackets`: `{ a: ['b', 'c'] }` will be formatted as `a[]=b&a[]=c`  
+`repeat`: `{ a: ['b', 'c'] }` will be formatted as `a=b&a=c`  
+`comma`: `{ a: ['b', 'c'] }` will be formatted as `a=b,c`
+- **auth**: Used for Basic auth. Provide `username` and ``password`.
+- **disableFollowRedirect**: By default, we'll follow redirects. You can set this to false to prevent this from happening
+- **skipSslCertificateValidation**: Used for calling HTTPS services without proper certificate
+- **returnFullResponse**: Instead of returning only the body, returns an object with more data instead in the following format:  
+`{body: body, headers: object, statusCode: 200, statusMessage: 'OK', request: requestObject}`
+- **encoding**: We usually detect the content type correctly but you can specify `arrayBuffer` to receive a Buffer you can read from and interact with.
+
+## Deprecation of the previous helper
+
+The previous helper implementation using `this.helpers.request(options)` used and exposed the `request-promise` library which was deprecated.
+
+In an effort to keep maximum compatibility, we made a transparent conversion to another library called `axios`.
+
+If you are having issues, please report them in our Community Forums or on Github. We'll be glad to fix it.
+
+Also, you can temporarily enable n8n to use the deprecated library by setting the environment variable `N8N_USE_DEPRECATED_REQUEST_LIB=true`.
+
+**Please note:** This behavior is permanent and we will be removing the `request-promise` library entirely in the future (date TBA) so please report any errors you have so we can fix them.
+
+## Migration guide to the new helper {#migration-guide}
+
+As mentioned above, the previous helper is deprecated and will be replaced in the future. The new helper is much more robust, library agnostic and easier to use.
+
+New nodes should all use the new helper, and if you have built custom nodes we strongly suggest you migrate to the new helper. Here are the main considerations when migrating:
+
+- `qs` is now called `queryString`
+- Only `url` is accepted. Previously `uri` was also accepted
+- `encoding: null` now must be `encoding: arrayBuffer`
+- If using `json: true` you should now instead set the `accept: application/json` header
+- `rejectUnauthorized: false` is now `skipSslCertificateValidation: true`
+- Use `body` according to `content-type` headers to clarify what is being sent
+- `resolveWithFullResponse` is now `returnFullResponse` and has similar behavior
+
+## Example
+
+For an example, please check the [Mattermost node](https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/Mattermost/v1/MattermostV1.node.ts)

--- a/docs/nodes/creating-nodes/making-http-requests.md
+++ b/docs/nodes/creating-nodes/making-http-requests.md
@@ -23,7 +23,7 @@ Where `options` is an object in this format:
 	headers?: object;
 	method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'HEAD';
 	body?: FormData | Array | string | number | object | Buffer | URLSearchParams;
-	queryString?: object;
+	qs?: object;
 	arrayFormat?: 'indices' | 'brackets' | 'repeat' | 'comma';
 	auth?: {
 		username: string,
@@ -43,6 +43,7 @@ Where `options` is an object in this format:
 		protocol?: string;
 	};
 	timeout?: number;
+	json?: boolean;
 }	
 ```
 
@@ -55,7 +56,7 @@ Some notes about the possible fields:
 	* If `body` is an instance of `FormData` then `content-type: multipart/form-data` is injected automatically.  
 	* If `body` is an instance of `URLSearchParams`, then `content-type: application/x-www-form-urlencoded` is added.  
 	* To override this behavior, you can set any `content-type` header you wish and it won't be overridden.
-- **arrayFormat**: If your query string contains an array of data, let's say `const queryString = {IDs: [15,17]}`, the values set to `arrayFormat` define how it will be sent.  
+- **arrayFormat**: If your query string contains an array of data, let's say `const qs = {IDs: [15,17]}`, the values set to `arrayFormat` define how it will be sent.  
 	* `indices` (default): `{ a: ['b', 'c'] }` will be formatted as `a[0]=b&a[1]=c`  
 	* `brackets`: `{ a: ['b', 'c'] }` will be formatted as `a[]=b&a[]=c`  
 	* `repeat`: `{ a: ['b', 'c'] }` will be formatted as `a=b&a=c`  
@@ -63,7 +64,7 @@ Some notes about the possible fields:
 - **auth**: Used for Basic auth. Provide `username` and `password`.
 - **disableFollowRedirect**: By default, we'll follow redirects. You can set this to false to prevent this from happening
 - **skipSslCertificateValidation**: Used for calling HTTPS services without proper certificate
-- **returnFullResponse**: Instead of returning only the body, returns an object with more data in the following format: `{body: body, headers: object, statusCode: 200, statusMessage: 'OK', request: requestObject}`
+- **returnFullResponse**: Instead of returning only the body, returns an object with more data in the following format: `{body: body, headers: object, statusCode: 200, statusMessage: 'OK'}`
 - **encoding**: We usually detect the content type correctly but you can specify `arrayBuffer` to receive a Buffer you can read from and interact with.
 
 ## Deprecation of the previous helper
@@ -84,10 +85,8 @@ As mentioned above, the previous helper is deprecated and will be replaced in th
 
 New nodes should all use the new helper, and if you have built custom nodes we strongly suggest you migrate to the new helper. Here are the main considerations when migrating:
 
-- `qs` is now called `queryString`
 - Only `url` is accepted. Previously `uri` was also accepted
 - `encoding: null` now must be `encoding: arrayBuffer`
-- If using `json: true` you should now instead set the `accept: application/json` header
 - `rejectUnauthorized: false` is now `skipSslCertificateValidation: true`
 - Use `body` according to `content-type` headers to clarify what is being sent
 - `resolveWithFullResponse` is now `returnFullResponse` and has similar behavior


### PR DESCRIPTION
This PR is related to changes made on this branch: https://github.com/n8n-io/n8n/tree/versioned-nodes-updated

Highlights:

- Node versioning
- Deprecated the previous request lib
- Migration guide for people who built custom nodes
- Fallback to continue using the request library if needed