### PR TITLE
DOC-912: Standardize creds intros and other small fixes

### DIFF
--- a/docs/integrations/builtin/credentials/acuityscheduling.md
+++ b/docs/integrations/builtin/credentials/acuityscheduling.md
@@ -6,7 +6,7 @@ contentType: integration
 
 # Acuity Scheduling credentials
 
-You can use these credentials to authenticate the following nodes with Acuity Scheduling.
+You can use these credentials to authenticate the following nodes:
 
 - [Acuity Scheduling Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.acuityschedulingtrigger/)
 

--- a/docs/integrations/builtin/credentials/adalo.md
+++ b/docs/integrations/builtin/credentials/adalo.md
@@ -6,7 +6,7 @@ contentType: integration
 
 # Adalo credentials
 
-You can use these credentials to authenticate the following nodes with Adalo:
+You can use these credentials to authenticate the following nodes:
 
 - [Adalo node](/integrations/builtin/app-nodes/n8n-nodes-base.adalo/)
 

--- a/docs/integrations/builtin/credentials/affinity.md
+++ b/docs/integrations/builtin/credentials/affinity.md
@@ -6,7 +6,7 @@ contentType: integration
 
 # Affinity credentials
 
-You can use these credentials to authenticate the following nodes with Affinity.
+You can use these credentials to authenticate the following nodes:
 
 - [Affinity](/integrations/builtin/app-nodes/n8n-nodes-base.affinity/)
 - [Affinity Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.affinitytrigger/)

--- a/docs/integrations/builtin/credentials/agilecrm.md
+++ b/docs/integrations/builtin/credentials/agilecrm.md
@@ -6,7 +6,7 @@ contentType: integration
 
 # Agile CRM credentials
 
-You can use these credentials to authenticate the following nodes with Agile CRM.
+You can use these credentials to authenticate the following nodes:
 
 - [Agile CRM](/integrations/builtin/app-nodes/n8n-nodes-base.agilecrm/)
 

--- a/docs/integrations/builtin/credentials/airtable.md
+++ b/docs/integrations/builtin/credentials/airtable.md
@@ -6,7 +6,7 @@ contentType: integration
 
 # Airtable credentials
 
-You can use these credentials to authenticate the following nodes with Airtable.
+You can use these credentials to authenticate the following nodes:
 
 - [Airtable](/integrations/builtin/app-nodes/n8n-nodes-base.airtable/)
 - [Airtable Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.airtabletrigger/)

--- a/docs/integrations/builtin/credentials/alienvault.md
+++ b/docs/integrations/builtin/credentials/alienvault.md
@@ -5,7 +5,7 @@ description: Documentation for the AlienVault credentials. Use these credentials
 
 # AlienVault credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/auth0management.md
+++ b/docs/integrations/builtin/credentials/auth0management.md
@@ -5,7 +5,7 @@ description: Documentation for the Auth0 Management credentials. Use these crede
 
 # Auth0 Management credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/bitbucket.md
+++ b/docs/integrations/builtin/credentials/bitbucket.md
@@ -6,7 +6,7 @@ contentType: integration
 
 # Bitbucket credentials
 
-You can use these credentials to authenticate the following nodes with Bitbucket.
+You can use these credentials to authenticate the following nodes:
 
 - [Bitbucket Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.bitbuckettrigger/)
 

--- a/docs/integrations/builtin/credentials/cal.md
+++ b/docs/integrations/builtin/credentials/cal.md
@@ -6,7 +6,7 @@ contentType: integration
 
 # Cal credentials
 
-You can use these credentials to authenticate the following nodes with Cal.
+You can use these credentials to authenticate the following nodes:
 
 - [Cal Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.caltrigger/)
 

--- a/docs/integrations/builtin/credentials/calendly.md
+++ b/docs/integrations/builtin/credentials/calendly.md
@@ -6,7 +6,7 @@ contentType: integration
 
 # Calendly credentials
 
-You can use these credentials to authenticate the following nodes with Calendly.
+You can use these credentials to authenticate the following nodes:
 
 - [Calendly Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.calendlytrigger/)
 

--- a/docs/integrations/builtin/credentials/carbonblack.md
+++ b/docs/integrations/builtin/credentials/carbonblack.md
@@ -5,7 +5,7 @@ description: Documentation for the Carbon Black credentials. Use these credentia
 
 # Carbon Black credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/chargebee.md
