### PR TITLE
Add note about community nodes not available on cloud

### DIFF
--- a/docs/integrations/community-nodes/index.md
+++ b/docs/integrations/community-nodes/index.md
@@ -8,3 +8,5 @@ n8n provides hundreds of built-in nodes. It also supports users [creating their 
 
 The community nodes repository allows users who create nodes to publish them to npm. These nodes are then available to install and use in your n8n instance.
 
+!!! note "Only available on self-hosted instances"
+    Community nodes are not available on n8n cloud and require [self-hosting](/hosting/) n8n.


### PR DESCRIPTION
We're getting support requests from folks missing community nodes on cloud and should clarify they aren't available