### PR TITLE
Update docker.md

### DIFF
--- a/docs/hosting/installation/docker.md
+++ b/docs/hosting/installation/docker.md
@@ -172,12 +172,7 @@ More information about Docker setup can be found in the README file of the [Dock
 Start n8n with `--tunnel` by running:
 
 ```bash
-docker run -it --rm \
- --name n8n \
- -p 5678:5678 \
- -v ~/.n8n:/home/node/.n8n \
- n8nio/n8n \
- n8n start --tunnel
+docker run -it --rm --name n8n -p 5678:5678 -v ~/.n8n:/home/node/.n8n n8nio/n8n start --tunnel
 ```
 
 ## Next steps


### PR DESCRIPTION
The existing `docker run` command provided to start n8n with tunnel won't work anymore with n8n version 1 (or on Windows) as the `n8n` part of the command has to be committed.

This PR ensures the example command works with n8n version 1 and when using Windows while maintaining compatibility with Mac and Linux.