### PR TITLE
Update README.md

### DIFF
--- a/docs/nodes/nodes-library/core-nodes/ErrorTrigger/README.md
+++ b/docs/nodes/nodes-library/core-nodes/ErrorTrigger/README.md
@@ -11,6 +11,7 @@ The Error Trigger node triggers a workflow when another workflow has an error. O
 1. If a workflow is using the Error Trigger node, you don't have to activate the workflow.
 2. If you want to receive error messages for a workflow, make sure that you select the 'Error Workflow' in the ***Workflow Settings*** for the workflow.
 3. If a workflow is using the Error Trigger node, by default, the workflow will use itself as the Error Workflow.
+4. The Error Trigger node is designed to get triggered ONLY when the workflows execute automatically which means you will not be able to test this while running the workflows manually.
 :::
 
 ## Example Usage


### PR DESCRIPTION
I spent a good deal of time trying to understand why the error trigger node wasn't working and after a lot of poking around in the forums, found this message from Harshil that it works / triggers only when the workflows are executed automatically. Not sure why this critical information is missing in the documentation. I can see a lot of questions in the forums regarding the "error trigger node" not working.