### PR TITLE
updated api playground documentation

### DIFF
--- a/docs/api/using-api-playground.md
+++ b/docs/api/using-api-playground.md
@@ -21,8 +21,22 @@ For n8n Cloud users, the API playground path contains your cloud instance URL:
 The API includes built-in documentation about credential formats. This is available using the `credentials` endpoint:
 
 ```shell
-/api/credentials/schema/{id}
+<your-cloud-instance>/api/v<version-number>/credentials/schema/{credentialTypeName}
 ```
+
+!!! note "How to find `credentialTypeName`"
+    To find the type, download your workflow and examine it (it's a JSON file). For a Google Drive node is `googleDriveOAuth2Api` the `{credentialTypeName}`:
+```json
+{
+    ...,
+    "credentials": {
+        "googleDriveOAuth2Api": {
+        "id": "9",
+        "name": "Google Drive"
+        }
+    }
+}
+``` 
 
 !!! warning "Real data"
     If you click **Authorize** and enter your API key in the API playground, you have access to your live data. This is useful for trying out requests. However, be aware you can change or delete real data.

--- a/docs/api/using-api-playground.md
+++ b/docs/api/using-api-playground.md
@@ -18,6 +18,9 @@ For n8n Cloud users, the API playground path contains your cloud instance URL:
 <your-cloud-instance>/api/v<version-number>/docs
 ```
 
+!!! warning "Real data"
+    If you click **Authorize** and enter your API key in the API playground, you have access to your live data. This is useful for trying out requests. However, be aware you can change or delete real data.
+
 The API includes built-in documentation about credential formats. This is available using the `credentials` endpoint:
 
 ```shell
@@ -37,6 +40,3 @@ The API includes built-in documentation about credential formats. This is availa
     }
 }
 ``` 
-
-!!! warning "Real data"
-    If you click **Authorize** and enter your API key in the API playground, you have access to your live data. This is useful for trying out requests. However, be aware you can change or delete real data.

--- a/docs/api/using-api-playground.md
+++ b/docs/api/using-api-playground.md
@@ -28,7 +28,7 @@ The API includes built-in documentation about credential formats. This is availa
 ```
 
 !!! note "How to find `credentialTypeName`"
-    To find the type, download your workflow and examine it (it's a JSON file). For a Google Drive node is `googleDriveOAuth2Api` the `{credentialTypeName}`:
+    To find the type, download your workflow as JSON and examine it. For example, for a Google Drive node the `{credentialTypeName}` is `googleDriveOAuth2Api` :
 ```json
 {
     ...,


### PR DESCRIPTION
As the following community thread shows, the documentation for the API playground was not that clear:
https://community.n8n.io/t/how-to-get-type-for-credentials-api/21795

So I fixed the wrong url for the playground and tried to explain the process for getting the `credentialTypeName`. 