### PR TITLE
DOC-888: Add guidance to OpenAI, Send Email, Telegram, WhatsApp credentials

### DIFF
--- a/docs/integrations/builtin/credentials/openai.md
+++ b/docs/integrations/builtin/credentials/openai.md
@@ -15,7 +15,7 @@ You can use these credentials to authenticate the following nodes:
 
 ## Prerequisites
 
-Create an [OpenAI](https://openai.com/) account.
+Create an [OpenAI](https://openai.com/){:target=_blank .external-link} account.
 
 ## Supported authentication methods
 

--- a/docs/integrations/builtin/credentials/openai.md
+++ b/docs/integrations/builtin/credentials/openai.md
@@ -6,14 +6,31 @@ contentType: integration
 
 # OpenAI credentials
 
-You can use these credentials to authenticate the following nodes with OpenAI.
+You can use these credentials to authenticate the following nodes:
 
 - [OpenAI](/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/)
 - [Chat OpenAI](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai)
 - [Embeddings OpenAI](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsopenai)
 - [LM OpenAI](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmopenai)
 
-You need an OpenAI account. OpenAI uses API keys. Log in to your account, then go to your [API keys](https://platform.openai.com/api-keys){:target=_blank .external-link} to create your key.
+## Prerequisites
 
-Once you have your key, copy it into **API Key** in the credentials modal in n8n.
+Create an [OpenAI](https://openai.com/) account.
+
+## Supported authentication methods
+
+- API key
+
+## Related resources
+
+Refer to [OpenAI's API documentation](https://platform.openai.com/docs/introduction){:target=_blank .external-link} for more information about the service.
+
+## Using API key
+
+To configure this credential, you'll need:
+
+- An **API Key**: From your OpenAI account, open the [API keys](https://platform.openai.com/api-keys){:target=_blank .external-link} page to create an API key. Refer to the [API Quickstart Account Setup documentation](https://platform.openai.com/docs/quickstart/account-setup){:target=_blank .external-link} for more information.
+- An **Organization ID**: Required if you belong to multiple organizations; otherwise, leave this blank.
+    - Go to your [Organization Settings](https://platform.openai.com/account/organization) page to get your Organization ID. Refer to [Setting up your organization](https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization) for more information.
+    - API requests made using an Organization ID will count toward the organization's subscription quota.
 

--- a/docs/integrations/builtin/credentials/sendemail.md
+++ b/docs/integrations/builtin/credentials/sendemail.md
@@ -21,7 +21,7 @@ You can use these credentials to authenticate the following nodes:
 
 ## Related resources
 
-Simple Message Transfer Protocol (SMTP) is a standard protocol for sending and receiving email. Most email providers offer instructions on setting up their service with SMTP; refer to your provider's SMTP instructions.
+Simple Message Transfer Protocol (SMTP) is a standard protocol for sending and receiving email. Most email providers offer instructions on setting up their service with SMTP. Refer to your provider's SMTP instructions.
 
 ## Using SMTP account
 

--- a/docs/integrations/builtin/credentials/sendemail.md
+++ b/docs/integrations/builtin/credentials/sendemail.md
@@ -6,16 +6,69 @@ contentType: integration
 
 # Send Email credentials
 
-You can use these credentials to authenticate the following nodes with SMTP.
+You can use these credentials to authenticate the following nodes:
 
 - [Send Email](/integrations/builtin/core-nodes/n8n-nodes-base.sendemail/)
 
 ## Prerequisites
 
-Create an email account on a service with SMTP support. 
+- Create an email account on a service that supports SMTP.
+- Some email providers require that you enable or set up outgoing SMTP or generate an app password. Refer to your provider's documentation to see if there are other required steps.
 
-## Using SMTP
+## Supported authentication methods
 
-1. Retrieve your login credentials and SMTP connection parameters.
-2. Use the login credentials and SMTP connection parameters with your Send Email node credentials in n8n.
+- SMTP account
+
+## Related resources
+
+Simple Message Transfer Protocol (SMTP) is a standard protocol for sending and receiving email. Most email providers offer instructions on setting up their service with SMTP; refer to your provider's SMTP instructions.
+
+## Using SMTP account
+
+To configure this credential, you'll need:
+
+- A **User** email address
+- A **Password**: Depending on your email provider, this may be the user's password or an app password. Refer to the documentation for your email provider.
+- The **Host**: The SMTP host address for your email provider, often formatted as `smtp.<provider>.com`. Check with your provider.
+- A **Port** number: The default is port 465, commonly used for SSL. Other common ports are 587 for TLS or 25 for no encryption. Check with your provider.
+- **SSL/TLS**: When turned on, SMTP will use SSL/TLS.
+- **Client Host Name**: If needed by your provider, add a client host name. This name identifies the client to the server.
+
+Quickstart guides to some common email providers are below.
+
+### Using Gmail
+
+To configure the SMTP credential with a Gmail account, use these settings:
+
+- **User**: Enter your Gmail email address.
+- **Password**: Generate an **App password** and use that password in the n8n credential. Refer to Google's [Sign in with app passwords documentation](https://support.google.com/accounts/answer/185833?hl=en){:target=_blank .external-link} for detailed instructions.
+- **Host**: Enter `smtp.gmail.com`.
+- **Port**: Keep the default 465 for SSL; enter `587` for TLS; or check with your email administrator.
+- **SSL/TLS**: Toggle on.
+
+Refer to the Outgoing Mail (SMTP) Server settings in [Read Gmail messages on other email clients using POP](https://support.google.com/mail/answer/7104828?hl=en){:target=_blank .external-link} for more information.
+
+### Using Yahoo Mail
+
+To configure the SMTP credential with a Yahoo Mail account, use these settings:
+
+- **User**: Enter your Yahoo email address.
+- **Password**: Generate an **App password** and use that password in the n8n credential. Refer to Yahoo's [Generate and manage 3rd-party app passwords](https://help.yahoo.com/kb/generate-manage-third-party-passwords-sln15241.html){:target=_blank .external-link} for detailed instructions.
+- **Host**: Enter `smtp.mail.yahoo.com`.
+- **Port**: Yahoo supports the default `465` and `587`; check with your email administrator.
+- **SSL/TLS**: Toggle on.
+
+Refer to [IMAP server settings for Yahoo Mail](https://help.yahoo.com/kb/sln4075.html){:target=_blank .external-link} for more information.
+
+### Using Outlook.com
+
+To configure the SMTP credential with Outlook.com account, use these settings:
+
+- **User**: Enter your Outlook.com email address.
+- **Password**: Enter your Outlook.com password. You can also use an app password, but Outlook.com doesn't require one. Refer to Outlook's [Create app passwords from the Security info (preview) page](https://support.microsoft.com/en-us/account-billing/create-app-passwords-from-the-security-info-preview-page-d8bc744a-ce3f-4d4d-89c9-eb38ab9d4137){:target=_blank .external-link} for detailed instructions.
+- **Host**: Enter `smtp-mail.outlook.com`.
+- **Port**: Enter `587`.
+- **SSL/TLS**: Toggle on.
+
+Refer to Microsoft's [POP, IMAP, and SMTP settings for Outlook.com](https://support.microsoft.com/en-us/office/pop-imap-and-smtp-settings-for-outlook-com-d088b986-291d-42b8-9564-9c414e2aa040){:target=_blank .external-link} documentation for more information.
 

--- a/docs/integrations/builtin/credentials/telegram.md
+++ b/docs/integrations/builtin/credentials/telegram.md
@@ -6,18 +6,33 @@ contentType: integration
 
 # Telegram credentials
 
-You can use these credentials to authenticate the following nodes with Telegram.
+You can use these credentials to authenticate the following nodes:
 
 - [Telegram](/integrations/builtin/app-nodes/n8n-nodes-base.telegram/)
 - [Telegram Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.telegramtrigger/)
 
 ## Prerequisites
 
-Create a [Telegram](https://telegram.org/) account.
+Create a [Telegram](https://telegram.org/){:target=_blank .external-link} account.
 
-## Using Bot Access Token
+## Supported authentication methods
 
-1. Start a chat with the [BotFather](https://telegram.me/BotFather).
+- API bot access token
+
+## Related resources
+
+Refer to [Telegram's Bot API documentation](https://core.telegram.org/bots/api){:target=_blank .external-link} for more information about the service.
+
+## Using API bot access token
+
+To configure this credential, you'll need:
+
+- A bot **Access Token**
+
+To generate your access token:
+
+1. Start a chat with the [BotFather](https://telegram.me/BotFather){:target=_blank .external-link}.
 2. Enter `/newbot` and reply with your new bot's display name and username.
-3. Copy the bot token and use it in the Telegram node credentials in n8n.
+3. Copy the bot token and add it as the **Access Token** in n8n.
 
+Refer to the [BotFather Create a new bot documentation](https://core.telegram.org/bots/features#creating-a-new-bot) for more information.

--- a/docs/integrations/builtin/credentials/whatsapp.md
+++ b/docs/integrations/builtin/credentials/whatsapp.md
@@ -13,18 +13,77 @@ You can use these credentials to authenticate the following nodes:
 
 Refer to the [WhatsApp documentation](https://developers.facebook.com/docs/whatsapp/){:target=_blank .external-link} to get your access token and business account ID.
 
-## Configuring a new app in Meta for Developers
+## Prerequisites
 
-You need an app in Meta for Developers to authenticate with WhatsApp.
+- Create a [Meta developer](https://developers.facebook.com/docs/development/register){:target=_blank .external-link} account.
+- Create a Meta [business app](https://developers.facebook.com/docs/development/create-an-app/){:target=_blank .external-link}.
+    - WhatsApp messaging services require a Meta business portfolio (formerly called a Business Manager account--the UI may still show either option). Refer to Meta's [Create a business portfolio documentation](https://www.facebook.com/business/help/1710077379203657?id=180505742745347){:target=_blank .external-link} for detailed instructions.
 
-1. Create a new app in [Meta for Developers](https://developers.facebook.com/){:target=_blank .external-link}.
-1. For **What do you want your app to do?** select **Other**.    
-1. For **App type** seelct **Business**.    
-1. Give the app a name.
-1. Select **Create app**.    
-1. In **App settings** > **Basic** set the **Privacy Policy URL** and **Terms of Service URL** for the app.    
-1. Change the **App Mode** to **Live**.    
-1. In **Add product**, add WhatsApp by selecting **Set up** in the corresponding WhatsApp box.
-1. In **WhatsApp** >  **Quickstart** select a business portfolio, then selecting **Continue**.
+See each supported authentication method below for more detailed instructions on creating the app.
 
+## Supported authentication methods
 
+- API key
+- OAuth2
+
+## Related resources
+
+Refer to [WhatsApp's API documentation](https://developers.facebook.com/docs/whatsapp/#platform-apis){:target=_blank .external-link} for more information about the service.
+
+Meta classifies users who create WhatsApp business apps as Tech Providers; refer to Meta's [Get Started for Tech Providers](https://developers.facebook.com/docs/whatsapp/cloud-api/get-started-for-tech-providers/){:target=_blank .external-link} for more information.
+
+## Using API key
+
+To configure this credential, you'll need:
+
+- An API **Access Token**
+- A **Business Account ID**
+
+To generate an access token, create a Meta app with WhatsApp as the product. To create the app:
+
+1. From the Meta for Developers [Apps dashboard](https://developers.facebook.com/apps/){:target=_blank .external-link}, select **Create App**.
+2. Select **Business**. If you don't see that option:
+    1. Select **Other**.
+    2. For **App type**, select **Business**, then select **Next**.
+3. Enter a **name** for your app.
+4. Enter a contact **email address**.
+5. Select **Create app**. Refer to [Create a Meta app](https://developers.facebook.com/docs/whatsapp/cloud-api/get-started-for-tech-providers/#step-2--create-a-meta-app){:target=_blank .external-link} for more detail on the above steps.
+6. In **Add products to your app**, select **Set up** in the WhatsApp tile. Refer to [Add the WhatsApp Product](https://developers.facebook.com/docs/whatsapp/cloud-api/get-started-for-tech-providers/#step-3--add-the-whatsapp-product){:target=_blank .external-link} for more detail.
+7. This opens the WhatsApp **Quickstart** page. Either select an existing business portfolio or create a new one.
+8. Select **Continue**.
+9. Go to **App settings** > **Basic**.
+10. Set the **Privacy Policy URL** and **Terms of Service URL** for the app.
+10. Change the **App Mode** to **Live**.
+11. Open the **API Setup** page either from the app navigation or from the **Start Using API** on the **Quickstart** page.
+12. Copy the **Temporary access token** and add it to n8n as the **Access Token**.
+13. Copy the **WhatsApp Business Account ID** and add it to n8n as the **Business Account ID**. Refer to [Test Business Messaging on WhatsApp](https://developers.facebook.com/docs/whatsapp/cloud-api/get-started-for-tech-providers/#step-4--test-business-messaging-on-whatsapp){:target=_blank .external-link} for more information on the above steps.
+
+Fully verifying and launching your app will take further configuration; refer to Meta's [Get Started for Tech Providers](https://developers.facebook.com/docs/whatsapp/cloud-api/get-started-for-tech-providers/){:target=_blank .external-link} Steps 5 and for more information.
+
+## Using OAuth2
+
+To configure this credential, you'll need:
+
+- A **Client ID**
+- A **Client Secret**
+
+To generate both, create a Meta app with WhatsApp as the product. To create the app:
+
+1. From the Meta for Developers [Apps dashboard](https://developers.facebook.com/apps/){:target=_blank .external-link}, select **Create App**.
+2. Select **Business**. If you don't see that option:
+    1. Select **Other**.
+    2. For **App type**, select **Business**, then select **Next**.
+3. Enter a **name** for your app.
+4. Enter a contact **email address**.
+5. Select **Create app**. Refer to [Create a Meta app](https://developers.facebook.com/docs/whatsapp/cloud-api/get-started-for-tech-providers/#step-2--create-a-meta-app){:target=_blank .external-link} for more detail on the above steps.
+6. In **Add products to your app**, select **Set up** in the WhatsApp tile. Refer to [Add the WhatsApp Product](https://developers.facebook.com/docs/whatsapp/cloud-api/get-started-for-tech-providers/#step-3--add-the-whatsapp-product){:target=_blank .external-link} for more detail.
+7. This opens the WhatsApp **Quickstart** page. Either select an existing business portfolio or create a new one.
+8. Select **Continue**.
+9. Go to **App settings** > **Basic**.
+10. Set the **Privacy Policy URL** and **Terms of Service URL** for the app.
+10. Change the **App Mode** to **Live**.
+11. Go to **App settings > Basic**.
+12. Copy the **App ID**. Use this as the **Client ID** within the n8n credential.
+13. Copy the **App Secret**. Use this as the **Client Secret** within the n8n credential.
+
+Fully verifying and launching your app will take further configuration; refer to Meta's [Get Started for Tech Providers](https://developers.facebook.com/docs/whatsapp/cloud-api/get-started-for-tech-providers/){:target=_blank .external-link} for more information.

--- a/docs/integrations/builtin/credentials/whatsapp.md
+++ b/docs/integrations/builtin/credentials/whatsapp.md
@@ -17,7 +17,7 @@ Refer to the [WhatsApp documentation](https://developers.facebook.com/docs/whats
 
 - Create a [Meta developer](https://developers.facebook.com/docs/development/register){:target=_blank .external-link} account.
 - Create a Meta [business app](https://developers.facebook.com/docs/development/create-an-app/){:target=_blank .external-link}.
-    - WhatsApp messaging services require a Meta business portfolio (formerly called a Business Manager account--the UI may still show either option). Refer to Meta's [Create a business portfolio documentation](https://www.facebook.com/business/help/1710077379203657?id=180505742745347){:target=_blank .external-link} for detailed instructions.
+    - WhatsApp messaging services require a Meta business portfolio (formerly called a Business Manager account. The UI may still show either option). Refer to Meta's [Create a business portfolio documentation](https://www.facebook.com/business/help/1710077379203657?id=180505742745347){:target=_blank .external-link} for detailed instructions.
 
 See each supported authentication method below for more detailed instructions on creating the app.
 


### PR DESCRIPTION
This is one piece of DOC-795, focusing on these credential nodes:
- OpenAI
- Send Email
- Telegram
- WhatsApp

The remaining nodes are fairly involved so I'll probably do one PR per node just to make review and merging easier.

Two things I'd like to call out with this PR:

1. **Send Email**: I copied the format we had with IMAP credential here, and added some quickstart guides for Gmail, Yahoo, and Outlook.com. This felt like it was a consistent way to offer more detailed guidance in the credential; let me know if that seems unwise.

2. **WhatsApp**: I struggled a bit with how detailed to make these detailed instructions, because the portion to get n8n to authenticate is just a tiny piece of configuring the Meta app overall. I focused on what was necessary to get the app configured enough to be able to complete the credentials and offered links to other things. Since Meta's UI also seems to change somewhat regularly, I tried to offer links to specific docs of theirs at different steps in the process, to try to hedge our bets against this becoming outdated within a month. Not sure if that makes the instructions too busy though.

