### PR TITLE
Add note about managed OAuth credentials for Google services 

### DIFF
--- a/_snippets/integrations/managed-google-oauth.md
+++ b/_snippets/integrations/managed-google-oauth.md
@@ -1,5 +1,5 @@
 /// note | Note for n8n Cloud users
-For the following nodes, you can authenticate just by connecting your Google account to n8n. You can do so by clicking on **Sign in with Google** in the OAuth section. Skip the instructions explained in this document.
+For the following nodes, you can authenticate by selecting **Sign in with Google** in the OAuth section. Skip the instructions explained in this document.
 
 * [Google Calendar](/integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/)
 * [Google Contacts](/integrations/builtin/app-nodes/n8n-nodes-base.googlecontacts/)

--- a/_snippets/integrations/managed-google-oauth.md
+++ b/_snippets/integrations/managed-google-oauth.md
@@ -1,5 +1,5 @@
 /// note | Note for n8n Cloud users
-For the following nodes, you can authenticate by selecting **Sign in with Google** in the OAuth section. Skip the instructions explained in this document.
+For the following nodes, you can authenticate by selecting **Sign in with Google** in the OAuth section. 
 
 * [Google Calendar](/integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/)
 * [Google Contacts](/integrations/builtin/app-nodes/n8n-nodes-base.googlecontacts/)

--- a/_snippets/integrations/managed-google-oauth.md
+++ b/_snippets/integrations/managed-google-oauth.md
@@ -1,0 +1,9 @@
+/// note | Note for n8n Cloud users
+For the following nodes, you can authenticate just by connecting your Google account to n8n. You can do so by clicking on **Sign in with Google** in the OAuth section. Skip the instructions explained in this document.
+
+* [Google Calendar](/integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/)
+* [Google Contacts](/integrations/builtin/app-nodes/n8n-nodes-base.googlecontacts/)
+* [Google Drive](/integrations/builtin/app-nodes/n8n-nodes-base.googledrive/)
+* [Google Sheets](/integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/)
+* [Google Tasks](/integrations/builtin/app-nodes/n8n-nodes-base.googletasks/)
+///

--- a/docs/integrations/builtin/credentials/google/index.md
+++ b/docs/integrations/builtin/credentials/google/index.md
@@ -23,6 +23,7 @@ For the following nodes, you can authenticate by entering the **Credentials Name
 
 * [Google Calendar](/integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/)
 * [Google Contacts](/integrations/builtin/app-nodes/n8n-nodes-base.googlecontacts/)
+* [Google Drive](/integrations/builtin/app-nodes/n8n-nodes-base.googledrive/)
 * [Google Sheets](/integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/)
 * [Google Tasks](/integrations/builtin/app-nodes/n8n-nodes-base.googletasks/)
 ///

