### PR TITLE
Mention email change as an alternative to ownership transfer

### DIFF
--- a/docs/user-management/account-types.md
+++ b/docs/user-management/account-types.md
@@ -11,7 +11,7 @@ There are three account types, owner, admin, and member. The account type affect
 To use admin accounts, you need a pro or enterprise plan.
 ///
 
-* Owner: this is the account that set up user management. There's one owner account for each n8n instance. You can't transfer ownership.
+* Owner: this is the account that set up user management. There's one owner account for each n8n instance. You can't transfer ownership to another user, but you can change the email of the owner account instead.
   The owner can:
     * Add and remove users, including admin users
 	* Upgrade members to admin, and downgrade admins to member
@@ -27,6 +27,7 @@ To use admin accounts, you need a pro or enterprise plan.
   Members can:
     * See all workflow tags, create new tags, and assign tags to their workflows. Members can't delete tags.
     * Change their own password.
+    * Change their own email.
     * See their own workflows.
 
 /// note | Create a member-level account for the owner


### PR DESCRIPTION
These changes were suggested during a previous support conversation (ticket #765085). The user was under the impression that changes could not be made to the owner account. This PR is my suggestion to clarify that an email change is indeed possible and will be sufficient in most cases.