### PR TITLE
DOC 777: Add more detail for Shopify credentials

### DIFF
--- a/docs/integrations/builtin/credentials/shopify.md
+++ b/docs/integrations/builtin/credentials/shopify.md
@@ -15,17 +15,17 @@ You can use these credentials to authenticate the following nodes with Shopify.
 
 Create a [Shopify](https://shopify.com/){:target=_blank .external-link} account.
 
-Then [create a custom app](https://help.shopify.com/en/manual/apps/app-types/custom-apps){:target=_blank .external-link} to authenticate to. Shopify often defaults to OAuth2 token exchange, so that may be the fastest configuration for initial testing.
+Then [create a custom app](https://help.shopify.com/en/manual/apps/app-types/custom-apps){:target=_blank .external-link} to authenticate to.
 
 ## Supported authentication methods
 
 * [Access Token](https://shopify.dev/docs/apps/auth/access-token-types/admin-app-access-tokens){:target=_blank .external-link}. Requires:
     - Shop Subdomain (remove `.myshopify.com`)
-    - Access Token
-    - APP Secret Key
+    - Access Token: In Shopify UI, the **Admin API Access Token**
+    - APP Secret Key: In Shopify UI, the **API Secret Key**
 * [OAuth2](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange){:target=_blank .external-link}. Requires:
-    - Client ID (API Key)
-    - Client Secret (API Secret Key)
+    - Client ID: In Shopify UI, the **API Key**
+    - Client Secret: In Shopify UI, the **API Secret Key**
     - Shop Subdomain (remove `.myshopify.com`)
 * API Key. Requires:
     - API Key
@@ -35,3 +35,11 @@ Then [create a custom app](https://help.shopify.com/en/manual/apps/app-types/cus
 ## Related resources
 
 Refer to [Shopify's authentication documentation](https://shopify.dev/docs/apps/auth){:target=_blank .external-link} for more information about the service.
+
+<!-- If this is a credential-only node, add a link to the node page on n8n's website. For example: https://n8n.io/integrations/356-gmail/ -->
+This is a credential-only node. Refer to [Shopify](/integrations/builtin/app-nodes/n8n-nodes-base.shopify/) and [Shopify Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.shopifytrigger/) to learn more. View [example Shopify workflows and related content](https://n8n.io/integrations/shopify/){:target=_blank .external-link} and [example Shopify Trigger workflows and related content](https://n8n.io/integrations/shopify-trigger/){:target=_blank .external-link} on n8n's website.
+
+## Quirks
+
+<!-- This issue was noted by someone in the forums and we also ran into it while testing auth setup -->
+If you get a "Couldn't connect with these settings / Forbidden - perhaps check your credentials" warning when you test the credentials, this may have to do with [access scope](https://shopify.dev/docs/api/usage/access-scopes){:target=_blank .external-link} dependencies (for example, `read_orders` scope also requires `read_products` scope to function).

--- a/docs/integrations/builtin/credentials/shopify.md
+++ b/docs/integrations/builtin/credentials/shopify.md
@@ -15,11 +15,22 @@ You can use these credentials to authenticate the following nodes with Shopify.
 
 Create a [Shopify](https://shopify.com/){:target=_blank .external-link} account.
 
+Then [create a custom app](https://help.shopify.com/en/manual/apps/app-types/custom-apps){:target=_blank .external-link} to authenticate to. Shopify often defaults to OAuth2 token exchange, so that may be the fastest configuration for initial testing.
+
 ## Supported authentication methods
 
-* Access Token
-* OAuth2
-* API Key
+* [Access Token](https://shopify.dev/docs/apps/auth/access-token-types/admin-app-access-tokens){:target=_blank .external-link}. Requires:
+    - Shop Subdomain (remove `.myshopify.com`)
+    - Access Token
+    - APP Secret Key
+* [OAuth2](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange){:target=_blank .external-link}. Requires:
+    - Client ID (API Key)
+    - Client Secret (API Secret Key)
+    - Shop Subdomain (remove `.myshopify.com`)
+* API Key. Requires:
+    - API Key
+    - Password
+    - Shop Subdomain (remove `.myshopify.com`)
 
 ## Related resources
 


### PR DESCRIPTION
Summary of changes made:

- Added suggestion to create a custom app and link to Shopify docs into **Prerequisites** section
- Added list of required fields to **Supported authentication methods** with guidance on how those fields map to Shopify's UI
- Added Related Resources links based on the credentials template
- Added a **Quirks** section with one hiccup both I and someone in the community forum ran into (the forum post was how I figured out how to solve it, so it seemed like maybe I wasn't the only one with such an issue)

One thing for review: based on the Slack thread, it did not seem like we needed full step-by-step instructions here. I was able to get the Access Token setup working very quickly with the field mappings I added to the doc. But I wasn't sure if I should have put those mappings somewhere else rather than in the Supported authentication methods section.