### PR TITLE
Comment out OAuth cloud instruction for Zoom

### DIFF
--- a/docs/nodes/credentials/Zoom/README.md
+++ b/docs/nodes/credentials/Zoom/README.md
@@ -14,9 +14,9 @@ Create a [Zoom](https://zoom.us/) account.
 
 ## Using OAuth
 
-::: tip ⛅️ Note for n8n.cloud users
+<!-- ::: tip ⛅️ Note for n8n.cloud users
 You'll only need to enter the Credentials Name and click on the circle button in the OAuth section to connect your Zoom account to n8n.
-:::
+::: -->
 
 1. Visit the [Zoom App Marketplace](https://marketplace.zoom.us/) and select the 'Build App' option in the *Develop* dropdown on the top-right corner.
 2. Create a new OAuth app.


### PR DESCRIPTION
Managed OAuth is not implemented on Zoom yet. This PR comments out that step for n8n cloud.