### PR TITLE
coda.io instead of coda.com

### DIFF
--- a/docs/integrations/builtin/credentials/coda.md
+++ b/docs/integrations/builtin/credentials/coda.md
@@ -12,7 +12,7 @@ You can use these credentials to authenticate the following nodes with Coda.
 
 ## Prerequisites
 
-Create a [Coda](https://www.coda.io/) account.
+Create a [Coda](https://www.coda.io/){:target=_blank .external-link} account.
 
 ## Using Access Token
 

--- a/docs/integrations/builtin/credentials/coda.md
+++ b/docs/integrations/builtin/credentials/coda.md
@@ -12,7 +12,7 @@ You can use these credentials to authenticate the following nodes with Coda.
 
 ## Prerequisites
 
-Create a [Coda](https://www.coda.com/) account.
+Create a [Coda](https://www.coda.io/) account.
 
 ## Using Access Token
 


### PR DESCRIPTION
found a broken link, and fixed it! (they have changed domain)
Thanks :) 