### PR TITLE
Mark Compatibility with Service Account in BigQuery as supported

### DIFF
--- a/docs/integrations/builtin/credentials/google/index.md
+++ b/docs/integrations/builtin/credentials/google/index.md
@@ -29,7 +29,7 @@ Once configured, you can use your credentials to authenticate the following node
 	| [Google Ads](/integrations/builtin/app-nodes/n8n-nodes-base.googleads/) | :white_check_mark: | :x: |
 	| [Gmail](/integrations/builtin/app-nodes/n8n-nodes-base.gmail/) | :white_check_mark: | :white_check_mark: |
 	| [Google Analytics](/integrations/builtin/app-nodes/n8n-nodes-base.googleanalytics/) | :white_check_mark: | :x: |
-	| [Google BigQuery](/integrations/builtin/app-nodes/n8n-nodes-base.googlebigquery/) | :white_check_mark: | :x: |
+	| [Google BigQuery](/integrations/builtin/app-nodes/n8n-nodes-base.googlebigquery/) | :white_check_mark: | :white_check_mark: |
 	| [Google Books](/integrations/builtin/app-nodes/n8n-nodes-base.googlebooks/) | :white_check_mark: | :white_check_mark: |
 	| [Google Calendar](/integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/) | :white_check_mark: | :x: |
 	| [Google Chat](/integrations/builtin/app-nodes/n8n-nodes-base.googlechat/) | :x: | :white_check_mark: |


### PR DESCRIPTION
This PR updates the documentation to mark the Service Account authentication method as supported for the Google BigQuery node.

I have personally been using the Service Account method for authentication with the BigQuery node and have found it to be fully functional and reliable, without encountering any issues.

For further reference, please see [the relevant section of the codebase](https://github.com/n8n-io/n8n/blob/f50fc8443e3359b0a3b0ca991b4be878aa52e606/packages/nodes-base/nodes/Google/BigQuery/v2/transport/index.ts#L21-L25) where the Service Account authentication method is implemented as a viable option.