### PR TITLE
Add label to assign middleware to n8n route

### DIFF
--- a/docs/hosting/server-setups/docker-compose.md
+++ b/docs/hosting/server-setups/docker-compose.md
@@ -103,6 +103,7 @@ services:
       - traefik.http.middlewares.n8n.headers.SSLHost=${DOMAIN_NAME}
       - traefik.http.middlewares.n8n.headers.STSIncludeSubdomains=true
       - traefik.http.middlewares.n8n.headers.STSPreload=true
+      - traefik.http.routers.n8n.middlewares=n8n@docker
     environment:
       - N8N_BASIC_AUTH_ACTIVE=true
       - N8N_BASIC_AUTH_USER


### PR DESCRIPTION
Add label to assign middleware to n8n route. It's necessary to traefik apply this middleware with header configs to the n8n route.