### PR TITLE
add documentation for new environment variables that allow configuring the session duration and refresh threshold

### DIFF
--- a/docs/hosting/environment-variables/environment-variables.md
+++ b/docs/hosting/environment-variables/environment-variables.md
@@ -111,8 +111,8 @@ Refer to [User management](/hosting/user-management-self-hosted/) for more infor
 | `N8N_UM_EMAIL_TEMPLATES_INVITE` | String | - | Full path to your HTML email template. This overrides the default template for invite emails. |
 | `N8N_UM_EMAIL_TEMPLATES_PWRESET` | String | - | Full path to your HTML email template. This overrides the default template for password reset emails. |
 | `N8N_USER_MANAGEMENT_JWT_SECRET` | String | - | Set a specific JWT secret. By default, n8n generates one on start. |
-| `N8N_USER_MANAGEMENT_JWT_DURATION_HOURS` | Number | 168 | Set a specific expiration date for the JWTs in hours. |
-| `N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS` | Number | 0 | How many hours before the JWT expires to automatically refresh it. 0 means 25% of `N8N_USER_MANAGEMENT_JWT_DURATION_HOURS`. -1 means it will never refresh, which forces users to login again after the defined period in `N8N_USER_MANAGEMENT_JWT_DURATION_HOURS`. |
+| `N8N_USER_MANAGEMENT_JWT_DURATION_HOURS` | Number | 168 | Set an expiration date for the JWTs in hours. |
+| `N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS` | Number | 0 | How many hours before the JWT expires to automatically refresh it. 0 means 25% of `N8N_USER_MANAGEMENT_JWT_DURATION_HOURS`. -1 means it will never refresh, which forces users to log in again after the period defined in `N8N_USER_MANAGEMENT_JWT_DURATION_HOURS`. |
 | `N8N_MFA_ENABLED` | Boolean | `true` | Whether to enable two-factor authentication (true) or disable (false). n8n ignores this if existing users have 2FA enabled. |
 
 

--- a/docs/hosting/environment-variables/environment-variables.md
+++ b/docs/hosting/environment-variables/environment-variables.md
@@ -111,6 +111,8 @@ Refer to [User management](/hosting/user-management-self-hosted/) for more infor
 | `N8N_UM_EMAIL_TEMPLATES_INVITE` | String | - | Full path to your HTML email template. This overrides the default template for invite emails. |
 | `N8N_UM_EMAIL_TEMPLATES_PWRESET` | String | - | Full path to your HTML email template. This overrides the default template for password reset emails. |
 | `N8N_USER_MANAGEMENT_JWT_SECRET` | String | - | Set a specific JWT secret. By default, n8n generates one on start. |
+| `N8N_USER_MANAGEMENT_JWT_DURATION_HOURS` | Number | 168 | Set a specific expiration date for the JWTs in hours. |
+| `N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS` | Number | 0 | How many hours before the JWT expires to automatically refresh it. 0 means 25% of `N8N_USER_MANAGEMENT_JWT_DURATION_HOURS`. -1 means it will never refresh, which forces users to login again after the defined period in `N8N_USER_MANAGEMENT_JWT_DURATION_HOURS`. |
 | `N8N_MFA_ENABLED` | Boolean | `true` | Whether to enable two-factor authentication (true) or disable (false). n8n ignores this if existing users have 2FA enabled. |
 
 


### PR DESCRIPTION
This documents the new environment variables that allow configuring the session duration and renewal.
They are added in this PR: https://github.com/n8n-io/n8n/pull/8342

Tickets:
https://linear.app/n8n/issue/PAY-1182/custom-session-timeout-configuration
https://linear.app/n8n/issue/DOC-734/add-custom-session-timeout-setting-to-environment-variables-page
