### PR TITLE
Fix Custom Auth in httprequest.md

### DIFF
--- a/docs/integrations/builtin/credentials/httprequest.md
+++ b/docs/integrations/builtin/credentials/httprequest.md
@@ -83,7 +83,7 @@ Read more about [OAuth2](https://oauth.net/2/){:target=_blank .external-link}.
 
 ### Using Custom Auth
 
-The **Generic Auth Type** > **Custom Auth** option expects JSON data to define your credential. You can define credentials using headers, qs, body, or a combination of these within a parent `json` key. See the examples below to get started.
+The **Generic Auth Type** > **Custom Auth** option expects JSON data to define your credential. You can define credentials using `headers`, `qs`, `body`, or a combination of these within a parent `json` key. See the examples below to get started.
 
 #### Sending two headers
 ```

--- a/docs/integrations/builtin/credentials/httprequest.md
+++ b/docs/integrations/builtin/credentials/httprequest.md
@@ -83,14 +83,16 @@ Read more about [OAuth2](https://oauth.net/2/){:target=_blank .external-link}.
 
 ### Using Custom Auth
 
-The **Generic Auth Type** > **Custom Auth** option expects JSON data to define your credential. You can use `headers`, `qs`, `body` or a mix. See the examples below to get started.
+The **Generic Auth Type** > **Custom Auth** option expects JSON data to define your credential. You can define credentials using headers, qs, body, or a combination of these within a parent `json` key. See the examples below to get started.
 
 #### Sending two headers
 ```
 {
-	"headers": {
-		"X-AUTH-USERNAME": "username",
-		"X-AUTH-PASSWORD": "password"
+	"json": {
+		"headers": {
+			"X-AUTH-USERNAME": "username",
+			"X-AUTH-PASSWORD": "password"
+		}
 	}
 }
 ```
@@ -98,9 +100,11 @@ The **Generic Auth Type** > **Custom Auth** option expects JSON data to define y
 #### Body
 ```
 {
-	 "body" : {
-		"user": "username",
-		"pass": "password"
+	"json": {
+		 "body" : {
+			"user": "username",
+			"pass": "password"
+		}
 	}
 }
 ```
@@ -108,9 +112,11 @@ The **Generic Auth Type** > **Custom Auth** option expects JSON data to define y
 #### Query string
 ```
 {
-	"qs": { 
-		"appid": "123456",
-		"apikey": "my-api-key"
+	"json": {
+		"qs": { 
+			"appid": "123456",
+			"apikey": "my-api-key"
+		}
 	}
 }
 ```
@@ -118,11 +124,13 @@ The **Generic Auth Type** > **Custom Auth** option expects JSON data to define y
 #### Sending header and query string
 ```
 {
-	"headers": {
-		"api-version": "202404"
-	},
-	"qs": {
-		"apikey": "my-api-key"
+	"json": {
+		"headers": {
+			"api-version": "202404"
+		},
+		"qs": {
+			"apikey": "my-api-key"
+		}
 	}
 }
 ```

--- a/docs/integrations/builtin/credentials/httprequest.md
+++ b/docs/integrations/builtin/credentials/httprequest.md
@@ -90,8 +90,8 @@ The **Generic Auth Type** > **Custom Auth** option expects JSON data to define y
 {
 	"json": {
 		"headers": {
-			"X-AUTH-USERNAME": "username",
-			"X-AUTH-PASSWORD": "password"
+			"X-AUTH-USERNAME": "<username>",
+			"X-AUTH-PASSWORD": "<password>"
 		}
 	}
 }
@@ -102,8 +102,8 @@ The **Generic Auth Type** > **Custom Auth** option expects JSON data to define y
 {
 	"json": {
 		 "body" : {
-			"user": "username",
-			"pass": "password"
+			"user": "<username>",
+			"pass": "<password>"
 		}
 	}
 }
@@ -114,8 +114,8 @@ The **Generic Auth Type** > **Custom Auth** option expects JSON data to define y
 {
 	"json": {
 		"qs": { 
-			"appid": "123456",
-			"apikey": "my-api-key"
+			"appid": "<123456>",
+			"apikey": "<my-api-key>"
 		}
 	}
 }
@@ -126,10 +126,10 @@ The **Generic Auth Type** > **Custom Auth** option expects JSON data to define y
 {
 	"json": {
 		"headers": {
-			"api-version": "202404"
+			"api-version": "<202404>"
 		},
 		"qs": {
-			"apikey": "my-api-key"
+			"apikey": "<my-api-key>"
 		}
 	}
 }


### PR DESCRIPTION
The custom auth docs and examples were incorrect or out of date. 
The json needs to be nested under a `json` key to work. 

Updated the code examples and rewrote a sentence to clarify that it needs a `json` key as well.

I tested each code sample in my self hosted instance (1.38.2 on docker)