### PR TITLE
Add Porter Cloud deployment offering to n8n docs

### DIFF
--- a/docs/hosting/installation/server-setups/index.md
+++ b/docs/hosting/installation/server-setups/index.md
@@ -6,6 +6,7 @@ contentType: overview
 
 Self-host with Docker Compose:
 
+* [Porter Cloud](/hosting/installation/server-setups/porter/)
 * [Digital Ocean](/hosting/installation/server-setups/digital-ocean/)
 * [Heroku](/hosting/installation/server-setups/heroku/)
 * [Hetzner Cloud](/hosting/installation/server-setups/hetzner/)

--- a/docs/hosting/installation/server-setups/porter.md
+++ b/docs/hosting/installation/server-setups/porter.md
@@ -1,0 +1,23 @@
+---
+contentType: tutorial
+---
+
+# Hosting n8n on Porter Cloud
+
+This hosting guide shows you how to self-host n8n on Porter Cloud. It uses n8n with Postgres as a database backend.
+
+## Prerequisites
+
+You must have a Postgres instance in order to use n8n. You can either provide the connection information of an existing instance, or provision a new one for free via the Porter Cloud Datastores offering.
+
+## Use the deploy to Porter button to one-click deploy n8n
+
+The quickest way to get started with deploying n8n to Porter Cloud is using the **Deploy to Porter** button:
+
+[![Deploy](https://mintlify.s3-us-west-1.amazonaws.com/porter/images/deploying-applications/deploy-to-porter.svg)](https://cloud.porter.run/addons/new?addon_name=quivr)
+
+After sign-up or login, you will be redirected to the n8n form, where you can specify configuration for the n8n instance you are about to deploy.
+
+## Next steps
+
+--8<-- "_snippets/self-hosting/installation/server-setups-next-steps.md"

--- a/docs/hosting/installation/server-setups/porter.md
+++ b/docs/hosting/installation/server-setups/porter.md
@@ -14,7 +14,7 @@ You must have a Postgres instance in order to use n8n. You can either provide th
 
 The quickest way to get started with deploying n8n to Porter Cloud is using the **Deploy to Porter** button:
 
-[![Deploy](https://mintlify.s3-us-west-1.amazonaws.com/porter/images/deploying-applications/deploy-to-porter.svg)](https://cloud.porter.run/addons/new?addon_name=quivr)
+[![Deploy](https://mintlify.s3-us-west-1.amazonaws.com/porter/images/deploying-applications/deploy-to-porter.svg)](https://cloud.porter.run/addons/new?addon_name=n8n)
 
 After sign-up or login, you will be redirected to the n8n form, where you can specify configuration for the n8n instance you are about to deploy.
 


### PR DESCRIPTION
Hi n8n team!

I am an engineer at Porter, and we are currently building out [Porter Cloud](https://www.porter.run/porter-cloud), which allows users to deploy several open-source projects with one-click. 

We are excited to provide n8n as our newest offering, and would love to be included in the installation documentation. If you would like to give it a try for yourself, you can navigate to [this link](https://cloud.porter.run/addons/new?addon_name=n8n), which the 'Deploy to Porter' button will redirect users to. 

We appreciate your time!