### PR TITLE
Account for new login logic

### DIFF
--- a/docs/manage-cloud/update-cloud-version.md
+++ b/docs/manage-cloud/update-cloud-version.md
@@ -7,8 +7,7 @@ contentType: howto
 
 n8n recommends regularly updating your Cloud version. Check the [Release notes](/release-notes/) to learn more about changes.
 
-1. [Log in to n8n](https://app.n8n.cloud/login){:target=_blank .external-link}
-1. Select **Admin Dashboard**. n8n opens the dashboard.
+1. [Log in to the n8n Cloud dashboard](https://app.n8n.cloud/manage){:target=_blank .external-link}
 1. On your dashboard, select **Manage**.
 1. Use the **n8n version** dropdown to select your preferred release version: 
 	* Latest Stable: recommended for most users.


### PR DESCRIPTION
This PR accounts for the new login logic on n8n cloud. The old link pointed to https://app.n8n.cloud/login which would automatically log out users from the n8n cloud dashboard when opened. The new link leads to https://app.n8n.cloud/manage which either opens the dashboard immediately (if there is an active login session) or asks the user to log in through their n8n cloud instance (if there is no active login session).