### PR TITLE
update data pruning documentation

### DIFF
--- a/docs/hosting/scaling/execution-data.md
+++ b/docs/hosting/scaling/execution-data.md
@@ -4,9 +4,7 @@ contentType: howto
 
 # Execution data
 
-
 Depending on your executions settings and volume, your n8n database can quickly grow in size and eventually run out of storage.
-
 
 To avoid this, n8n recommends that you don't save unnecessary data, and enable pruning of old executions data.
 
@@ -15,7 +13,7 @@ To do this, configure the corresponding [environment variables](/hosting/environ
 ## Reduce saved data
 
 !!! note "Configuration at workflow level"
-    You can also configure these settings on an individual workflow basis using the [workflow settings](/workflows/workflows/#workflow-settings).
+You can also configure these settings on an individual workflow basis using the [workflow settings](/workflows/workflows/#workflow-settings).
 
 You can select which executions data n8n saves. For example, you can save only executions that result in an `Error`.
 
@@ -47,7 +45,6 @@ docker run -it --rm \
  docker.n8n.io/n8nio/n8n
 ```
 
-
 ```yaml
 # Docker Compose
 n8n:
@@ -58,13 +55,11 @@ n8n:
       - EXECUTIONS_DATA_SAVE_MANUAL_EXECUTIONS=false
 ```
 
-
 ## Enable data pruning
 
-You can enable data pruning to automatically delete executions after a given time period. If you don't set `EXECUTIONS_DATA_MAX_AGE`, 336 hours (14 days) is the default.
+You can enable data pruning to automatically delete finished executions after a given time period. If you don't set `EXECUTIONS_DATA_MAX_AGE`, 336 hours (14 days) is the default.
 
-You can choose to prune executions data before the time set in `EXECUTIONS_DATA_MAX_AGE`, using `EXECUTIONS_DATA_PRUNE_MAX_COUNT`. This sets a maximum number of executions to store in the database. Once you reach the limit, n8n starts to delete the oldest execution records. This can help with database performance issues, especially if you use SQLite.
-
+You can choose to prune finished executions data before the time set in `EXECUTIONS_DATA_MAX_AGE`, using `EXECUTIONS_DATA_PRUNE_MAX_COUNT`. This sets a maximum number of executions to store in the database. Once you reach the limit, n8n starts to delete the oldest execution records. This can help with database performance issues, especially if you use SQLite. This number is however not exact, and in some cases there might be more executions left in the database.
 
 ```sh
 # npm
@@ -97,6 +92,5 @@ n8n:
 	  	- EXECUTIONS_DATA_PRUNE_MAX_COUNT=50000
 ```
 
-
 !!! note "SQLite"
-    If you run n8n using the default SQLite database, the disk-space of any pruned data isn't automatically freed up but rather reused for future executions data. To free up this space configure the `DB_SQLITE_VACUUM_ON_STARTUP` [environment variable](/hosting/environment-variables/environment-variables/#sqlite) or manually run the [VACUUM](https://www.sqlite.org/lang_vacuum.html) operation.
+If you run n8n using the default SQLite database, the disk-space of any pruned data isn't automatically freed up but rather reused for future executions data. To free up this space configure the `DB_SQLITE_VACUUM_ON_STARTUP` [environment variable](/hosting/environment-variables/environment-variables/#sqlite) or manually run the [VACUUM](https://www.sqlite.org/lang_vacuum.html) operation.

--- a/docs/hosting/scaling/execution-data.md
+++ b/docs/hosting/scaling/execution-data.md
@@ -59,7 +59,7 @@ n8n:
 
 You can enable data pruning to automatically delete finished executions after a given time period. If you don't set `EXECUTIONS_DATA_MAX_AGE`, 336 hours (14 days) is the default.
 
-You can choose to prune finished executions data before the time set in `EXECUTIONS_DATA_MAX_AGE`, using `EXECUTIONS_DATA_PRUNE_MAX_COUNT`. This sets a maximum number of executions to store in the database. Once you reach the limit, n8n starts to delete the oldest execution records. This can help with database performance issues, especially if you use SQLite. This number is however not exact. Old executions that have not finished yet don't get deleted, even if they otherwise would be subject to deletion.
+You can choose to prune finished executions data before the time set in `EXECUTIONS_DATA_MAX_AGE`, using `EXECUTIONS_DATA_PRUNE_MAX_COUNT`. This sets a maximum number of executions to store in the database. Once you reach the limit, n8n starts to delete the oldest execution records. This can help with database performance issues, especially if you use SQLite. The database size can still exceed the limit you set: old executions that haven't finished running don't get deleted, even if they would otherwise be subject to deletion.
 
 ```sh
 # npm

--- a/docs/hosting/scaling/execution-data.md
+++ b/docs/hosting/scaling/execution-data.md
@@ -13,7 +13,7 @@ To do this, configure the corresponding [environment variables](/hosting/environ
 ## Reduce saved data
 
 !!! note "Configuration at workflow level"
-You can also configure these settings on an individual workflow basis using the [workflow settings](/workflows/workflows/#workflow-settings).
+	You can also configure these settings on an individual workflow basis using the [workflow settings](/workflows/workflows/#workflow-settings).
 
 You can select which executions data n8n saves. For example, you can save only executions that result in an `Error`.
 
@@ -93,4 +93,4 @@ n8n:
 ```
 
 !!! note "SQLite"
-If you run n8n using the default SQLite database, the disk-space of any pruned data isn't automatically freed up but rather reused for future executions data. To free up this space configure the `DB_SQLITE_VACUUM_ON_STARTUP` [environment variable](/hosting/environment-variables/environment-variables/#sqlite) or manually run the [VACUUM](https://www.sqlite.org/lang_vacuum.html) operation.
+	If you run n8n using the default SQLite database, the disk space of any pruned data isn't automatically freed up but rather reused for future executions data. To free up this space configure the `DB_SQLITE_VACUUM_ON_STARTUP` [environment variable](/hosting/environment-variables/environment-variables/#sqlite){:target=_blank .external-link} or manually run the [VACUUM](https://www.sqlite.org/lang_vacuum.html){:target=_blank .external-link} operation.

--- a/docs/hosting/scaling/execution-data.md
+++ b/docs/hosting/scaling/execution-data.md
@@ -93,4 +93,4 @@ n8n:
 ```
 
 !!! note "SQLite"
-	If you run n8n using the default SQLite database, the disk space of any pruned data isn't automatically freed up but rather reused for future executions data. To free up this space configure the `DB_SQLITE_VACUUM_ON_STARTUP` [environment variable](/hosting/environment-variables/environment-variables/#sqlite){:target=_blank .external-link} or manually run the [VACUUM](https://www.sqlite.org/lang_vacuum.html){:target=_blank .external-link} operation.
+	If you run n8n using the default SQLite database, the disk space of any pruned data isn't automatically freed up but rather reused for future executions data. To free up this space configure the `DB_SQLITE_VACUUM_ON_STARTUP` [environment variable](/hosting/environment-variables/environment-variables/#sqlite) or manually run the [VACUUM](https://www.sqlite.org/lang_vacuum.html){:target=_blank .external-link} operation.

--- a/docs/hosting/scaling/execution-data.md
+++ b/docs/hosting/scaling/execution-data.md
@@ -59,7 +59,7 @@ n8n:
 
 You can enable data pruning to automatically delete finished executions after a given time period. If you don't set `EXECUTIONS_DATA_MAX_AGE`, 336 hours (14 days) is the default.
 
-You can choose to prune finished executions data before the time set in `EXECUTIONS_DATA_MAX_AGE`, using `EXECUTIONS_DATA_PRUNE_MAX_COUNT`. This sets a maximum number of executions to store in the database. Once you reach the limit, n8n starts to delete the oldest execution records. This can help with database performance issues, especially if you use SQLite. This number is however not exact, and in some cases there might be more executions left in the database.
+You can choose to prune finished executions data before the time set in `EXECUTIONS_DATA_MAX_AGE`, using `EXECUTIONS_DATA_PRUNE_MAX_COUNT`. This sets a maximum number of executions to store in the database. Once you reach the limit, n8n starts to delete the oldest execution records. This can help with database performance issues, especially if you use SQLite. This number is however not exact. Old executions that have not finished yet don't get deleted, even if they otherwise would be subject to deletion.
 
 ```sh
 # npm


### PR DESCRIPTION
Only executions that are in an end-state are pruned and the max count is not always exact.

Related PR: https://github.com/n8n-io/n8n/pull/7333