### PR TITLE
DOC-887: Additional creds guidance for Google, Ollama, HTTP Request

### DIFF
--- a/_snippets/integrations/managed-google-oauth.md
+++ b/_snippets/integrations/managed-google-oauth.md
@@ -1,5 +1,5 @@
 /// note | Note for n8n Cloud users
-For the following nodes, you can authenticate by selecting **Sign in with Google** in the OAuth section. 
+For the following nodes, you can authenticate by selecting **Sign in with Google** in the OAuth section: 
 
 * [Google Calendar](/integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/)
 * [Google Contacts](/integrations/builtin/app-nodes/n8n-nodes-base.googlecontacts/)

--- a/docs/integrations/builtin/credentials/google/googleai.md
+++ b/docs/integrations/builtin/credentials/google/googleai.md
@@ -15,11 +15,29 @@ You can use these credentials to authenticate the following nodes:
 
 ## Prerequisites
 
-You need an API key and the API host URL.
+* Create a [Google Cloud](https://cloud.google.com/){:target=_blank .external-link} account.
+* Create a [Google Cloud Platform project](https://developers.google.com/workspace/marketplace/create-gcp-project){:target=_blank .external-link}.
+
+## Supported authentication methods
+
+- Gemini(PaLM) API key
 
 ## Related resources
 
-
-Refer to [Google's documentation](https://developers.generativeai.google/tutorials/setup){:target=_blank .external-link} for more information about the service.
+Refer to [Google's Gemini API documentation](https://ai.google.dev/gemini-api/docs){:target=_blank .external-link} for more information about the service.
 
 --8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
+
+## Using Gemini(PaLM) API key
+
+To configure this credential, you'll need:
+
+- The API **Host** URL: Both PaLM and Gemini use the default `https://generativelanguage.googleapis.com`.
+- An **API Key**: Create a key in [Google AI Studio](https://makersuite.google.com/app/apikey){:target=_blank .external-link}.
+
+To create an API key:
+
+1. Go to the API Key page in Google AI Studio: [https://makersuite.google.com/app/apikey](https://makersuite.google.com/app/apikey){:target=_blank .external-link}.
+2. Select **Create API Key**.
+3. You can choose whether to **Create API key in new project** or search for an existing Google Cloud project to **Create API key in existing project**.
+4. Copy the API key that is generated and add it to your n8n credential.

--- a/docs/integrations/builtin/credentials/google/googleai.md
+++ b/docs/integrations/builtin/credentials/google/googleai.md
@@ -40,4 +40,4 @@ To create an API key:
 1. Go to the API Key page in Google AI Studio: [https://makersuite.google.com/app/apikey](https://makersuite.google.com/app/apikey){:target=_blank .external-link}.
 2. Select **Create API Key**.
 3. You can choose whether to **Create API key in new project** or search for an existing Google Cloud project to **Create API key in existing project**.
-4. Copy the API key that is generated and add it to your n8n credential.
+4. Copy the generated API key and add it to your n8n credential.

--- a/docs/integrations/builtin/credentials/google/oauth-generic.md
+++ b/docs/integrations/builtin/credentials/google/oauth-generic.md
@@ -22,7 +22,14 @@ This document contains instructions for creating a generic OAuth2 Google credent
 
 ### Create a new credential in n8n
 
-1. Follow the steps to [Create a credential](/credentials/add-edit-credentials/). If you create a credential by selecting **Create new** in the credentials dropdown in a node, n8n automatically creates the correct credential type for that node. If you select **Credentials > New**, you must browse for the credential type. To create a credential for a [custom API call](/integrations/custom-operations/), select **Google OAuth2 API**. This allows you to create a generic credential, then set its scopes.
+1. Follow the steps to [Create a credential](/credentials/add-edit-credentials/). 
+
+    /// note | Generic and specific credentials
+    If you create a credential by selecting **Create new** in the credentials dropdown in a node, n8n automatically creates the correct credential type for that node. If you select **Credentials > New**, you must browse for the credential type:
+
+	* To create a credential for a [custom API call](/integrations/custom-operations/), select **Google OAuth2 API**. This allows you to create a generic credential, then set its scopes.
+    ///
+
 2. Note the **OAuth Redirect URL** from the node credential modal. You'll need this in the next section.
 
 	??? Details "View screenshot"
@@ -43,7 +50,7 @@ This document contains instructions for creating a generic OAuth2 Google credent
 		![Create credentials](/_images/integrations/builtin/credentials/google/create-credentials.png)
 
 3. In the **Application type** dropdown, select **Web application**. Google automatically generates a name.
-4. Under **Authorizes redirect URIs**, select **+ ADD URI**. Paste in the OAuth redirect URL from the previous step.
+4. Under **Authorized redirect URIs**, select **+ ADD URI**. Paste in the OAuth redirect URL from the previous step.
 
 	??? Details "View screenshot"   
 		![Web application](/_images/integrations/builtin/credentials/google/application-web-application.png)

--- a/docs/integrations/builtin/credentials/google/oauth-generic.md
+++ b/docs/integrations/builtin/credentials/google/oauth-generic.md
@@ -25,9 +25,9 @@ This document contains instructions for creating a generic OAuth2 Google credent
 1. Follow the steps to [Create a credential](/credentials/add-edit-credentials/). 
 
     /// note | Generic and specific credentials
-    If you create a credential by selecting **Create new** in the credentials dropdown in a node, n8n automatically creates the correct credential type for that node. If you select **Credentials > New**, you must browse for the credential type:
-
-	* To create a credential for a [custom API call](/integrations/custom-operations/), select **Google OAuth2 API**. This allows you to create a generic credential, then set its scopes.
+    If you create a credential by selecting **Create new** in the credentials dropdown in a node, n8n automatically creates the correct credential type for that node.
+	
+	If you select **Credentials > New**, you must browse for the credential type. To create a credential for a [custom API call](/integrations/custom-operations/), select **Google OAuth2 API**. This allows you to create a generic credential, then set its scopes.
     ///
 
 2. Note the **OAuth Redirect URL** from the node credential modal. You'll need this in the next section.

--- a/docs/integrations/builtin/credentials/google/oauth-single-service.md
+++ b/docs/integrations/builtin/credentials/google/oauth-single-service.md
@@ -23,7 +23,15 @@ This document contains instructions for creating a Google credential for a singl
 
 ### Create a new credential in n8n
 
-1. Follow the steps to [Create a credential](/credentials/add-edit-credentials/). If you create a credential by selecting **Create new** in the credentials dropdown in a node, n8n automatically creates the correct credential type for that node. If you select **Credentials > New**, you must browse for the credential type. To create a credential for a [custom API call](/integrations/custom-operations/), select **Google OAuth2 API**. This allows you to create a generic credential, then set its scopes.
+1. Follow the steps to [Create a credential](/credentials/add-edit-credentials/).
+
+    /// note | Generic and specific credentials
+    If you create a credential by selecting **Create new** in the credentials dropdown in a node, n8n automatically creates the correct credential type for that node. If you select **Credentials > New**, you must browse for the credential type:
+
+	* To connect with a specific service, using resources and operations supported by n8n, choose that service. For example, to create a credential for use in the Gmail node, search for `Gmail`.
+	* To create a credential for a [custom API call](/integrations/custom-operations/), select **Google OAuth2 API**. This allows you to create a generic credential, then set its scopes.
+    ///
+
 2. Note the **OAuth Redirect URL** from the node credential modal. You'll need this in the next section.
 
 	??? Details "View screenshot"
@@ -59,7 +67,7 @@ This document contains instructions for creating a Google credential for a singl
 	??? Details "View screenshot"   
 		![Web application](/_images/integrations/builtin/credentials/google/application-web-application.png)
 
-5. Under **Authorizes redirect URIs**, select **+ ADD URI**. Paste in the OAuth redirect URL from n8n.
+5. Under **Authorized redirect URIs**, select **+ ADD URI**. Paste in the OAuth redirect URL from n8n.
 
 	??? Details "View screenshot"  
 		![OAuth Callback URL](/_images/integrations/builtin/credentials/google/oauth_callback.png) 

--- a/docs/integrations/builtin/credentials/google/service-account.md
+++ b/docs/integrations/builtin/credentials/google/service-account.md
@@ -9,7 +9,7 @@ contentType: integration
 Using service accounts is more complex than OAuth2. Before you begin:
 
 * Check if your node is [compatible](/integrations/builtin/credentials/google/#compatible-nodes) with Service Account.
-* Make sure you need to use service account. For most use cases, OAuth2 is a better option.
+* Make sure you need to use Service Account. For most use cases, OAuth2 is a better option.
 * Read the Google documentation on [Creating and managing service accounts](https://cloud.google.com/iam/docs/creating-managing-service-accounts){:target=_blank .external-link}.
 
 
@@ -49,7 +49,7 @@ In your [Google Cloud Console](https://console.cloud.google.com){:target=_blank 
 	??? Details "View screenshot"
 		![Access the Credentials page for APIs and services](/_images/integrations/builtin/credentials/google/service-account-create-credentials.png)
 
-3. Enter a name in **Service account name**, and an ID in **Service account ID**. Refer to [Creating a service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts?hl=en#creating){:target=_blank .external-link} for more information.
+3. Enter a name in **Service account name** and an ID in **Service account ID**. Refer to [Creating a service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts?hl=en#creating){:target=_blank .external-link} for more information.
 4. Select **CREATE AND CONTINUE**.
 5. Based on your use-case, you may want to **Select a role** and **Grant users access to this service account**  using the corresponding sections.
 6. Select **DONE**.

--- a/docs/integrations/builtin/credentials/httprequest.md
+++ b/docs/integrations/builtin/credentials/httprequest.md
@@ -14,76 +14,164 @@ You can use these credentials to authenticate the following nodes:
 
 You must use the authentication method required by the app or service you want to query.
 
-### Predefined credential types
+## Supported authentication methods
 
-n8n recommends using this option whenever there's a credential type available for the service you want to connect to. It offers an easier way to set up and manage credentials, compared to configuring generic credentials.
+- Predefined credential type
+- Generic credential type
+
+/// note | Predefined credential types
+n8n recommends using predefined credential types whenever there's a credential type available for the service you want to connect to. It offers an easier way to set up and manage credentials, compared to configuring generic credentials.
 
 You can use [Predefined credential types](/integrations/custom-operations/#predefined-credential-types) to perform custom operations with some APIs where n8n has a node for the platform. For example, n8n has an Asana node, and supports using your Asana credentials in the HTTP Request node. Refer to [Custom operations](/integrations/custom-operations/) for more information.
+///
 
-### Using a predefined credential type
+## Using predefined credential type
 
 --8<-- "_snippets/integrations/predefined-credential-type-how-to.md"
 
 Refer to [Custom API operations](/integrations/custom-operations/) for more information.
 
-## Generic authentication
+## Using generic credential type
 
 The following generic authentication methods are available:
 
-* Basic Auth
-* Custom Auth
-* Digest Auth
-* Header Auth
-* OAuth1 API
-* OAuth2 API
-* Query Auth
+* Basic auth
+* Custom auth
+* Digest auth
+* Header auth
+* OAuth1
+* OAuth2
+* Query auth
 
-You can learn more about HTTP authentication [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#see_also){:target=_blank .external-link}.
+Refer to [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication){:target=_blank .external-link} for more information.
 
-### Using Basic Auth or Digest Auth
+### Using basic auth
 
-1. Update the credential name.
-2. Enter the **Username** and **Password** for the app or service your HTTP Request is targeting. 
-3. Select **Save** to save your credentials.
+Use this generic authentication if the app or service you want to use supports basic authentication.
 
-### Using Header Auth
+To configure this credential, you'll need:
 
-1. Update the credential name.
-2. Enter the header **Name** and **Value** required for the app or service your HTTP Request is targeting. Read more about [HTTP headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#authentication){:target=_blank .external-link}.
-3. Select **Save** to save your credentials.
+- A **Username** you use to access the app or service your HTTP Request is targeting
+- The **Password** that goes with that username
+
+### Using digest auth
+
+Use this generic authentication if the app or service you want to use supports digest authentication.
+
+To configure this credential, you'll need:
+
+- A **Username** you use to access the app or service your HTTP Request is targeting
+- The **Password** that goes with that username
+
+### Using header auth
+
+Use this generic authentication if the app or service you want to use supports header authentication.
+
+To configure this credential, you'll need:
+
+- The header **Name** you need to pass to the app or service your HTTP request is targeting
+- The **Value** for the header 
+
+Read more about [HTTP headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#authentication){:target=_blank .external-link}.
 
 ### Using OAuth1
 
-1. Update the credential name.
-2. Enter the following authentication details:
-    * **Authorization URL**
-    * **Access Token URL**
-    * **Consumer Key**
-    * **Consumer Secret**
-    * **Request Token URL**
-    * **Signature Method**
-3. Select **Save** to save your credentials.
+Use this generic authentication if the app or service you want to use supports OAuth1 authentication.
 
-Read more about [OAuth1](https://oauth.net/1/){:target=_blank .external-link}.
+To configure this credential, you'll need:
+
+- An **Authorization URL**: Also known as the Resource Owner Authorization URI. This URL typically ends in `/oauth1/authorize`. The temporary credentials are sent here to prompt a user to complete authorization.
+- An **Access Token URL**: This is the URI used for the initial request for temporary credentials. This URL typically ends in `/oauth1/request` or `/oauth1/token`.
+- A **Consumer Key**: Also known as the client key, similar to a username. This specifies the `oauth_consumer_key` to use for the call.
+- A **Consumer Secret**: Also known as the client secret, similar to a password.
+- A **Request Token URL**: This is the URI used to switch from temporary credentials to long-lived credentials after authorization. This URL typically ends in `/oauth1/access`.
+- Select the **Signature Method** the auth handshake uses. This specifies the `oauth_signature_method` to use for the call. Options include:
+	- **HMAC-SHA1**
+	- **HMAC-SHA256**
+	- **HMAC-SHA512**
+
+Typically, you'll need to configure an app, service, or integration to generate most of these OAuth1 fields. Use the **OAuth Redirect URL** in n8n as the redirect URL or redirect URI for such a service.
+
+Read more about [OAuth1](https://oauth.net/1/){:target=_blank .external-link} and the [OAuth1 authorization flow](https://oauth1.wp-api.org/docs/basics/Auth-Flow.html){:target=_blank .external-link}.
 
 ### Using OAuth2
 
-1. Update the credential name.
-2. Enter the following authentication details:
-    * **Authorization URL**
-    * **Access Token URL**
-    * **Client ID**
-    * **Client Secret**
-    * **Scope**
-    * **Auth URI Query Parameters**
-    * **Authentication**
-3. Select **Save** to save your credentials.
+Use this generic authentication if the app or service you want to use supports OAuth2 authentication.
+
+Requirements to configure this credential depend on the **Grant Type** selected. Refer to [OAuth Grant Types](https://oauth.net/2/grant-types/) for more information on each grant type:
+
+#### Authorization Code grant type
+
+Authorization Code grant type is used to exchange an authorization code for an access token. After the user returns to the client via the redirect URL, the application will get the authorization code from the URL and use it to request an access token. Refer to [Authorization Code Request](https://www.oauth.com/oauth2-servers/access-tokens/authorization-code-request/){:target=_blank .external-link} for more information.
+
+To configure this credential, you'll need:
+
+- Select **Authorization Code** as the **Grant Type**
+- An **Authorization URL**
+- An **Access Token URL**
+- A **Client ID**: The ID or username to log in with.
+- A **Client Secret**: The secret or password used to log in with.
+- _Optional:_ Enter one or more **Scope**s for the credential. If unspecified, the credential will request all scopes available to the client.
+- _Optional:_ Some services require additional query parameters. If your service does, add them as **Auth URI Query Parameters**.
+- Select the **Authentication** type. Options include:
+	- **Header**: Will send the credentials as a basic auth header
+	- **Body**: Will send credentials in the body of the request
+- _Optional:_ Choose whether to **Ignore SSL Issues**. If turned on, n8n will connect even if SSL validation fails.
 
 Read more about [OAuth2](https://oauth.net/2/){:target=_blank .external-link}.
 
-### Using Custom Auth
+#### Client Credentials grant type
 
-The **Generic Auth Type** > **Custom Auth** option expects JSON data to define your credential. You can use `headers`, `qs`, `body` or a mix. See the examples below to get started.
+The Client Credentials grant type is used when applications request an access token to access their own resources, not on behalf of a user. Refer to [Client Credentials](https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/){:target=_blank .external-link} for more information.
+
+To configure this credential, you'll need:
+
+- Select **Client Credentials** as the **Grant Type**.
+- An **Access Token URL**: The URL to hit to initiate the OAuth2 flow. Typically this URL ends in `/token`.
+- A **Client ID**: The ID or username to use to log in to the client.
+- A **Client Secret**: The secret or password used to log in to the client.
+- _Optional:_ Enter one or more **Scope**s for the credential. Most services don't support scopes for Client Credentials grant types; only enter scopes here if yours does.
+- Select the **Authentication** type. Options include:
+	- **Header**: Will send the credentials as a basic auth header
+	- **Body**: Will send credentials in the body of the request
+- _Optional:_ Choose whether to **Ignore SSL Issues**. If turned on, n8n will connect even if SSL validation fails.
+
+Read more about [OAuth2](https://oauth.net/2/){:target=_blank .external-link}.
+
+#### PKCE grant type
+
+Proof Key for Code Exchange (PKCE) grant type is an extension to the Authorization Code flow to prevent CSRF and authorization code injection attacks.
+
+To configure this credential, you'll need:
+
+- Select **PKCE** as the **Grant Type**
+- An **Authorization URL**
+- An **Access Token URL**
+- A **Client ID**: The ID or username to log in with.
+- A **Client Secret**: The secret or password used to log in with.
+- _Optional:_ Enter one or more **Scope**s for the credential. If unspecified, the credential will request all scopes available to the client.
+- _Optional:_ Some services require additional query parameters. If your service does, add them as **Auth URI Query Parameters**.
+- Select the **Authentication** type. Options include:
+	- **Header**: Will send the credentials as a basic auth header
+	- **Body**: Will send credentials in the body of the request
+- _Optional:_ Choose whether to **Ignore SSL Issues**. If turned on, n8n will connect even if SSL validation fails.
+
+Read more about [OAuth2](https://oauth.net/2/){:target=_blank .external-link}.
+
+### Using query auth
+
+Use this generic authentication if the app or service you want to use supports passing authentication as a single key/value query parameter. (For multiple query parameters, use [Custom Auth](#using-custom-auth).)
+
+To configure this credential, you'll need:
+
+- A query parameter key or **Name**
+- A query parameter **Value**
+
+### Using custom auth
+
+Use this generic authentication if the app or service you want to use supports passing authentication as multiple key/value query parameters or you need more flexibility than the other generic auth options.
+
+The **Custom Auth** credential expects JSON data to define your credential. You can use `headers`, `qs`, `body` or a mix. See the examples below to get started.
 
 #### Sending two headers
 ```
@@ -129,8 +217,19 @@ The **Generic Auth Type** > **Custom Auth** option expects JSON data to define y
 
 ## Provide an SSL certificate
 
-You can send an SSL certificate with your HTTP request. You can use this alongside other credential types.
+You can send an SSL certificate with your HTTP request. Create the SSL certificate as an additional credential for use by the node:
 
-1. In the node **Settings**, enable **SSL Certificates**.
-1. On the **Parameters** tab, add the SSL credential to **Credential for SSL Certificates**.
+1. In the HTTP Request node **Settings**, turn on **SSL Certificates**.
+2. On the **Parameters** tab, add an existing SSL Certificate credential to **Credential for SSL Certificates** or create a new one.
 
+To configure your SSL Certificates credential, you'll need:
+
+- The Certificate Authority **CA** bundle
+- The **Certificate** (CRT): May also appear as a Public Key, depending on who your issuing CA was and how the cert was formatted
+- The **Private Key** (KEY)
+- _Optional:_ If the **Private Key** is encrypted, enter a **Passphrase** for the private key.
+
+If your SSL certificate is in a single file (such as a `.pfx` file), you'll need to open the file to copy details from it to paste into the appropriate fields:
+
+- Enter the Public Key/CRT as the **Certificate**
+- Enter the **Private Key**/KEY in that field

--- a/docs/integrations/builtin/credentials/httprequest.md
+++ b/docs/integrations/builtin/credentials/httprequest.md
@@ -14,10 +14,20 @@ You can use these credentials to authenticate the following nodes:
 
 You must use the authentication method required by the app or service you want to query.
 
+If you need to secure the authentication with an SSL certificate, refer to [Provide an SSL certificate](#provide-an-ssl-certificate) for the information you'll need.
+
 ## Supported authentication methods
 
 - Predefined credential type
-- Generic credential type
+- Basic auth (generic credential type)
+- Custom auth (generic credential type)
+- Digest auth (generic credential type)
+- Header auth (generic credential type)
+- OAuth1 (generic credential type)
+- OAuth2 (generic credential type)
+- Query auth (generic credential type)
+
+Refer to [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication){:target=_blank .external-link} for more information relating to generic credential types.
 
 /// note | Predefined credential types
 n8n recommends using predefined credential types whenever there's a credential type available for the service you want to connect to. It offers an easier way to set up and manage credentials, compared to configuring generic credentials.
@@ -31,41 +41,18 @@ You can use [Predefined credential types](/integrations/custom-operations/#prede
 
 Refer to [Custom API operations](/integrations/custom-operations/) for more information.
 
-## Using generic credential type
+## Using basic auth or digest auth
 
-The following generic authentication methods are available:
-
-* Basic auth
-* Custom auth
-* Digest auth
-* Header auth
-* OAuth1
-* OAuth2
-* Query auth
-
-Refer to [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication){:target=_blank .external-link} for more information.
-
-### Using basic auth
-
-Use this generic authentication if the app or service you want to use supports basic authentication.
+Use one of these generic authentications if your app or service supports basic or digest authentication.
 
 To configure this credential, you'll need:
 
-- A **Username** you use to access the app or service your HTTP Request is targeting
+- The **Username** you use to access the app or service your HTTP Request is targeting
 - The **Password** that goes with that username
 
-### Using digest auth
+## Using header auth
 
-Use this generic authentication if the app or service you want to use supports digest authentication.
-
-To configure this credential, you'll need:
-
-- A **Username** you use to access the app or service your HTTP Request is targeting
-- The **Password** that goes with that username
-
-### Using header auth
-
-Use this generic authentication if the app or service you want to use supports header authentication.
+Use this generic authentication if your app or service supports header authentication.
 
 To configure this credential, you'll need:
 
@@ -74,106 +61,107 @@ To configure this credential, you'll need:
 
 Read more about [HTTP headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#authentication){:target=_blank .external-link}.
 
-### Using OAuth1
+## Using OAuth1
 
-Use this generic authentication if the app or service you want to use supports OAuth1 authentication.
+Use this generic authentication if your app or service supports OAuth1 authentication.
 
 To configure this credential, you'll need:
 
 - An **Authorization URL**: Also known as the Resource Owner Authorization URI. This URL typically ends in `/oauth1/authorize`. The temporary credentials are sent here to prompt a user to complete authorization.
 - An **Access Token URL**: This is the URI used for the initial request for temporary credentials. This URL typically ends in `/oauth1/request` or `/oauth1/token`.
-- A **Consumer Key**: Also known as the client key, similar to a username. This specifies the `oauth_consumer_key` to use for the call.
-- A **Consumer Secret**: Also known as the client secret, similar to a password.
+- A **Consumer Key**: Also known as the client key, like a username. This specifies the `oauth_consumer_key` to use for the call.
+- A **Consumer Secret**: Also known as the client secret, like a password.
 - A **Request Token URL**: This is the URI used to switch from temporary credentials to long-lived credentials after authorization. This URL typically ends in `/oauth1/access`.
 - Select the **Signature Method** the auth handshake uses. This specifies the `oauth_signature_method` to use for the call. Options include:
 	- **HMAC-SHA1**
 	- **HMAC-SHA256**
 	- **HMAC-SHA512**
 
-Typically, you'll need to configure an app, service, or integration to generate most of these OAuth1 fields. Use the **OAuth Redirect URL** in n8n as the redirect URL or redirect URI for such a service.
+For most OAuth1 integrations, you'll need to configure an app, service, or integration to generate the values for most of these fields. Use the **OAuth Redirect URL** in n8n as the redirect URL or redirect URI for such a service.
 
 Read more about [OAuth1](https://oauth.net/1/){:target=_blank .external-link} and the [OAuth1 authorization flow](https://oauth1.wp-api.org/docs/basics/Auth-Flow.html){:target=_blank .external-link}.
 
-### Using OAuth2
+## Using OAuth2
 
-Use this generic authentication if the app or service you want to use supports OAuth2 authentication.
+Use this generic authentication if your app or service supports OAuth2 authentication.
 
-Requirements to configure this credential depend on the **Grant Type** selected. Refer to [OAuth Grant Types](https://oauth.net/2/grant-types/) for more information on each grant type:
+Requirements to configure this credential depend on the **Grant Type** selected. Refer to [OAuth Grant Types](https://oauth.net/2/grant-types/) for more information on each grant type.
 
-#### Authorization Code grant type
+For most OAuth2 integrations, you'll need to configure an app, service, or integration to generate the values for most of these fields. Use the **OAuth Redirect URL** in n8n as the redirect URL or redirect URI for such a service.
 
-Authorization Code grant type is used to exchange an authorization code for an access token. After the user returns to the client via the redirect URL, the application will get the authorization code from the URL and use it to request an access token. Refer to [Authorization Code Request](https://www.oauth.com/oauth2-servers/access-tokens/authorization-code-request/){:target=_blank .external-link} for more information.
+Read more about [OAuth2](https://oauth.net/2/){:target=_blank .external-link}.
 
-To configure this credential, you'll need:
+### Authorization Code grant type
 
-- Select **Authorization Code** as the **Grant Type**
+Use Authorization Code grant type to exchange an authorization code for an access token. The auth flow uses the redirect URL to return the user to the client. Then the application gets the authorization code from the URL and uses it to request an access token. Refer to [Authorization Code Request](https://www.oauth.com/oauth2-servers/access-tokens/authorization-code-request/){:target=_blank .external-link} for more information.
+
+To configure this credential, select **Authorization Code** as the **Grant Type**.
+
+Then you'll need:
+
 - An **Authorization URL**
 - An **Access Token URL**
 - A **Client ID**: The ID or username to log in with.
 - A **Client Secret**: The secret or password used to log in with.
 - _Optional:_ Enter one or more **Scope**s for the credential. If unspecified, the credential will request all scopes available to the client.
-- _Optional:_ Some services require additional query parameters. If your service does, add them as **Auth URI Query Parameters**.
-- Select the **Authentication** type. Options include:
+- _Optional:_ Some services require more query parameters. If your service does, add them as **Auth URI Query Parameters**.
+- An **Authentication** type: Select the option that best suits your use case. Options include:
 	- **Header**: Will send the credentials as a basic auth header
 	- **Body**: Will send credentials in the body of the request
 - _Optional:_ Choose whether to **Ignore SSL Issues**. If turned on, n8n will connect even if SSL validation fails.
 
-Read more about [OAuth2](https://oauth.net/2/){:target=_blank .external-link}.
+### Client Credentials grant type
 
-#### Client Credentials grant type
+Use the Client Credentials grant type when applications request an access token to access their own resources, not on behalf of a user. Refer to [Client Credentials](https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/){:target=_blank .external-link} for more information.
 
-The Client Credentials grant type is used when applications request an access token to access their own resources, not on behalf of a user. Refer to [Client Credentials](https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/){:target=_blank .external-link} for more information.
+To configure this credential, select **Client Credentials** as the **Grant Type**.
 
-To configure this credential, you'll need:
+Then you'll need:
 
-- Select **Client Credentials** as the **Grant Type**.
-- An **Access Token URL**: The URL to hit to initiate the OAuth2 flow. Typically this URL ends in `/token`.
+- An **Access Token URL**: The URL to hit to begin the OAuth2 flow. Typically this URL ends in `/token`.
 - A **Client ID**: The ID or username to use to log in to the client.
 - A **Client Secret**: The secret or password used to log in to the client.
 - _Optional:_ Enter one or more **Scope**s for the credential. Most services don't support scopes for Client Credentials grant types; only enter scopes here if yours does.
-- Select the **Authentication** type. Options include:
+- An **Authentication** type: Select the option that best suits your use case. Options include:
 	- **Header**: Will send the credentials as a basic auth header
 	- **Body**: Will send credentials in the body of the request
 - _Optional:_ Choose whether to **Ignore SSL Issues**. If turned on, n8n will connect even if SSL validation fails.
 
-Read more about [OAuth2](https://oauth.net/2/){:target=_blank .external-link}.
-
-#### PKCE grant type
+### PKCE grant type
 
 Proof Key for Code Exchange (PKCE) grant type is an extension to the Authorization Code flow to prevent CSRF and authorization code injection attacks.
 
-To configure this credential, you'll need:
+To configure this credential, select **PKCE** as the **Grant Type**.
 
-- Select **PKCE** as the **Grant Type**
+Then you'll need:
+
 - An **Authorization URL**
 - An **Access Token URL**
 - A **Client ID**: The ID or username to log in with.
 - A **Client Secret**: The secret or password used to log in with.
 - _Optional:_ Enter one or more **Scope**s for the credential. If unspecified, the credential will request all scopes available to the client.
-- _Optional:_ Some services require additional query parameters. If your service does, add them as **Auth URI Query Parameters**.
-- Select the **Authentication** type. Options include:
+- _Optional:_ Some services require more query parameters. If your service does, add them as **Auth URI Query Parameters**.
+- An **Authentication** type: Select the option that best suits your use case. Options include:
 	- **Header**: Will send the credentials as a basic auth header
 	- **Body**: Will send credentials in the body of the request
 - _Optional:_ Choose whether to **Ignore SSL Issues**. If turned on, n8n will connect even if SSL validation fails.
 
-Read more about [OAuth2](https://oauth.net/2/){:target=_blank .external-link}.
+## Using query auth
 
-### Using query auth
-
-Use this generic authentication if the app or service you want to use supports passing authentication as a single key/value query parameter. (For multiple query parameters, use [Custom Auth](#using-custom-auth).)
+Use this generic authentication if your app or service supports passing authentication as a single key/value query parameter. (For multiple query parameters, use [Custom Auth](#using-custom-auth).)
 
 To configure this credential, you'll need:
 
 - A query parameter key or **Name**
 - A query parameter **Value**
 
-### Using custom auth
+## Using custom auth
 
-Use this generic authentication if the app or service you want to use supports passing authentication as multiple key/value query parameters or you need more flexibility than the other generic auth options.
+Use this generic authentication if your app or service supports passing authentication as multiple key/value query parameters or you need more flexibility than the other generic auth options.
 
 The **Custom Auth** credential expects JSON data to define your credential. You can use `headers`, `qs`, `body` or a mix. See the examples below to get started.
 
-#### Sending two headers
+### Sending two headers
 ```
 {
 	"headers": {
@@ -183,7 +171,7 @@ The **Custom Auth** credential expects JSON data to define your credential. You 
 }
 ```
 
-#### Body
+### Body
 ```
 {
 	 "body" : {
@@ -193,7 +181,7 @@ The **Custom Auth** credential expects JSON data to define your credential. You 
 }
 ```
 
-#### Query string
+### Query string
 ```
 {
 	"qs": { 
@@ -203,7 +191,7 @@ The **Custom Auth** credential expects JSON data to define your credential. You 
 }
 ```
 
-#### Sending header and query string
+### Sending header and query string
 ```
 {
 	"headers": {
@@ -217,15 +205,15 @@ The **Custom Auth** credential expects JSON data to define your credential. You 
 
 ## Provide an SSL certificate
 
-You can send an SSL certificate with your HTTP request. Create the SSL certificate as an additional credential for use by the node:
+You can send an SSL certificate with your HTTP request. Create the SSL certificate as a separate credential for use by the node:
 
 1. In the HTTP Request node **Settings**, turn on **SSL Certificates**.
 2. On the **Parameters** tab, add an existing SSL Certificate credential to **Credential for SSL Certificates** or create a new one.
 
-To configure your SSL Certificates credential, you'll need:
+To configure your SSL Certificates credential, you'll need to add:
 
 - The Certificate Authority **CA** bundle
-- The **Certificate** (CRT): May also appear as a Public Key, depending on who your issuing CA was and how the cert was formatted
+- The **Certificate** (CRT): May also appear as a Public Key, depending on who your issuing CA was and how they format the cert
 - The **Private Key** (KEY)
 - _Optional:_ If the **Private Key** is encrypted, enter a **Passphrase** for the private key.
 

--- a/docs/integrations/builtin/credentials/ollama.md
+++ b/docs/integrations/builtin/credentials/ollama.md
@@ -13,10 +13,20 @@ You can use these credentials to authenticate the following nodes:
 
 ## Prerequisites
 
-You need the base URL for your Ollama instance.
+Create and run an [Ollama](https://ollama.com/){:target=_blank .external-link} instance with one user. Refer to the Ollama [Quick Start](https://github.com/ollama/ollama/blob/main/README.md#quickstart){:target=_blank .external-link} for more information.
+
+## Supported authentication methods
+
+- Instance URL
 
 ## Related resources
 
-Refer to [Ollama's documentation](https://github.com/jmorganca/ollama/blob/main/docs/api.md){:target=_blank .external-link} for more information about the service.
+Refer to [Ollama's API documentation](https://github.com/ollama/ollama/blob/main/docs/api.md){:target=_blank .external-link} for more information about the service.
 
 --8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
+
+## Using Instance URL
+
+To configure this credential, you'll need:
+
+- The **Base URL** of your Ollama instance. The default is `http://localhost:11434`, but if you've set the `OLLAMA_HOST` environment variable, use whatever that variable is set to. Refer to [How do I configure Ollama server?](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-do-i-configure-ollama-server){:target=_blank .external-link} for more information.

--- a/docs/integrations/builtin/credentials/ollama.md
+++ b/docs/integrations/builtin/credentials/ollama.md
@@ -25,7 +25,7 @@ Refer to [Ollama's API documentation](https://github.com/ollama/ollama/blob/main
 
 --8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
 
-## Using Instance URL
+## Using instance URL
 
 To configure this credential, you'll need:
 


### PR DESCRIPTION
Summary of changes:
- Google creds: Built out the Google AI cred; the rest were very detailed, so those I just made a few tweaks to
- HTTP Request cred: Much more detailed overhaul of the available credential options plus adding SSL cert. The page is fairly long, so I'm open to ways to handle that more elegantly
- Ollama cred: Had no detail previously; added a bit, but this is a fairly simple credential to set up so there's still not a lot.
