### PR TITLE
Change search bar input text color for better visibility against background

### DIFF
--- a/docs/_extra/css/extra.css
+++ b/docs/_extra/css/extra.css
@@ -92,6 +92,7 @@
   [data-md-color-scheme="light"] .md-search__input {
 	border: 1px solid var(--color-foreground-base);
 	background-color: white;
+  color: var(--color-text-dark);
   } 
   
   [data-md-color-scheme="light"] .md-search__input::placeholder {


### PR DESCRIPTION
### Motivation 
Search bar input text color is white when search bar is collapsed (default styling from the material theme) and not visible against the white background. I find this to be confusing since users are unable to see any pre-existing text within the search bar. 

![CleanShot 2024-04-02 at 09 07 32](https://github.com/n8n-io/n8n-docs/assets/15815271/421c39cb-0995-4276-b61a-9c76d8ff373f)
### Changes
Change the text color from white to --color-text-dark (#555555) 

