### PR TITLE
Update to mention smtp user and pass are optional

### DIFF
--- a/docs/hosting/user-management-self-hosted.md
+++ b/docs/hosting/user-management-self-hosted.md
@@ -51,8 +51,8 @@ To set up SMTP with n8n, configure the SMTP environment variables for your n8n i
 | `N8N_EMAIL_MODE` | string | smtp | Required |
 | `N8N_SMTP_HOST` | string | _your_SMTP_server_name_ | Required |
 | `N8N_SMTP_PORT` | number | _your_SMTP_server_port_ Default is `465`.| Optional |
-| `N8N_SMTP_USER` | string | _your_SMTP_username_ | Required |
-| `N8N_SMTP_PASS` | string | _your_SMTP_password_ | Required |
+| `N8N_SMTP_USER` | string | _your_SMTP_username_ | Optional |
+| `N8N_SMTP_PASS` | string | _your_SMTP_password_ | Optional |
 | `N8N_SMTP_SENDER` | string | Sender email address. You can optionally include the sender name. Example with name: _N8N `<contact@n8n.com>`_ | Required |
 | `N8N_SMTP_SSL` | boolean | Whether to use SSL for SMTP (true) or not (false). Defaults to `true`. | Optional | 
 | `N8N_UM_EMAIL_TEMPLATES_INVITE` | string | Full path to your HTML email template. This overrides the default template for invite emails. | Optional |


### PR DESCRIPTION
Changes the UM setup table to mark N8N_SMTP_USER and N8N_SMTP_PASS as optional rather than required. This will change once this is released: https://github.com/n8n-io/n8n/pull/3742 