### PR TITLE
Fixed Docker Compose Commands

### DIFF
--- a/docs/hosting/installation/docker.md
+++ b/docs/hosting/installation/docker.md
@@ -139,13 +139,13 @@ If you've running n8n using a Docker Compose file, follow the below mentioned st
 
 ```sh
 // Pull latest version
-docker compose pull
+docker-compose pull
 
 // Stop and remove older version
-docker compose down
+docker-compose down
 
 // Start the container
-docker compose up -d
+docker-compose up -d
 ```
 
 ## Further reading

--- a/docs/hosting/installation/server-setups/docker-compose.md
+++ b/docs/hosting/installation/server-setups/docker-compose.md
@@ -183,13 +183,13 @@ mkdir /root/n8n/
 n8n can now be started via:
 
 ```bash
-sudo docker compose up -d
+sudo docker-compose up -d
 ```
 
 To stop the container:
 
 ```bash
-sudo docker compose stop
+sudo docker-compose stop
 ```
 
 ### 9. Done


### PR DESCRIPTION
There is mistake in docker commands instead of docker-compose it was docker compose which is not not correct command.
Locations:
hosting/installation/docker/
hosting/installation/server-setups/docker-compose/
