### PR TITLE
remove section about `n8n --help` showing all possible commands

### DIFF
--- a/docs/hosting/cli-commands.md
+++ b/docs/hosting/cli-commands.md
@@ -17,14 +17,6 @@ You can use CLI commands with self-hosted n8n. Depending on how you choose to in
     docker exec -u node -it <n8n-container-name> <n8n-cli-command>
     ```
 
-## View the CLI help
-
-You can see a list of available commands and descriptions in your CLI:
-
-```bash
-n8n --help
-```
-
 ## Start a workflow
 
 You can start workflows directly using the CLI.


### PR DESCRIPTION
`n8n --help` will instead link to the online docs for the CLI

See:
https://linear.app/n8n/issue/PAY-195/ensure-n8n-help-gives-useful-and-accurate-info
https://github.com/n8n-io/n8n/pull/8440
