### PR TITLE
Update docker compose install instructions docker compose v2

### DIFF
--- a/docs/hosting/installation/server-setups/docker-compose.md
+++ b/docs/hosting/installation/server-setups/docker-compose.md
@@ -29,7 +29,7 @@ su - ${USER}
 
 ### 3. Install Docker-Compose
 
-This can vary depending on the Linux distribution used. You can find detailed instructions [here in the Docker documentation](https://docs.docker.com/compose/).
+This can vary depending on the Linux distribution used. You can find detailed instructions in the [Docker documentation](https://docs.docker.com/compose/){:target=_blank .external-link}.
 
 The example below is for Ubuntu:
 

--- a/docs/hosting/installation/server-setups/docker-compose.md
+++ b/docs/hosting/installation/server-setups/docker-compose.md
@@ -4,24 +4,18 @@ If you have already installed Docker and Docker-Compose, then you can start with
 
 ### 1. Install Docker
 
-This can vary depending on the Linux distribution used. The below example is for Ubuntu:
+This can vary depending on the Linux distribution used. You can find detailed instructions [here in the Docker documentation](https://docs.docker.com/engine/install/). The below example is for Ubuntu:
 
 ```bash
-sudo apt update
-sudo apt install apt-transport-https ca-certificates curl software-properties-common -y
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo apt-get remove docker docker-engine docker.io containerd runc
+sudo apt-get update
+sudo apt-get install ca-certificates curl gnupg lsb-release
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-# Depending on Version:
-
-# Ubuntu 18.04:
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
-
-# Ubuntu 20.04
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"
-
-sudo apt update
-sudo apt upgrade -y
-sudo apt install docker-ce -y
+sudo apt-get update
+sudo apt-get install docker-ce docker-ce-cli containerd.io
 ```
 
 ### 2. Optional: Non-root user access
@@ -35,13 +29,12 @@ su - ${USER}
 
 ### 3. Install Docker-Compose
 
-This can vary depending on the Linux distribution used. Before proceeding check the latest version of Docker Compose v1 [on the repository's release page](https://github.com/docker/compose/releases) and replace the `1.29.2` below. Should you wish to use Docker Compose v2 instead you can find detailed instructions [here in the Docker documentation](https://docs.docker.com/compose/cli-command/).
+This can vary depending on the Linux distribution used. You can find detailed instructions [here in the Docker documentation](https://docs.docker.com/compose/).
 
 The example below is for Ubuntu:
 
 ```bash
-sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
+sudo apt-get install docker-compose-plugin
 ```
 
 ### 4. DNS setup

--- a/docs/hosting/installation/server-setups/docker-compose.md
+++ b/docs/hosting/installation/server-setups/docker-compose.md
@@ -4,7 +4,7 @@ If you have already installed Docker and Docker-Compose, then you can start with
 
 ### 1. Install Docker
 
-This can vary depending on the Linux distribution used. You can find detailed instructions [here in the Docker documentation](https://docs.docker.com/engine/install/). The below example is for Ubuntu:
+This can vary depending on the Linux distribution used. You can find detailed instructions in the [Docker documentation](https://docs.docker.com/engine/install/){:target=_blank .external-link}. The following example is for Ubuntu:
 
 ```bash
 sudo apt-get remove docker docker-engine docker.io containerd runc


### PR DESCRIPTION
Docker compose v1 is no longer actively supported and will be removed from desktop distributions starting June 23. From https://docs.docker.com/compose/:

> From the end of June 2023 Compose V1 won’t be supported anymore and will be removed from all Docker Desktop versions.

This PR removes installation instructions for docker compose v1 and replaces them with the installation instruction for docker compose v2 (the plugin). It also updates the general docker installation instructions to match the current approach from https://docs.docker.com/engine/install/ubuntu/.