### PR TITLE
Added warning for scopes to be added to the app in Hubspot

### DIFF
--- a/docs/integrations/builtin/credentials/hubspot.md
+++ b/docs/integrations/builtin/credentials/hubspot.md
@@ -27,8 +27,10 @@ Create a [HubSpot](https://www.hubspot.com/) account.
 6. Use the provided **Client ID** and the **Client secret** with your HubSpot OAuth2 API credentials in n8n.
 7. If you are using the [HubSpot Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.hubSpotTrigger/) node, copy the **App ID** along with the information in the previous step.
 8. Copy your OAuth Callback URL from the 'Create New Credentials' screen in n8n and paste in the **Redirect URL** section.
+
 !!! warning "Exact scope needed"
     If you grant access to more scopes than listed below, this might cause an issue with the authentication step. Make sure to only include what is listed below.
+	
 9. In the Scopes section, select the following scopes in the **Find a scope** search box:
     * Trigger node:
         * oauth

--- a/docs/integrations/builtin/credentials/hubspot.md
+++ b/docs/integrations/builtin/credentials/hubspot.md
@@ -28,8 +28,8 @@ Create a [HubSpot](https://www.hubspot.com/) account.
 7. If you are using the [HubSpot Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.hubSpotTrigger/) node, copy the **App ID** along with the information in the previous step.
 8. Copy your OAuth Callback URL from the 'Create New Credentials' screen in n8n and paste in the **Redirect URL** section.
 
-!!! note "Exact scope needed"
-    If you grant access to more or less scopes than listed below, this might cause an issue with the authentication step. Make sure to only include what is listed below.
+	!!! note "Exact scope needed"
+	    If you grant access to more or less scopes than listed below, this might cause an issue with the authentication step. Make sure to only include what is listed below.
 	
 9. In the Scopes section, select the following scopes in the **Find a scope** search box:
     * Trigger node:

--- a/docs/integrations/builtin/credentials/hubspot.md
+++ b/docs/integrations/builtin/credentials/hubspot.md
@@ -29,7 +29,7 @@ Create a [HubSpot](https://www.hubspot.com/) account.
 8. Copy your OAuth Callback URL from the 'Create New Credentials' screen in n8n and paste in the **Redirect URL** section.
 
 !!! warning "Exact scope needed"
-    If you grant access to more scopes than listed below, this might cause an issue with the authentication step. Make sure to only include what is listed below.
+    If you grant access to more or less scopes than listed below, this might cause an issue with the authentication step. Make sure to only include what is listed below.
 	
 9. In the Scopes section, select the following scopes in the **Find a scope** search box:
     * Trigger node:

--- a/docs/integrations/builtin/credentials/hubspot.md
+++ b/docs/integrations/builtin/credentials/hubspot.md
@@ -28,7 +28,7 @@ Create a [HubSpot](https://www.hubspot.com/) account.
 7. If you are using the [HubSpot Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.hubSpotTrigger/) node, copy the **App ID** along with the information in the previous step.
 8. Copy your OAuth Callback URL from the 'Create New Credentials' screen in n8n and paste in the **Redirect URL** section.
 
-!!! warning "Exact scope needed"
+!!! note "Exact scope needed"
     If you grant access to more or less scopes than listed below, this might cause an issue with the authentication step. Make sure to only include what is listed below.
 	
 9. In the Scopes section, select the following scopes in the **Find a scope** search box:

--- a/docs/integrations/builtin/credentials/hubspot.md
+++ b/docs/integrations/builtin/credentials/hubspot.md
@@ -27,6 +27,8 @@ Create a [HubSpot](https://www.hubspot.com/) account.
 6. Use the provided **Client ID** and the **Client secret** with your HubSpot OAuth2 API credentials in n8n.
 7. If you are using the [HubSpot Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.hubSpotTrigger/) node, copy the **App ID** along with the information in the previous step.
 8. Copy your OAuth Callback URL from the 'Create New Credentials' screen in n8n and paste in the **Redirect URL** section.
+!!! warning "Exact scope needed"
+    If you grant access to more scopes than listed below, this might cause an issue with the authentication step. Make sure to only include what is listed below.
 9. In the Scopes section, select the following scopes in the **Find a scope** search box:
     * Trigger node:
         * oauth
@@ -50,9 +52,9 @@ Create a [HubSpot](https://www.hubspot.com/) account.
         * crm.schemas.companies (read),
         * forms,
         * tickets,
-11. Click on the **Save** button to save your settings in HubSpot.
-12. Back in n8n, click on the circle button in the OAuth section to connect your HubSpot account to n8n.
-13. Click the **Save** button to save your credentials.
+10. Click on the **Save** button to save your settings in HubSpot.
+11. Back in n8n, click on the circle button in the OAuth section to connect your HubSpot account to n8n.
+12. Click the **Save** button to save your credentials.
 
 
 ## Using API key


### PR DESCRIPTION
If the scopes aren't exactly like those listed in the docs this can cause errors during authentication of the OAuth2 credentials.
I simply granted all, and got the error: 'Insufficient scopes were provided' 
Which makes no sense of course.