### PR TITLE
Update quickstart for new expressions interface

### DIFF
--- a/docs/try-it-out/quickstart.md
+++ b/docs/try-it-out/quickstart.md
@@ -40,10 +40,10 @@ Add a third node to message each customer and tell them their description. The C
 2. Search for **Customer Messenger**. n8n shows a list of nodes that match the search.
 3. Select **Customer Messenger (n8n training)** to add the node to the canvas. n8n opens the node automatically.
 4. You're going to use [expressions](/code-examples/expressions/) to map in the **Customer ID** and create the **Message**:
-    1. Next to **Customer ID**, select **Parameter options** <span class="inline-image">![Parameter options icon](/_images/try-it-out/parameter-options.png)</span> > **Add Expression**. n8n opens the expressions editor for this field.
+    1. Next to **Customer ID**, select the **Expression** tab. n8n opens the expressions editor for this field.
     2. Select **Current Node** > **Input Data** > **JSON** > **customer_ID**. n8n adds the expression to the **Expression** editor, and displays a sample output.
     3. Close the expressions editor.
-    4. Next to **Message**, select **Parameter options** <span class="inline-image">![Parameter options icon](/_images/try-it-out/parameter-options.png)</span> > **Add Expression**. n8n opens the expressions editor for this field.
+    4. Next to **Message**, select the **Expression** tab. n8n opens the expressions editor for this field.
     5. Copy this expression into the editor:
         ```
         Hi {{$json.customer_name}},  Your description is {{$json.customer_description}}


### PR DESCRIPTION
There is no longer 'Parameter options', just a slider that says 'Fixed | Expression'.