### PR TITLE
update apt-get update for hetzner

### DIFF
--- a/docs/hosting/installation/server-setups/hetzner.md
+++ b/docs/hosting/installation/server-setups/hetzner.md
@@ -32,7 +32,8 @@ The rest of this guide requires you to log in to the server using a terminal wit
 The Hetzner Docker app image doesn't have Docker compose installed. Install it with the following commands:
 
 ```shell
-apt get update
+apt-get update
+apt-get upgrade
 apt install docker-compose-plugin
 ```
 


### PR DESCRIPTION
The default for Hetzner Cloud with Docker-CE is now Ubuntu 22.04 - Therefore the update command should be apt-get update

Also added apt-get upgrade.