--- a/docs/integrations/builtin/credentials/google/index.md
+++ b/docs/integrations/builtin/credentials/google/index.md
@@ -18,6 +18,15 @@ This section contains:
 
 There are two authentication methods available for Google services nodes, [OAuth2](https://developers.google.com/identity/protocols/oauth2){:target=_blank .external-link} and [Service Account](https://cloud.google.com/iam/docs/understanding-service-accounts){:target=_blank .external-link}. n8n recommends using OAuth. It's more widely available, and easier to set up. Refer to the [Google documentation: Understanding service accounts](https://cloud.google.com/iam/docs/understanding-service-accounts){:target=_blank .external-link} for guidance on when you need service account.
 
+/// note | Note for n8n Cloud users
+For the following nodes, you can authenticate by entering the **Credentials Name** and selecting **Sign in with Google** in the OAuth section to connect your Google account to n8n:
+
+* [Google Calendar](/integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/)
+* [Google Contacts](/integrations/builtin/app-nodes/n8n-nodes-base.googlecontacts/)
+* [Google Sheets](/integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/)
+* [Google Tasks](/integrations/builtin/app-nodes/n8n-nodes-base.googletasks/)
+///
+
 ## Compatible nodes
 
 Once configured, you can use your credentials to authenticate the following nodes. Most nodes are compatible with OAuth2 authentication. Support for Service Account authentication is limited.
@@ -47,16 +56,6 @@ Once configured, you can use your credentials to authenticate the following node
 	| [Google Tasks](/integrations/builtin/app-nodes/n8n-nodes-base.googletasks/) | :white_check_mark: | :x: |
 	| [Google Translate](/integrations/builtin/app-nodes/n8n-nodes-base.googletranslate/) | :white_check_mark: | :white_check_mark: |
 	| [YouTube](/integrations/builtin/app-nodes/n8n-nodes-base.youtube/) | :white_check_mark: | :x: |
-
-/// note | Note for n8n Cloud users
-For the following nodes, you can authenticate by entering the **Credentials Name** and selecting **Sign in with Google** in the OAuth section to connect your Google account to n8n:
-
-* [Google Calendar](/integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/)
-* [Google Contacts](/integrations/builtin/app-nodes/n8n-nodes-base.googlecontacts/)
-* [Google Sheets](/integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/)
-* [Google Tasks](/integrations/builtin/app-nodes/n8n-nodes-base.googletasks/)
-///
-
 
 
 

--- a/docs/integrations/builtin/credentials/google/index.md
+++ b/docs/integrations/builtin/credentials/google/index.md
@@ -18,15 +18,7 @@ This section contains:
 
 There are two authentication methods available for Google services nodes, [OAuth2](https://developers.google.com/identity/protocols/oauth2){:target=_blank .external-link} and [Service Account](https://cloud.google.com/iam/docs/understanding-service-accounts){:target=_blank .external-link}. n8n recommends using OAuth. It's more widely available, and easier to set up. Refer to the [Google documentation: Understanding service accounts](https://cloud.google.com/iam/docs/understanding-service-accounts){:target=_blank .external-link} for guidance on when you need service account.
 
-/// note | Note for n8n Cloud users
-For the following nodes, you can authenticate by entering the **Credentials Name** and selecting **Sign in with Google** in the OAuth section to connect your Google account to n8n:
-
-* [Google Calendar](/integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/)
-* [Google Contacts](/integrations/builtin/app-nodes/n8n-nodes-base.googlecontacts/)
-* [Google Drive](/integrations/builtin/app-nodes/n8n-nodes-base.googledrive/)
-* [Google Sheets](/integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/)
-* [Google Tasks](/integrations/builtin/app-nodes/n8n-nodes-base.googletasks/)
-///
+--8<-- "_snippets/integrations/managed-google-oauth.md"
 
 ## Compatible nodes
 

--- a/docs/integrations/builtin/credentials/google/oauth-generic.md
+++ b/docs/integrations/builtin/credentials/google/oauth-generic.md
@@ -8,6 +8,7 @@ contentType: integration
 
 This document contains instructions for creating a generic OAuth2 Google credential for use with [custom operations](/integrations/custom-operations/).
 
+--8<-- "_snippets/integrations/managed-google-oauth.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/google/oauth-single-service.md
+++ b/docs/integrations/builtin/credentials/google/oauth-single-service.md
@@ -8,6 +8,8 @@ contentType: integration
 
 This document contains instructions for creating a Google credential for a single service. They're also available as a [video](#video).
 
+--8<-- "_snippets/integrations/managed-google-oauth.md"
+
 ## Prerequisites
 
 * [Google Cloud](https://cloud.google.com/){:targe=_blank .external-link} account


### PR DESCRIPTION
## Motivation
> I am following the steps based on your documentation ... However, the moment that I add the "Credential to connect with" in n8n for the google sheets node, there is no information about the "OAuth Redirect URL" or the options to include "Client ID" and "Client Secret" in my account ([ticket](https://support.n8n.io/#ticket/zoom/5857))
- A user follows the Google OAuth documentation without realising n8n provides managed OAuth for some services. 

## Changes
- Added Google Drive to the list (based on this [Notion page](https://www.notion.so/n8n/Managed-credentials-on-Cloud-secrets-injection-mechanism-bbac6c8655eb4e57aad17e7c4a1bafb8#235cb7b091c3434eb34535e2a402fd44)) 
- Moved the note in the OAuth section of the index instead of all the way at the bottom 
- Created a slightly rephrased snippet of the above note and added at the top of the two Google OAuth pages