+++ b/docs/integrations/builtin/credentials/chargebee.md
@@ -6,7 +6,7 @@ contentType: integration
 
 # Chargebee credentials
 
-You can use these credentials to authenticate the following nodes with Chargebee.
+You can use these credentials to authenticate the following nodes:
 
 - [Chargebee](/integrations/builtin/app-nodes/n8n-nodes-base.chargebee/)
 - [Chargebee Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.chargebeetrigger/)

--- a/docs/integrations/builtin/credentials/circleci.md
+++ b/docs/integrations/builtin/credentials/circleci.md
@@ -6,7 +6,7 @@ contentType: integration
 
 # CircleCI credentials
 
-You can use these credentials to authenticate the following nodes with CircleCI.
+You can use these credentials to authenticate the following nodes:
 
 - [CircleCI](/integrations/builtin/app-nodes/n8n-nodes-base.circleci/)
 

--- a/docs/integrations/builtin/credentials/ciscomeraki.md
+++ b/docs/integrations/builtin/credentials/ciscomeraki.md
@@ -5,7 +5,7 @@ description: Documentation for the Cisco Meraki credentials. Use these credentia
 
 # Cisco Meraki credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/ciscosecureendpoint.md
+++ b/docs/integrations/builtin/credentials/ciscosecureendpoint.md
@@ -5,7 +5,7 @@ description: Documentation for the Cisco Secure Endpoint credentials. Use these 
 
 # Cisco Secure Endpoint credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/ciscoumbrella.md
+++ b/docs/integrations/builtin/credentials/ciscoumbrella.md
@@ -5,7 +5,7 @@ description: Documentation for the Cisco Umbrella credentials. Use these credent
 
 # Cisco Umbrella credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/crowdstrike.md
+++ b/docs/integrations/builtin/credentials/crowdstrike.md
@@ -5,7 +5,7 @@ description: Documentation for the CrowdStrike credentials. Use these credential
 
 # CrowdStrike credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/elasticsearch.md
+++ b/docs/integrations/builtin/credentials/elasticsearch.md
@@ -35,6 +35,8 @@ To configure this credential, you'll need:
     2. In the **Applications** section, copy the endpoint of the **Elasticsearch** application.
     3. Add this in n8n as the **Base URL**.
 
