### PR TITLE
docs: Qdrant vector store documentation

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreqdrant.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreqdrant.md
@@ -1,0 +1,49 @@
+---
+title: Qdrant Vector Store
+description: Documentation for the Qdrant node in n8n, a workflow automation platform. Includes details of operations and configuration, and links to examples and credentials information.
+---
+
+# Qdrant Vector Store
+
+Use the Qdrant node to interact with your Qdrant collection as a vector store. You can insert documents into a vector database, get documents from a vector database, and retrieve documents to provide them to a retriever connected to a chain.
+
+On this page, you'll find the node parameters for the Qdrant node, and links to more resources.
+
+/// note | Credentials
+You can find authentication information for this node [here](/integrations/builtin/credentials/qdrant/).
+///
+
+/// note | Examples and templates
+For usage examples and templates to help you get started, refer to n8n's [Qdrant Vector Store integrations](https://n8n.io/integrations/qdrant-vector-store/){:target=_blank .external-link} page.
+///
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
+	
+## Node parameters
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/vector-store-mode.md"
+
+### Parameters for **Get Many**
+
+* Qdrant collection name
+* Prompt: search query.
+* Limit: how many results to retrieve from the vector store. For example, set this to `10` to get the ten best results.
+
+### Parameters for **Insert Documents**
+
+* Qdrant collection name
+* Qdrant collection creation configuration - Optional
+
+### Parameters for **Retrieve Documents (For Agent/Chain)**
+
+* Qdrant collection name
+
+### Metadata Filter
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-root-nodes/vector-store-metadata-filter.md"
+
+## Related resources
+
+Refer to [LangChain's Qdrant documentation](https://js.langchain.com/docs/integrations/vectorstores/qdrant){:target=_blank .external-link} for more information about the service.
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreqdrant.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreqdrant.md
@@ -23,18 +23,18 @@ For usage examples and templates to help you get started, refer to n8n's [Qdrant
 
 --8<-- "_snippets/integrations/builtin/cluster-nodes/vector-store-mode.md"
 
-### Parameters for **Get Many**
+### Parameters for Get Many
 
 * Qdrant collection name
 * Prompt: search query.
 * Limit: how many results to retrieve from the vector store. For example, set this to `10` to get the ten best results.
 
-### Parameters for **Insert Documents**
+### Parameters for Insert Documents
 
 * Qdrant collection name
 * Qdrant collection creation configuration - Optional
 
-### Parameters for **Retrieve Documents (For Agent/Chain)**
+### Parameters for Retrieve Documents (For Agent/Chain)
 
 * Qdrant collection name
 

--- a/docs/integrations/builtin/credentials/qdrant.md
+++ b/docs/integrations/builtin/credentials/qdrant.md
@@ -1,0 +1,23 @@
+---
+title: Qdrant credentials
+description: Documentation for the Qdrant credentials. Use these credentials to authenticate Qdrant in n8n, a workflow automation platform.
+---
+
+# Qdrant credentials
+
+You can use these credentials to authenticate the following nodes:
+
+* [Qdrant Vector Store](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreqdrant/)
+
+
+## Prerequisites
+
+You need an API key and Qdrant cluster URL to establish a connection.
+
+Refer to [Qdrant's authentication docs](https://qdrant.tech/documentation/cloud/authentication/#authentication) to know how to get these.
+
+## Related resources
+
+Refer to [Qdrant's documentation](https://qdrant.tech/documentation/){:target=_blank .external-link}
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"

--- a/docs/integrations/builtin/credentials/qdrant.md
+++ b/docs/integrations/builtin/credentials/qdrant.md
@@ -14,7 +14,7 @@ You can use these credentials to authenticate the following nodes:
 
 You need an API key and Qdrant cluster URL to establish a connection.
 
-Refer to [Qdrant's authentication docs](https://qdrant.tech/documentation/cloud/authentication/#authentication) to know how to get these.
+Refer to [Qdrant's authentication docs](https://qdrant.tech/documentation/cloud/authentication/#authentication){:target=_blank .external-link} for guidance on getting your key and URL.
 
 ## Related resources
 

--- a/docs/langchain/langchain-n8n.md
+++ b/docs/langchain/langchain-n8n.md
@@ -54,6 +54,7 @@ Vector stores store embedded data, and perform vector searches on it.
 
 * [In Memory Vector Store](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreinmemory/)
 * [Pinecone Vector Store](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepinecone/)
+* [Qdrant Vector Store](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreqdrant/)
 * [Supabase Vector Store](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoresupabase/)
 * [Zep Vector Store](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorezep/)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -668,6 +668,7 @@ nav:
           - integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.openaiassistant.md
           - integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreinmemory.md
           - integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepinecone.md
+          - integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreqdrant.md
           - integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoresupabase.md
           - integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorezep.md
         - Sub-nodes:
@@ -901,6 +902,7 @@ nav:
         - integrations/builtin/credentials/pushcut.md
         - integrations/builtin/credentials/pushover.md
         - integrations/builtin/credentials/qradar.md
+        - integrations/builtin/credentials/qdrant.md
         - integrations/builtin/credentials/qualys.md
         - integrations/builtin/credentials/questdb.md
         - integrations/builtin/credentials/quickbase.md

--- a/styles/Vocab/default/accept.txt
+++ b/styles/Vocab/default/accept.txt
@@ -48,6 +48,7 @@ Pluralsight
 Postbin
 Postgres
 PostHog
+Qdrant
 Realtime
 Serverless
 serverless


### PR DESCRIPTION
This PR adds documentation for the new [Qdrant](https://qdrant.tech/) vectorstore. 

Implementation PR: https://github.com/n8n-io/n8n/pull/8080