### PR TITLE
Update desktop users

### DIFF
--- a/docs/getting-started/installation/updating.md
+++ b/docs/getting-started/installation/updating.md
@@ -78,4 +78,6 @@ docker-compose down
 docker-compose up -d
 ```
 
+## N8n Desktop
 
+If you've running n8n using the desktop distribution, updates are not currently available but should be coming soon. Keep an eye here for updates.


### PR DESCRIPTION
Currently customers are being sent to this page to update their desktop versions but there are no instructions on this page to let the customer know that an update is not currently avaiable. I've added a new header for N8n desktop along with a short blurb explaining that it is not updatable yet but should be soon.