### PR TITLE
remove note about feature availability

### DIFF
--- a/docs/credentials/credential-sharing.md
+++ b/docs/credentials/credential-sharing.md
@@ -6,7 +6,7 @@ contentType: howto
 # Credential sharing
 
 /// info | Feature availability
-Available on Pro and Enterprise Cloud plans, and Enterprise self-hosted plans.
+Available on all Cloud plans, and Enterprise self-hosted plans.
 ///
 
 Credential sharing allows you to share a credential you created with other users in the same n8n workspace as you. The other users can then use the credential in their workflows. They can't access or edit the credential details.

--- a/docs/user-management/cloud-setup.md
+++ b/docs/user-management/cloud-setup.md
@@ -5,10 +5,6 @@ contentType: howto
 
 # Set up user management on n8n Cloud
 
-/// info | Feature availability
-Available on paid self-hosted and selected Cloud plans. Refer to [Pricing](https://n8n.io/pricing/){:target=_blank .external-link} for more information.
-///
-
 To access user management, upgrade to version 0.195.0 or newer.
 
 /// warning | Irreversible upgrade


### PR DESCRIPTION
## Changes
- User management is now available for all n8n editions, not just 'selected Cloud plans'
- Credential sharing is available for all Cloud plans + Enterprise plan