### PR TITLE
DOC-889: Update Slack credential to template

### DIFF
--- a/docs/integrations/builtin/credentials/slack.md
+++ b/docs/integrations/builtin/credentials/slack.md
@@ -14,88 +14,82 @@ You can use these credentials to authenticate the following nodes:
 
 ## Prerequisites
 
-Create a [Slack](https://slack.com/) account.
+- Create a [Slack](https://slack.com/){:target=_blank .external-link} account.
+- Create a Slack app. Refer to the Slack API [Quickstart](https://api.slack.com/quickstart){:target=_blank .external-link} for more information.
 
-## Using OAuth
+## Supported authentication methods
 
-/// note | Note for n8n Cloud users
-You'll only need to enter the Credentials Name and click on the circle button in the OAuth section to connect your Slack account to n8n.
-///
+- API access token
+- OAuth2
 
-1. Open the [Slack API](https://api.slack.com/) page.
-2. Click on the **Create an app** button and select **From scratch**.
-3. Enter an **App Name** in the corresponding field.
-4. **Select a workspace** for your app from the dropdown list.
-5. Click on the **Create App** button.
-6. Scroll down to the **App Credentials** section.
-7. Copy and paste **Client ID** and **Client Secret** in the corresponding fields of your n8n credentials.
-8. On the Basic Information page, navigate to **Building Apps for Slack** > **Add features and functionality** > **Permissions**.
-9. In the **Redirect URLs** section, click on **Add New Redirect URL**.
-10. Copy the **OAuth Callback URL** provided in n8n and paste it here.
-11. Click on the **Save URLs** button.
-12. Scroll down to the **Scopes** section.
-13. Add the required scopes under the **Bot Token Scopes** section. You can refer to the list of scopes on the [Scopes and permissions](https://api.slack.com/scopes){:target=_blank .external-link} documentation on Slack.
-14. Click on the circle button in the OAuth section to connect a Slack account to n8n.
-15. Click the **Save** button to save your credentials in n8n.
-16. Return to the Slack OAuth & Permissions page, scroll up to the **OAuth Tokens for Your Workspace** section and click on **Install to Workspace** button.
-17. Click on the **Allow** button.
+## Related resources
 
-### Add OAuth Scopes to a Slack app
+Refer to [Slack's API documentation](https://api.slack.com/apis){:target=_blank .external-link} for more information about the service.
 
-Your app needs appropriate scopes and permissions to perform actions. For example, if you want to create a new channel, your app requires the `channel:manage` scope. To add scopes and permissions:
+## Using API access token
 
-1. Navigate to the [Slack App dashboard](https://api.slack.com/apps){:target=_blank .external-link} page and select your app.
-2. Select **OAuth & Permissions** under the **Feature** section on the left sidebar.
-3. Scroll down to the **Scopes** section.
-4. If you're building a bot, select **Add an OAuth Scope** under the **Bot Token Scopes**.
-5. Select the permissions you want to give to your bot from the dropdown list.
-6. If you want the app to access user data and act on behalf of users that authorize them, add scopes under the **User Token Scopes**.
-7. When you add new scopes, Slack will ask you to reinstall the app. Select **Reinstall your app** on the top of the page and reinstall the app.
+To configure this credential, you'll need:
 
-Refer to the official documentation on [Scopes and permissions](https://api.slack.com/scopes){:target=_blank .external-link} to learn more.
+- An **Access Token**
 
-<!---
-The following video demonstrates the steps mentioned above.
+To generate an access token, create a Slack app:
 
-<div class="video-container">
-<iframe width="840" height="472.5" src="https://www.youtube.com/embed/ewjfY-XQ2Mo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
-
-The following video demonstrates the steps to authenticate the Slack node on [n8n.cloud](https://n8n.cloud).
-
-<div class="video-container">
-<iframe width="840" height="472.5" src="https://www.youtube.com/embed/RHhaDb1KI2o" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
---->
-
-## Using Access Token
-
-1. Open the [Slack API](https://api.slack.com/){:target=_blank .external-link} page.
-2. Select **Create an app** > **From scratch**.
+1. Open your [Slack API Apps](https://api.slack.com/apps){:target=_blank .external-link} page.
+2. Select **Create New App > From scratch**.
 3. Enter an **App Name**.
-4. **Select a workspace** for your app from the dropdown list.
+4. Select the **Workspace** where you'll be developing your app.
 5. Select **Create App**.
-6. In the **Add features and functionality** section select **Permissions**.
-7. Scroll down to the **Scopes** section:
-    * If you want your app to act on behalf of users that authorize the app, add the required scopes under the **User Token Scopes** section.
+6. In **Basic Information > Building Apps for Slack**, select **Add features and functionality**.
+7. Select **Permissions**.
+8. In the **Scopes** section:
+    * If you want your app to act on behalf of users who authorize the app, add the required scopes under the **User Token Scopes** section.
     * If you're building a bot, add the required scopes under the **Bot Token Scopes** section. 
     
     /// note | Scopes
-    You can refer to the list of scopes on the officials Slack [Scopes and permissions](https://api.slack.com/scopes){:target=_blank .external-link} documentation.
+    Scopes determine what permissions an app has. Refer to Slack's [Permission scopes](https://api.slack.com/scopes){:target=_blank .external-link} documentation for a list of scopes.
     ///
     
-8. From the **OAuth Tokens for Your Workspace** section selec **Install to Workspace**.
-9. Select**Allow**.
-10. In n8n, enter the **Access Token** created above.
-11. Select **Save** to save your credentials in n8n.
+8. After you've added scopes, go up to the **OAuth Tokens for Your Workspace** section and select **Install to Workspace**. You must be a Slack workspace admin to complete this action.
+9. Select **Allow**.
+10. You'll return to the **OAuth Tokens for your Workspace** section, which now displays a **Bot User OAuth Token**.
+10. Copy that token and enter it into the n8n credential.
 
-<!---
-The following video demonstrates the steps mentioned above.
+Refer to the Slack API [Quickstart](https://api.slack.com/quickstart){:target=_blank .external-link} for more information.
 
-<div class="video-container">
-<iframe width="840" height="472.5" src="https://www.youtube.com/embed/8x3BzKhl_ek" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
---->
+## Using OAuth2
 
+--8<-- "_snippets/integrations/builtin/credentials/cloud-oauth-button.md"
 
+If you need to configure OAuth2 from scratch, you'll need:
 
+- A **Client ID**
+- A **Client Secret**
+
+To get both, create a Slack app:
+
+1. Open your [Slack API Apps](https://api.slack.com/apps){:target=_blank .external-link} page.
+2. Select **Create New App > From scratch**.
+3. Enter an **App Name**.
+4. Select the **Workspace** where you'll be developing your app.
+5. Select **Create App**.
+6. In **Basic Information**, open the **App Credentials** section.
+7. Copy the **Client ID** and **Client Secret**. Paste these into the corresponding fields in n8n.
+6. In **Basic Information > Building Apps for Slack**, select **Add features and functionality**.
+7. Select **Permissions**.
+7. In the **Redirect URLs** section, select **Add New Redirect URL**.
+8. Copy the **OAuth Callback URL** from n8n and enter it as the new Redirect URL in Slack.
+9. Select **Add**.
+10. Select **Save URLs**.
+11. In the **Scopes** section:
+    * If you want your app to act on behalf of users who authorize the app, add the required scopes under the **User Token Scopes** section.
+    * If you're building a bot, add the required scopes under the **Bot Token Scopes** section. 
+    
+    /// note | Scopes
+    Scopes determine what permissions an app has. Refer to Slack's [Permission scopes](https://api.slack.com/scopes){:target=_blank .external-link} documentation for a list of scopes.
+    ///
+    
+13. After you've added scopes, go up to the **OAuth Tokens for Your Workspace** section and select **Install to Workspace**. You must be a Slack workspace admin to complete this action.
+14. Select **Allow**.
+15. At this point, you should be able select the OAuth button in your n8n credential to connect.
+
+Refer to the Slack API [Quickstart](https://api.slack.com/quickstart){:target=_blank .external-link} for more information. Refer to the Slack [Installing with OAuth](https://api.slack.com/authentication/oauth-v2){:target=_blank .external-link} documentation for more details on the OAuth flow itself.


### PR DESCRIPTION
Part of DOC-795; this covers only the Slack credential.

One thing of note: The existing credential had a separate section about adding scopes to apps that already exist. It appeared as a subheading in the OAuth section. I've removed it entirely because this seems to have nothing to do with n8n configuration and it was adding more length and more detailed steps to have to maintain.

Let me know if you'd like me to revive it. If we do, I believe it shouldn't be nested under OAuth and should be its own h2.