### PR TITLE
[bitly] fix bitly node text in example usage

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.bitly.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.bitly.md
@@ -29,6 +29,6 @@ The start node exists by default when you create a new workflow.
 
 ### 2. Bitly node
 
-1. First of all, you'll have to enter credentials for the Twilio node. You can find out how to do that [here](/integrations/builtin/credentials/bitly/).
+1. First of all, you'll have to enter credentials for the Bitly node. You can find out how to do that [here](/integrations/builtin/credentials/bitly/).
 2. Enter the URL in the *Long URL* field.
 3. Click on *Execute Node* to run the workflow.


### PR DESCRIPTION
ref - 
#948

A small fix. In the example usage of the `Bitly` node, It was mentioned to enter the credentials of the `Twilio` node, but instead, it should be the `Bitly` node.