### PR TITLE
Update example to the new code node

### DIFF
--- a/docs/code-examples/methods-variables-examples/get-workflow-static-data.md
+++ b/docs/code-examples/methods-variables-examples/get-workflow-static-data.md
@@ -19,9 +19,9 @@ Example:
 
 ```javascript
 // Get the global workflow static data
-const staticData = getWorkflowStaticData('global');
+const staticData = $getWorkflowStaticData('global');
 // Get the static data of the node
-const staticData = getWorkflowStaticData('node');
+const staticData = $getWorkflowStaticData('node');
 
 // Access its data
 const lastExecution = staticData.lastExecution;


### PR DESCRIPTION
The new code node does not seemp to support `getWorkflowStaticData(type)` anymore. It does support `$getWorkflowStaticData(type)`, however. We should reflect that in the example.