### PR TITLE
Add doc to N8N_SMTP_SENDER parameter

### DIFF
--- a/docs/reference/user-management.md
+++ b/docs/reference/user-management.md
@@ -57,7 +57,7 @@ To set up SMTP with n8n, configure the SMTP environment variables for your n8n i
 | `N8N_SMTP_PORT` | number | _your_SMTP_server_port_ Default is `465`.| Optional |
 | `N8N_SMTP_USER` | string | _your_SMTP_username_ | Required |
 | `N8N_SMTP_PASS` | string | _your_SMTP_password_ | Required |
-| `N8N_SMTP_SENDER` | string | You can select the sender name from the sender addresses. Example: 'N8N <contact@n8n.com>' | Required |
+| `N8N_SMTP_SENDER` | string | You can select the sender name from the sender addresses. Example: `N8N _contact@n8n.com_'| Required |
 | `N8N_SMTP_SSL` | boolean | Whether to use SSL for SMTP (true) or not (false). Defaults to `true`. | Optional | 
 | `N8N_UM_EMAIL_TEMPLATES_INVITE` | string | Full path to your HTML email template. This overrides the default template for invite emails. | Optional |
 | `N8N_UM_EMAIL_TEMPLATES_PWRESET` | string | Full path to your HTML email template. This overrides the default template for password reset emails. | Optional |

--- a/docs/reference/user-management.md
+++ b/docs/reference/user-management.md
@@ -57,7 +57,7 @@ To set up SMTP with n8n, configure the SMTP environment variables for your n8n i
 | `N8N_SMTP_PORT` | number | _your_SMTP_server_port_ Default is `465`.| Optional |
 | `N8N_SMTP_USER` | string | _your_SMTP_username_ | Required |
 | `N8N_SMTP_PASS` | string | _your_SMTP_password_ | Required |
-| `N8N_SMTP_SENDER` | string | You can select the sender name from the sender addresses. Example: `N8N _contact@n8n.com_'| Required |
+| `N8N_SMTP_SENDER` | string | You can select the sender name from the sender addresses. Example: `N8N _contact@n8n.com_`| Required |
 | `N8N_SMTP_SSL` | boolean | Whether to use SSL for SMTP (true) or not (false). Defaults to `true`. | Optional | 
 | `N8N_UM_EMAIL_TEMPLATES_INVITE` | string | Full path to your HTML email template. This overrides the default template for invite emails. | Optional |
 | `N8N_UM_EMAIL_TEMPLATES_PWRESET` | string | Full path to your HTML email template. This overrides the default template for password reset emails. | Optional |

--- a/docs/reference/user-management.md
+++ b/docs/reference/user-management.md
@@ -57,7 +57,7 @@ To set up SMTP with n8n, configure the SMTP environment variables for your n8n i
 | `N8N_SMTP_PORT` | number | _your_SMTP_server_port_ Default is `465`.| Optional |
 | `N8N_SMTP_USER` | string | _your_SMTP_username_ | Required |
 | `N8N_SMTP_PASS` | string | _your_SMTP_password_ | Required |
-| `N8N_SMTP_SENDER` | string | _your_SMTP_sender_name_ | Required |
+| `N8N_SMTP_SENDER` | string | You can select the sender name from the sender addresses. Example: 'N8N <contact@n8n.com>' | Required |
 | `N8N_SMTP_SSL` | boolean | Whether to use SSL for SMTP (true) or not (false). Defaults to `true`. | Optional | 
 | `N8N_UM_EMAIL_TEMPLATES_INVITE` | string | Full path to your HTML email template. This overrides the default template for invite emails. | Optional |
 | `N8N_UM_EMAIL_TEMPLATES_PWRESET` | string | Full path to your HTML email template. This overrides the default template for password reset emails. | Optional |


### PR DESCRIPTION
It is important to use the example format as otherwise n8n fails to send email with some providers like Sendgrid