### PR TITLE
Add page on isolating n8n

### DIFF
--- a/docs/hosting/isolation.md
+++ b/docs/hosting/isolation.md
@@ -1,8 +1,8 @@
 # Isolating n8n
 
-By default even a self-hosted n8n instance would send certain data to n8n.io/n8n.cloud servers. This allows n8n to provide users with notifcations on available updates or to allow access to workflow templates for example. However, in some enviroments it might be necessary to prevent n8n from communicating with these servers.
+By default, even a self-hosted n8n instance would send certain data to the n8n.io/n8n.cloud servers. This allows n8n to notify users of available updates or provide access to workflow templates, for example. However, in some environments it may be necessary to prevent n8n from communicating with these servers.
 
-Such a behaviour can be achieved by setting the below [environment variables](/hosting/environment-variables/):
+This can be achieved by setting the following [environment variables](/hosting/environment-variables/):
 
 ```
 - N8N_DIAGNOSTICS_ENABLED=false

--- a/docs/hosting/isolation.md
+++ b/docs/hosting/isolation.md
@@ -1,0 +1,14 @@
+# Isolating n8n
+
+By default even a self-hosted n8n instance would send certain data to n8n.io/n8n.cloud servers. This allows n8n to provide users with notifcations on available updates or to allow access to workflow templates for example. However, in some enviroments it might be necessary to prevent n8n from communicating with these servers.
+
+Such a behaviour can be achieved by setting the below [environment variables](/hosting/environment-variables/):
+
+```
+- N8N_DIAGNOSTICS_ENABLED=false
+- N8N_VERSION_NOTIFICATIONS_ENABLED=false
+- N8N_TEMPLATES_ENABLED=false
+- EXTERNAL_FRONTEND_HOOKS_URLS=
+- N8N_DIAGNOSTICS_CONFIG_FRONTEND=
+- N8N_DIAGNOSTICS_CONFIG_BACKEND=
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -505,6 +505,7 @@ nav:
     - Architecture:
       - hosting/architecture/index.md
       - Database structure: hosting/architecture/database-structure.md
+    - Isolation: hosting/isolation.md
   - API:
     - api/index.md
     - Authentication: api/authentication.md


### PR DESCRIPTION
Adds a page explaining how to isolate self-hosted n8n instances. This is one of our action items following the recent Azure networking problems affecting the n8n server connectivity.