### PR TITLE
Parse versioned nodes

### DIFF
--- a/docs/.vuepress/plugins/nodes.js
+++ b/docs/.vuepress/plugins/nodes.js
@@ -40,7 +40,14 @@ async function getNodes() {
 
 	const descriptions = {};
 	for (let name in nodes) {
-		const node = nodes[name].description;
+		let node;
+
+		if (nodes[name].nodeVersions) {
+			const maxVersion = Math.max(...Object.keys(nodes[name].nodeVersions));
+			node = nodes[name].nodeVersions[maxVersion].description;
+		} else {
+			node = nodes[name].description;
+		}
 
 		const iconData = {};
 		if (node.icon) {


### PR DESCRIPTION
Mattermost is the first and for now only versioned node - the plugin cannot parse it, which breaks the build.

To test the fix, uncomment [here](https://github.com/n8n-io/n8n-docs/commit/9aa3c868c6e6c6a271d3b245374b3f16fdb7612d).