+- **Ignore SSL Issues**: When turned on, n8n will connect even if SSL certificate validation fails.
+
 /// note | Custom endpoint aliases
 If you add a [custom endpoint alias](https://www.elastic.co/guide/en/cloud/current/ec-regional-deployment-aliases.html){:target=_blank .external-link} to a deployment, update your n8n credential **Base URL** with the new endpoint.
 ///

--- a/docs/integrations/builtin/credentials/emelia.md
+++ b/docs/integrations/builtin/credentials/emelia.md
@@ -6,7 +6,7 @@ contentType: integration
 
 # Emelia credentials
 
-You can use these credentials to authenticate the following nodes with Emelia.
+You can use these credentials to authenticate the following nodes:
 
 - [Emelia](/integrations/builtin/app-nodes/n8n-nodes-base.emelia/)
 - [Emelia Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.emeliatrigger/)

--- a/docs/integrations/builtin/credentials/f5bigip.md
+++ b/docs/integrations/builtin/credentials/f5bigip.md
@@ -5,7 +5,7 @@ description: Documentation for the F5 Big-IP credentials. Use these credentials 
 
 # F5 Big-IP credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/facebookapp.md
+++ b/docs/integrations/builtin/credentials/facebookapp.md
@@ -6,7 +6,7 @@ contentType: integration
 
 # Facebook App credentials
 
-You can use these credentials to authenticate the following nodes with Facebook.
+You can use these credentials to authenticate the following nodes:
 
 - [Facebook Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/)
 

--- a/docs/integrations/builtin/credentials/facebookgraph.md
+++ b/docs/integrations/builtin/credentials/facebookgraph.md
@@ -6,7 +6,7 @@ contentType: integration
 
 # Facebook Graph API credentials
 
-You can use these credentials to authenticate the following nodes with Facebook.
+You can use these credentials to authenticate the following nodes:
 
 - [Facebook Graph API](/integrations/builtin/app-nodes/n8n-nodes-base.facebookgraphapi/)
 

--- a/docs/integrations/builtin/credentials/fortigate.md
+++ b/docs/integrations/builtin/credentials/fortigate.md
@@ -5,7 +5,7 @@ description: Documentation for the Fortinet FortiGate credentials. Use these cre
 
 # Fortinet FortiGate credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/gumroad.md
+++ b/docs/integrations/builtin/credentials/gumroad.md
@@ -6,7 +6,7 @@ contentType: integration
 
 # Gumroad credentials
 
-You can use these credentials to authenticate the following nodes with Gumroad.
+You can use these credentials to authenticate the following nodes:
 
 - [Gumroad Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.gumroadtrigger/)
 

--- a/docs/integrations/builtin/credentials/hybridanalysis.md
+++ b/docs/integrations/builtin/credentials/hybridanalysis.md
@@ -5,7 +5,7 @@ description: Documentation for the Hybrid Analysis credentials. Use these creden
 
 # Hybrid Analysis credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/impervawaf.md
+++ b/docs/integrations/builtin/credentials/impervawaf.md
@@ -5,7 +5,7 @@ description: Documentation for the Imperva WAF credentials. Use these credential
 
 # Imperva WAF credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/kibana.md
+++ b/docs/integrations/builtin/credentials/kibana.md
@@ -5,7 +5,7 @@ description: Documentation for the Kibana credentials. Use these credentials to 
 
 # Kibana credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/mautic.md
+++ b/docs/integrations/builtin/credentials/mautic.md
@@ -6,7 +6,7 @@ contentType: integration
 
 # Mautic credentials
 
-You can use these credentials to authenticate the following nodes with Mautic.
+You can use these credentials to authenticate the following nodes:
 
 - [Mautic](/integrations/builtin/app-nodes/n8n-nodes-base.mautic/)
 - [Mautic Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.mautictrigger/)

--- a/docs/integrations/builtin/credentials/microsoftentra.md
+++ b/docs/integrations/builtin/credentials/microsoftentra.md
@@ -5,7 +5,7 @@ description: Documentation for the Microsoft Entra ID credentials. Use these cre
 
 # Microsoft Entra ID credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/mist.md
+++ b/docs/integrations/builtin/credentials/mist.md
@@ -5,7 +5,7 @@ description: Documentation for the Mist credentials. Use these credentials to au
 
 # Mist credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/okta.md
+++ b/docs/integrations/builtin/credentials/okta.md
@@ -5,7 +5,7 @@ description: Documentation for the Okta credentials. Use these credentials to au
 
 # Okta credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/opencti.md
+++ b/docs/integrations/builtin/credentials/opencti.md
@@ -5,7 +5,7 @@ description: Documentation for the OpenCTI credentials. Use these credentials to
 
 # OpenCTI credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/qradar.md
+++ b/docs/integrations/builtin/credentials/qradar.md
@@ -5,7 +5,7 @@ description: Documentation for the QRadar credentials. Use these credentials to 
 
 # QRadar credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/qualys.md
+++ b/docs/integrations/builtin/credentials/qualys.md
@@ -5,7 +5,7 @@ description: Documentation for the Qualys credentials. Use these credentials to 
 
 # Qualys credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/recordedfuture.md
+++ b/docs/integrations/builtin/credentials/recordedfuture.md
@@ -5,7 +5,7 @@ description: Documentation for the Recorded Future credentials. Use these creden
 
 # Recorded Future credentials
 
-You can use these credentials to authenticate when using the [HTTP Request node](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) to make a [Custom API call](/integrations/custom-operations/).
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
 
 ## Prerequisites
 


### PR DESCRIPTION
This PR addresses three issues:

- Standardized all creds-only credentials to use the new snippet in the intro. (Only available since my PR for S and beyond.)
- Re-reviewed some of the very early credentials I did to make the intro statement generic as the template has, instead of mentioning the product by name. I didn't start consistently doing this right away, and wanted to ensure consistency across all creds.
- Add overlooked field to Elasticsearch (I had this listed as a possible "circle back to" but I've now seen that option so many times I know what it means, so just tucked it in here).

