### PR TITLE
Change custom plugin directory from /nodes to /custom

### DIFF
--- a/_snippets/integrations/creating-nodes/testing.md
+++ b/_snippets/integrations/creating-nodes/testing.md
@@ -18,7 +18,9 @@ You can test your node as you build it by running it in a local n8n instance.
   ```
 
     !!! note "Check your directory"
-        Make sure you run `npm link <node-name>` in the nodes directory within your n8n installation. This is probably something like `~/.n8n/custom/`
+        Make sure you run `npm link <node-name>` in the nodes directory within your n8n installation. This can be: 
+        * `~/.n8n/custom/`
+        * `~/.n8n/<your-custom-name>`: if your n8n installation set a different name using `N8N_CUSTOM_EXTENSIONS`.
  
 4. Start n8n:
   ```

--- a/_snippets/integrations/creating-nodes/testing.md
+++ b/_snippets/integrations/creating-nodes/testing.md
@@ -20,8 +20,8 @@ You can test your node as you build it by running it in a local n8n instance.
     !!! note "Check your directory"
         Make sure you run `npm link <node-name>` in the nodes directory within your n8n installation. This can be: 
 		
-            * `~/.n8n/custom/`
-            * `~/.n8n/<your-custom-name>`: if your n8n installation set a different name using `N8N_CUSTOM_EXTENSIONS`.
+        * `~/.n8n/custom/`
+        * `~/.n8n/<your-custom-name>`: if your n8n installation set a different name using `N8N_CUSTOM_EXTENSIONS`.
  
 4. Start n8n:
   ```

--- a/_snippets/integrations/creating-nodes/testing.md
+++ b/_snippets/integrations/creating-nodes/testing.md
@@ -19,6 +19,7 @@ You can test your node as you build it by running it in a local n8n instance.
 
     !!! note "Check your directory"
         Make sure you run `npm link <node-name>` in the nodes directory within your n8n installation. This can be: 
+		
             * `~/.n8n/custom/`
             * `~/.n8n/<your-custom-name>`: if your n8n installation set a different name using `N8N_CUSTOM_EXTENSIONS`.
  

--- a/_snippets/integrations/creating-nodes/testing.md
+++ b/_snippets/integrations/creating-nodes/testing.md
@@ -18,8 +18,8 @@ You can test your node as you build it by running it in a local n8n instance.
   ```
 
     !!! note "Check your directory"
-        Make sure you run `npm link <node-name>` in the nodes directory within your n8n installation. This is probably something like `~/.n8n/nodes/`
-    
+        Make sure you run `npm link <node-name>` in the nodes directory within your n8n installation. This is probably something like `~/.n8n/custom/`
+ 
 4. Start n8n:
   ```
   n8n start
@@ -28,3 +28,15 @@ You can test your node as you build it by running it in a local n8n instance.
 
     !!! note "Node names"
         Make sure you search using the node name, not the package name. For example, if your npm package name is `n8n-nodes-weather-nodes`, and the package contains nodes named `rain`, `sun`, `snow`, you should search for `rain`, not `weather-nodes`. 
+
+### Troubleshooting
+
+- There is no `custom` directory in `~/.n8n` local installation.
+
+You have to create `custom` directory manually and run `npm init`
+```shell
+# In ~/.n8n directory run
+mkdir custom 
+cd custom 
+npm init
+```

--- a/_snippets/integrations/creating-nodes/testing.md
+++ b/_snippets/integrations/creating-nodes/testing.md
@@ -19,8 +19,8 @@ You can test your node as you build it by running it in a local n8n instance.
 
     !!! note "Check your directory"
         Make sure you run `npm link <node-name>` in the nodes directory within your n8n installation. This can be: 
-        * `~/.n8n/custom/`
-        * `~/.n8n/<your-custom-name>`: if your n8n installation set a different name using `N8N_CUSTOM_EXTENSIONS`.
+            * `~/.n8n/custom/`
+            * `~/.n8n/<your-custom-name>`: if your n8n installation set a different name using `N8N_CUSTOM_EXTENSIONS`.
  
 4. Start n8n:
   ```


### PR DESCRIPTION
Hi! 👋 

Me and my colleges had issues with tutorial which was saying that we need to have /nodes directory inside of our .n8n installation and it was not working.

We had to create `custom` directory instead so I decided that it would be great if I will update docs to make it easier for new users to go through this tutorial.