### PR TITLE
Small docs update to explain additional permissions for instance owners/admins

### DIFF
--- a/docs/external-secrets.md
+++ b/docs/external-secrets.md
@@ -70,3 +70,9 @@ For example, you have two n8n instances, one for development and one for product
 ### Infisical version changes
 
 Infisical version upgrades can introduce problems connecting to n8n. If your Infisical connection stops working, check if there was a recent version change. If so, report the issue to help@n8n.io.
+
+### External secrets should only be set on credentials owned by an instance owner or admin
+
+Due to the additional permissions that instance owners and admins have, it would be possible to update credentials owned by another user with a secrets expression. Whilst this will preview correctly for an instance owner or admin, the secret will not resolve when the workflow is run in production. 
+
+Therefore, it's important that external secrets are only used on credentials that are owned by an instance admin or owner to ensure they are resolved when a production execution occurs.

--- a/docs/user-management/account-types.md
+++ b/docs/user-management/account-types.md
@@ -16,7 +16,7 @@ To use admin accounts, you need a pro or enterprise plan.
     * Add and remove users, including admin users
 	* Upgrade members to admin, and downgrade admins to member
     * See and share all workflows    
-	* See and share all credentials (but not see the sensitive information)
+	* See, edit and share all credentials (but not see the sensitive information)
 	* Delete tags
 	* Set up and use [Source control](/source-control-environments/)
 * Admin: elevated permissions within the app.


### PR DESCRIPTION
We've extended the ability for instance admins and owners to edit all credentials on an instance. Some minor docs updates to reflect this change.