### PR TITLE
Make Oauth2 rule respect case so it throws appropriate messages

### DIFF
--- a/styles/n8n-styles/oauth2.yml
+++ b/styles/n8n-styles/oauth2.yml
@@ -1,7 +1,7 @@
 extends: existence
 message: OAuth2
 level: warning
-ignorecase: true
+ignorecase: false
 tokens:
   - '\bOauth2\b'
   - '\boauth2\b'


### PR DESCRIPTION
I was getting linting warnings when using OAuth2, and it appears that setting ignorecase to false fixes this issue, while still properly throwing warnings on oauth2 and Oauth2.