### PR TITLE
feat: add N8N_GRACEFUL_SHUTDOWN_TIMEOUT & deprecate QUEUE_WORKER_TIMEOUT

### DIFF
--- a/docs/hosting/environment-variables/environment-variables.md
+++ b/docs/hosting/environment-variables/environment-variables.md
@@ -81,7 +81,7 @@ Enabling overwrites for credentials allows you to set default values for credent
 | `N8N_PUBLIC_API_SWAGGERUI_DISABLED` | Boolean | `false` | Whether the Swagger UI (API playground) is disabled (true) or not (false). |
 | `N8N_PUBLIC_API_DISABLED` | Boolean | `false` | Whether to disable the public API (false) or not (true). |
 | `N8N_PUBLIC_API_ENDPOINT` | String | `api` | Path for the public API endpoints. |
-
+| `N8N_GRACEFUL_SHUTDOWN_TIMEOUT` | Number | `30` | How long should n8n process wait (in seconds) for components to shut down before exiting the process. |
 
 ## Binary data
 
@@ -229,7 +229,7 @@ Refer to [External storage](/hosting/external-storage/) for more information on 
 | `QUEUE_BULL_REDIS_CLUSTER_NODES` | String | - | Expects a comma-separated list of Redis Cluster nodes in the format `host:port`, for the Redis client to initially connect to. If running in queue mode (`EXECUTIONS_MODE = queue`), setting this variable will create a Redis Cluster client instead of a Redis client, and n8n will ignore `QUEUE_BULL_REDIS_HOST` and `QUEUE_BULL_REDIS_PORT`. |
 | `QUEUE_BULL_REDIS_TLS` | Boolean | `false` | Enable TLS on Redis connections. |
 | `QUEUE_RECOVERY_INTERVAL` | Number | `60` | Interval (in seconds) for active polling to the queue to recover from Redis crashes. `0` disables recovery. May increase Redis traffic significantly. |
-| `QUEUE_WORKER_TIMEOUT` | Number | `30` | How long should n8n wait (seconds) for running executions before exiting worker process on shutdown. |
+| `QUEUE_WORKER_TIMEOUT` (**deprecated**) | Number | `30` | **Deprecated** Use N8N_GRACEFUL_SHUTDOWN_TIMEOUT instead.<br/><br/>How long should n8n wait (seconds) for running executions before exiting worker process on shutdown. |
 | `QUEUE_HEALTH_CHECK_ACTIVE` | Boolean | `false` | Whether to enable health checks (true) or disable (false). |
 | `QUEUE_HEALTH_CHECK_PORT` | Number | - | The port to serve health checks on. |
 | `QUEUE_WORKER_LOCK_DURATION` | Number | `30000` | How long (in ms) is the lease period for a worker to work on a message. |

--- a/docs/hosting/environment-variables/environment-variables.md
+++ b/docs/hosting/environment-variables/environment-variables.md
@@ -229,7 +229,7 @@ Refer to [External storage](/hosting/external-storage/) for more information on 
 | `QUEUE_BULL_REDIS_CLUSTER_NODES` | String | - | Expects a comma-separated list of Redis Cluster nodes in the format `host:port`, for the Redis client to initially connect to. If running in queue mode (`EXECUTIONS_MODE = queue`), setting this variable will create a Redis Cluster client instead of a Redis client, and n8n will ignore `QUEUE_BULL_REDIS_HOST` and `QUEUE_BULL_REDIS_PORT`. |
 | `QUEUE_BULL_REDIS_TLS` | Boolean | `false` | Enable TLS on Redis connections. |
 | `QUEUE_RECOVERY_INTERVAL` | Number | `60` | Interval (in seconds) for active polling to the queue to recover from Redis crashes. `0` disables recovery. May increase Redis traffic significantly. |
-| `QUEUE_WORKER_TIMEOUT` (**deprecated**) | Number | `30` | **Deprecated** Use N8N_GRACEFUL_SHUTDOWN_TIMEOUT instead.<br/><br/>How long should n8n wait (seconds) for running executions before exiting worker process on shutdown. |
+| `QUEUE_WORKER_TIMEOUT` (**deprecated**) | Number | `30` | **Deprecated** Use `N8N_GRACEFUL_SHUTDOWN_TIMEOUT` instead.<br/><br/>How long should n8n wait (seconds) for running executions before exiting worker process on shutdown. |
 | `QUEUE_HEALTH_CHECK_ACTIVE` | Boolean | `false` | Whether to enable health checks (true) or disable (false). |
 | `QUEUE_HEALTH_CHECK_PORT` | Number | - | The port to serve health checks on. |
 | `QUEUE_WORKER_LOCK_DURATION` | Number | `30000` | How long (in ms) is the lease period for a worker to work on a message. |

--- a/docs/hosting/environment-variables/environment-variables.md
+++ b/docs/hosting/environment-variables/environment-variables.md
@@ -81,7 +81,7 @@ Enabling overwrites for credentials allows you to set default values for credent
 | `N8N_PUBLIC_API_SWAGGERUI_DISABLED` | Boolean | `false` | Whether the Swagger UI (API playground) is disabled (true) or not (false). |
 | `N8N_PUBLIC_API_DISABLED` | Boolean | `false` | Whether to disable the public API (false) or not (true). |
 | `N8N_PUBLIC_API_ENDPOINT` | String | `api` | Path for the public API endpoints. |
-| `N8N_GRACEFUL_SHUTDOWN_TIMEOUT` | Number | `30` | How long should n8n process wait (in seconds) for components to shut down before exiting the process. |
+| `N8N_GRACEFUL_SHUTDOWN_TIMEOUT` | Number | `30` | How long should the n8n process wait (in seconds) for components to shut down before exiting the process. |
 
 ## Binary data
 


### PR DESCRIPTION
Deprecate `QUEUE_WORKER_TIMEOUT` env variable in favour of `N8N_GRACEFUL_SHUTDOWN_TIMEOUT`.

Related PR: https://github.com/n8n-io/n8n/pull/8068