### PR TITLE
add request a built-in node page

### DIFF
--- a/docs/integrations/builtin/request-builtin-node.md
+++ b/docs/integrations/builtin/request-builtin-node.md
@@ -1,0 +1,19 @@
+---
+title: Request a built-in node
+pageType: howto
+description: How to request and submit built-in nodes for n8n. 
+---
+
+# Request a built-in node
+
+## Make a feature request
+
+The best way to request a built-in node is to post it in the n8n Community Forum. You can upvote an existing post or create a new post in the [Feature Request > Nodes category](https://community.n8n.io/c/feature-requests/nodes/){:target=_blank .external-link}.
+
+## Submit a built-in node
+
+If you've created a node you'd like to add as an official node in n8n, open a pull request on [GitHub](https://github.com/n8n-io/n8n){:target=_blank .external-link}. An n8n team member will review it. Note that new nodes take time to review and this may take some time. 
+
+## Publish a community node
+
+For a faster way to make your node available, create a community node and publish it on npm. Refer to [Building community nodes](/integrations/community-nodes/build-community-nodes/) for details. Note that these nodes are available [only for self-hosted users and not for n8n Cloud users](/choose-n8n/). 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1092,6 +1092,7 @@ nav:
         - integrations/builtin/credentials/zulip.md
       - Custom API actions for existing nodes: integrations/custom-operations.md
       - Handle rate limits: integrations/builtin/rate-limits.md
+      - Request a node: integrations/builtin/request-builtin-node.md
     - Community nodes:
       - Installation and management: 
         - integrations/community-nodes/installation/index.md


### PR DESCRIPTION
### Motivation

Users frequently reach out asking support team about the process for adding a new built-in node. This update aims to provide clearer guidance, addressing common questions before they arise.