### PR TITLE
Enable instant loading for smoother transition between pages in the navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,8 @@ theme:
     - navigation.tabs.sticky
     # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=navigation+tabs#anchor-tracking
     - navigation.tracking
+      #https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading
+    - navigation.instant
 copyright: >
   <a href="#__consent">Change cookie settings</a>
 extra:


### PR DESCRIPTION
## Description 
When [instant loading](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading) is enabled, clicks on all internal links will be intercepted and dispatched via XHR without fully reloading the page which allows smoother transitions between pages. 
## Motivation
Enabling instant loading could improve user experience with quicker and more seamless transitions between navigation bar pages. 

Current implementation: 
the whole page reloads every time user clicks on a different link in the nav bar
![CleanShot 2024-03-24 at 22 52 18](https://github.com/n8n-io/n8n-docs/assets/15815271/2b7fb1fa-0cde-4abf-b5a8-4c5d237a151c)

With instant loading enabled:
smoother transitions between pages in the nav bar
![CleanShot 2024-03-24 at 22 53 27](https://github.com/n8n-io/n8n-docs/assets/15815271/e7f9ef20-c155-4c87-b9e5-1fb527218e25)
