### PR TITLE
DOC-934: Docs SEO improvements

### DIFF
--- a/_overrides/404.html
+++ b/_overrides/404.html
@@ -6,38 +6,9 @@
 <script>
     // Create an object containing all your redirects
     const redirects = {
-      // The big key concepts split
-      "/getting-started/key-concepts/": "/flow-logic/",
-      "/getting-started/key-concepts/#expression": "/code-examples/expressions/",
-      "/getting-started/key-concepts/#item": "/data/data-structure/",
-      "/getting-started/key-concepts/#function": "/data/code/",
-      "/getting-started/key-concepts/#data": "/data/",
-      "/getting-started/key-concepts/#data-structure": "/data/data-structure/",
-      "/key-concepts/#data-flow": "/data/data-structure/",
-      "/key-concepts/#error-workflow": "/flow-logic/error-handling/error-workflows/",
-      "/key-concepts/#security": "/hosting/authentication/",
-      // Other IA redirects that seemed essential
-      "/getting-started/whats-next.html": "/quickstart/#whats-next",
-      "/getting-started/installation/advanced/server-setup.html": "/hosting/installation/server-setups/",
-			"/getting-started/installation/advanced/server-setup.html#server-setup": "/hosting/installation/server-setups/",
-      "/getting-started/installation/advanced/server-setup.html#docker-compose-example": "/hosting/installation/server-setups/docker-compose/",
-      "/reference/faq.html#integrations": "/integrations/#requesting-new-integrations-or-integration-features",
-      "/reference/faq.html": "/reference/license/",
-      "/reference/faq.html#license": "/reference/license/",
-      "/reference/faq.html#n8n-cloud": "/choose-n8n/cloud/",
-      "/nodes/expressions.html#expressions": "/code-examples/expressions/",
-      // High traffic anchor tag landing pages (if not covered by the above or by /docs/_redirects)
-      "/#what-is-n8n": "/",
-      "/getting-started/tutorials.html#blogposts": "https://n8n.io/blog/tag/tutorial/",
-      "/#/server-setup": "/hosting/installation/server-setups/",
-      "/code-examples/expressions/expressions.html": "/code-examples/expressions/",
-			// Editor UI split
-			"/editor-ui/workflows": "/workflows/",
-			"/editor-ui/credentials": "/credentials/",
-			"/editor-ui/executions": "/workflows/executions/",
-			"/editor-ui/admin-panel": "/hosting/updating/cloud/",
-			// New code node
-			"/hosting/configuration/#use-built-in-and-external-modules-in-function-nodes": "/hosting/configuration/#use-built-in-and-external-modules-in-the-code-node"
+
+
+			// Use _redirects file to set redirects
 
     };
 

--- a/_snippets/code/tournament-notes.md
+++ b/_snippets/code/tournament-notes.md
@@ -2,5 +2,5 @@
 If you have issues with expressions in 1.9.0:
    
 * Please report the issue on the [forums](https://community.n8n.io/){:target=_blank .external-link}.
-* Self-hosted users can switch back to RiotTmpl: set `N8N_EXPRESSION_EVALUATOR` to `tmpl`.  Refer to [Environment variables](/hosting/configuration/) for more information on configuring self-hosted n8n.  
+* Self-hosted users can switch back to RiotTmpl: set `N8N_EXPRESSION_EVALUATOR` to `tmpl`.  Refer to [Environment variables](/hosting/configuration/environment-variables/) for more information on configuring self-hosted n8n.  
 /// 

--- a/_snippets/integrations/builtin/core-nodes/code-node.md
+++ b/_snippets/integrations/builtin/core-nodes/code-node.md
@@ -39,7 +39,7 @@ The Code node supports:
 
 ### External libraries
 
-If you self-host n8n, you can import and use built-in and external npm modules in the Code node. To learn how to enable external modules, refer to the [Configuration Environment Variables](/hosting/configuration/environment-variables/) guide.
+If you self-host n8n, you can import and use built-in and external npm modules in the Code node. To learn how to enable external modules, refer to the [Enable modules in Code node](/hosting/configuration/configuration-examples/modules-in-code-node/) guide.
 
 If you use n8n Cloud, you can't import external npm modules. n8n makes two modules available for you:
 

--- a/_snippets/integrations/builtin/core-nodes/code-node.md
+++ b/_snippets/integrations/builtin/core-nodes/code-node.md
@@ -39,7 +39,7 @@ The Code node supports:
 
 ### External libraries
 
-If you self-host n8n, you can import and use built-in and external npm modules in the Code node. To learn how to enable external modules, refer the [Configuration](/hosting/configuration/#use-built-in-and-external-modules-in-the-code-node) guide.
+If you self-host n8n, you can import and use built-in and external npm modules in the Code node. To learn how to enable external modules, refer to the [Configuration Environment Variables](/hosting/configuration/environment-variables/) guide.
 
 If you use n8n Cloud, you can't import external npm modules. n8n makes two modules available for you:
 

--- a/_snippets/self-hosting/installation/server-setups-next-steps.md
+++ b/_snippets/self-hosting/installation/server-setups-next-steps.md
@@ -1,2 +1,2 @@
-* Learn more about [configuring](/hosting/configuration/environment-variables/) and [scaling](/hosting/scaling/) n8n.
+* Learn more about [configuring](/hosting/configuration/environment-variables/) and [scaling](/hosting/scaling/overview) n8n.
 * Or explore using n8n: try the [Quickstarts](/try-it-out/).

--- a/_snippets/self-hosting/installation/server-setups-next-steps.md
+++ b/_snippets/self-hosting/installation/server-setups-next-steps.md
@@ -1,2 +1,2 @@
-* Learn more about [configuring](/hosting/configuration/) and [scaling](/hosting/scaling/) n8n.
+* Learn more about [configuring](/hosting/configuration/environment-variables/) and [scaling](/hosting/scaling/) n8n.
 * Or explore using n8n: try the [Quickstarts](/try-it-out/).

--- a/archive/n8n-nodes-base.functionItem.md
+++ b/archive/n8n-nodes-base.functionItem.md
@@ -80,4 +80,4 @@ delete staticData.lastExecution;
 
 ## External libraries
 
-You can import and use built-in and external npm modules in the Function Item node. To learn how to enable external moduels, refer the [Configuration](/hosting/configuration/) guide.
+You can import and use built-in and external npm modules in the Function Item node. To learn how to enable external modules, refer the [Configuration](/hosting/configuration/environment-variables/) guide.

--- a/docs/1-0-migration-checklist.md
+++ b/docs/1-0-migration-checklist.md
@@ -43,7 +43,7 @@ n8n has removed support for MySQL and MariaDB as storage backends for n8n. These
 
 Previously, you could use the `EXECUTIONS_PROCESS` environment variable to specify whether executions should run in the `main` process or in their `own` processes. This option and `own` mode are now deprecated and will be removed in a future version of n8n. This is because it led to increased code complexity while offering marginal benefits. Starting from n8n 1.0, `main` will be the new default.
 
-Note that executions start much faster in `main` mode than in `own` mode. However, if a workflow consumes more memory than is available, it might crash the entire n8n application instead of just the worker thread. To mitigate this, make sure to allocate enough system resources or configure [queue mode](https://docs.n8n.io/hosting/scaling/queue-mode/) to distribute executions among multiple workers.
+Note that executions start much faster in `main` mode than in `own` mode. However, if a workflow consumes more memory than is available, it might crash the entire n8n application instead of just the worker thread. To mitigate this, make sure to allocate enough system resources or configure [queue mode](/hosting/scaling/queue-mode/) to distribute executions among multiple workers.
 
 [PR #6196](https://github.com/n8n-io/n8n/pull/6196){:target=_blank .external link}
 
@@ -122,7 +122,7 @@ If you build custom nodes, refer to [HTTP request helpers](/integrations/creatin
 
 ### Removed WEBHOOK_TUNNEL_URL
 
-As of version 0.227.0, n8n has renamed the `WEBHOOK_TUNNEL_URL` configuration option to `WEBHOOK_URL`. In n8n 1.0, `WEBHOOK_TUNNEL_URL` has been removed. Update your setup to reflect the new name. For more information about this configuration option, refer to [the docs](/hosting/configuration/configuration-methods/#webhook-url).
+As of version 0.227.0, n8n has renamed the `WEBHOOK_TUNNEL_URL` configuration option to `WEBHOOK_URL`. In n8n 1.0, `WEBHOOK_TUNNEL_URL` has been removed. Update your setup to reflect the new name. For more information about this configuration option, refer to [the docs](/hosting/configuration/configuration-examples/webhook-url/).
 
 [PR #1408](https://github.com/n8n-io/n8n/pull/1408){:target=_blank .external link}
 

--- a/docs/_redirects
+++ b/docs/_redirects
@@ -1,3 +1,43 @@
+# 2024 SEO audit
+/nodes/nodes.html    /integrations/builtin/node-types/
+/getting-started/installation/advanced/server-setup.html    /hosting/installation/server-setups/
+/getting-started/installation/advanced/server-setup.html#server-setups  /hosting/installation/server-setups/
+/getting-started/key-components.html    /workflows/
+/integrations/buil%20%20%20%20%20%20%20%20%20%20%205tin/core-nodes/n8n-nodes-base.start/    /integrations/builtin/core-nodes/n8n-nodes-base.start/
+/getting-started/create-your-first-workflow/*    /try-it-out/
+/reference/security/   /privacy-security/security/
+/reference/reference.html   /
+
+
+# Moved from 404.html
+/getting-started/key-concepts/   /flow-logic/
+/getting-started/key-concepts/#expression   /code/expressions/
+/getting-started/key-concepts/#item   /data/data-structure/
+/getting-started/key-concepts/#function   /data/code/
+/getting-started/key-concepts/#data   /data/
+/getting-started/key-concepts/#data-structure   /data/data-structure/
+/key-concepts/#data-flow   /data/data-structure/
+/key-concepts/#error-workflow   /flow-logic/error-handling/
+/key-concepts/#security   /hosting/configuration/user-management-self-hosted/
+/getting-started/whats-next.html    /try-it-out/quickstart/#next-steps
+/getting-started/installation/advanced/server-setup.html#docker-compose-examples    /hosting/installation/server-setups/docker-compose/
+/reference/faq.html#Integrations    /integrations/
+/reference/faq.html     /faircode-license/
+/reference/faq.html#License     /faircode-license/
+/reference/faq.html#n8n-cloud   /manage-cloud/overview/
+/nodes/expressions.html#expressions     /code/expressions/
+/editor-ui/workflows    /workflows/
+/editor-ui/credentials     /credentials/
+/editor-ui/executions   /workflows/executions/
+/editor-ui/admin-panel  /manage-cloud/update-cloud-version/
+/#what-is-n8n   /
+/getting-started/tutorials.html#blogposts   https://n8n.io/blog/tag/tutorial/
+/#/server-setup     /hosting/installation/server-setups/
+/code-examples/expressions/expressions.html     /code/expressions/
+/hosting/configuration/#use-built-in-and-external-modules-in-function-nodes     /hosting/configuration/configuration-examples/modules-in-code-node/
+/hosting/configuration/#use-built-in-and-external-modules-in-the-code-node      /hosting/configuration/configuration-examples/modules-in-code-node/
+
+
 /integrations/builtin/credentials/google/googlepalm/   /integrations/builtin/credentials/google/googleai/
 
 /n8n-nodes-langchain.openaiassistant.md/   /n8n-nodes-langchain.openai/
@@ -31,7 +71,7 @@
 /langchain/access-langchain/   /advanced-ai/
 
 
-/choose-n8n/cloud/   /manage-cloud/
+/choose-n8n/cloud/   /manage-cloud/overview/
 /choose-n8n/faircode-license/   /faircode-license/
 /cloud-admin-dashboard/   /manage-cloud/cloud-admin-dashboard/
 /hosting/scaling/execution-modes-processes/   /hosting/scaling/queue-mode/
@@ -137,7 +177,7 @@
 
 # License release 2022/2023
 
-/reference/license/   /choose-n8n/faircode-license/
+/reference/license/   /faircode-license/
 
 # Workflows refactor 2022
 
@@ -151,7 +191,7 @@
 # Hosting user paths 2022
 
 /hosting/options/   /choose-n8n/
-/hosting/installation/cloud/   /manage-cloud/
+/hosting/installation/cloud/   /manage-cloud/overview/
 /hosting/installation/desktop-app/   /choose-n8n/
 /hosting/server-setups/*   /hosting/installation/server-setups/:splat
 /hosting/configuration/   /hosting/configuration/environment-variables/
@@ -163,7 +203,6 @@
 /hosting/databases/structure/   /hosting/architecture/database-structure/
 /hosting/security/   /hosting/user-management/
 /hosting/user-management/   /user-management/
-/hosting/configuration/   /hosting/configuration/configuration-methods/
 
 
 # 2022 SEO audit
@@ -242,7 +281,7 @@
 # Updated during IA work
 /getting-started/key-components/                     /workflows/
 /getting-started/key-components/connection.html      /workflows/connections/
-/getting-started/key-components/editor-ui.html       /editor-ui/
+/getting-started/key-components/editor-ui.html       /
 /getting-started/key-components/node.html            /workflows/nodes/
 /getting-started/key-components/workflow.html        /workflows/workflows/
 /getting-started/key-concepts/looping.html            /flow-logic/looping/

--- a/docs/_redirects
+++ b/docs/_redirects
@@ -33,7 +33,7 @@
 /editor-ui/admin-panel  /manage-cloud/update-cloud-version/
 /#what-is-n8n   /
 /getting-started/tutorials.html#blogposts   https://n8n.io/blog/tag/tutorial/
-/#/server-setup     /hosting/installation/server-setups/
+/#server-setup     /hosting/installation/server-setups/
 /code-examples/expressions/expressions.html     /code/expressions/
 /hosting/configuration/#use-built-in-and-external-modules-in-function-nodes     /hosting/configuration/configuration-examples/modules-in-code-node/
 /hosting/configuration/#use-built-in-and-external-modules-in-the-code-node      /hosting/configuration/configuration-examples/modules-in-code-node/

--- a/docs/_redirects
+++ b/docs/_redirects
@@ -7,6 +7,7 @@
 /getting-started/create-your-first-workflow/*    /try-it-out/
 /reference/security/   /privacy-security/security/
 /reference/reference.html   /
+/integrations/builtin/core-nodes/n8n-nodes-base.executionData  /integrations/builtin/core-nodes/n8n-nodes-base.executiondata/
 
 
 # Moved from 404.html

--- a/docs/hosting/index.md
+++ b/docs/hosting/index.md
@@ -20,7 +20,7 @@ This section provides guidance on setting up n8n for both the Enterprise and Com
 
 	Learn how to configure n8n with environment variables.
 
-	[:octicons-arrow-right-24: Configuration](/hosting/configuration/configuration-methods/)
+	[:octicons-arrow-right-24: Environment Variables](/hosting/configuration/environment-variables/)
 
 - __Users and authentication__
 

--- a/docs/hosting/installation/docker.md
+++ b/docs/hosting/installation/docker.md
@@ -47,7 +47,7 @@ If no directory is found, n8n creates automatically one on
 startup. In this case, existing credentials saved with a different encryption key can not be used anymore.
 
 /// note | Keep in mind
-Persisting the `/home/node/.n8n` directory even when using alternate databases is the recommended best practice, but not explicitly required. The encryption key can be provided using the `N8N_ENCRYPTION_KEY` [environment variable](/hosting/configuration/environment-variables/deployment).
+Persisting the `/home/node/.n8n` directory even when using alternate databases is the recommended best practice, but not explicitly required. The encryption key can be provided using the `N8N_ENCRYPTION_KEY` [environment variable](/hosting/configuration/environment-variables/).
 ///
 ### PostgresDB
 

--- a/docs/hosting/installation/server-setups/aws.md
+++ b/docs/hosting/installation/server-setups/aws.md
@@ -80,7 +80,7 @@ The `postgres-deployment.yaml` manifest then uses the values from this manifest 
 
 ### Create a volume for file storage
 
-While not essential for running n8n, using persistent volumes helps maintain files uploaded while using n8n and if you want to persist [manual n8n encryption keys](https://docs.n8n.io/hosting/configuration/#encryption-key) between restarts, which saves a file containing the key into file storage during startup.
+While not essential for running n8n, using persistent volumes helps maintain files uploaded while using n8n and if you want to persist [manual n8n encryption keys](/hosting/configuration/environment-variables/) between restarts, which saves a file containing the key into file storage during startup.
 
 The `n8n-claim0-persistentvolumeclaim.yaml` manifest creates this, and the n8n Deployment mounts that claim in the `volumes` section of the `n8n-deployment.yaml` manifest.
 

--- a/docs/hosting/installation/server-setups/aws.md
+++ b/docs/hosting/installation/server-setups/aws.md
@@ -80,7 +80,7 @@ The `postgres-deployment.yaml` manifest then uses the values from this manifest 
 
 ### Create a volume for file storage
 
-While not essential for running n8n, using persistent volumes helps maintain files uploaded while using n8n and if you want to persist [manual n8n encryption keys](/hosting/configuration/environment-variables/) between restarts, which saves a file containing the key into file storage during startup.
+While not essential for running n8n, using persistent volumes helps maintain files uploaded while using n8n and if you want to persist [manual n8n encryption keys](/hosting/configuration/environment-variables/deployment/) between restarts, which saves a file containing the key into file storage during startup.
 
 The `n8n-claim0-persistentvolumeclaim.yaml` manifest creates this, and the n8n Deployment mounts that claim in the `volumes` section of the `n8n-deployment.yaml` manifest.
 

--- a/docs/hosting/installation/server-setups/azure.md
+++ b/docs/hosting/installation/server-setups/azure.md
@@ -78,7 +78,7 @@ The `postgres-deployment.yaml` manifest then uses the values from this manifest 
 While not essential for running n8n, using persistent volumes is required for:
 
 * Using nodes that interact with files, such as the binary data node.
-* If you want too persist [manual n8n encryption keys](https://docs.n8n.io/hosting/configuration/#encryption-key) between restarts. This saves a file containing the key into file storage during startup.
+* If you want to persist [manual n8n encryption keys](/hosting/configuration/environment-variables/) between restarts. This saves a file containing the key into file storage during startup.
 
 The `n8n-claim0-persistentvolumeclaim.yaml` manifest creates this, and the n8n Deployment mounts that claim in the `volumes` section of the `n8n-deployment.yaml` manifest.
 

--- a/docs/hosting/installation/server-setups/azure.md
+++ b/docs/hosting/installation/server-setups/azure.md
@@ -78,7 +78,7 @@ The `postgres-deployment.yaml` manifest then uses the values from this manifest 
 While not essential for running n8n, using persistent volumes is required for:
 
 * Using nodes that interact with files, such as the binary data node.
-* If you want to persist [manual n8n encryption keys](/hosting/configuration/environment-variables/) between restarts. This saves a file containing the key into file storage during startup.
+* If you want to persist [manual n8n encryption keys](/hosting/configuration/environment-variables/deployment/) between restarts. This saves a file containing the key into file storage during startup.
 
 The `n8n-claim0-persistentvolumeclaim.yaml` manifest creates this, and the n8n Deployment mounts that claim in the `volumes` section of the `n8n-deployment.yaml` manifest.
 

--- a/docs/hosting/installation/server-setups/google-cloud.md
+++ b/docs/hosting/installation/server-setups/google-cloud.md
@@ -90,7 +90,7 @@ The `postgres-deployment.yaml` manifest then uses the values from this manifest 
 While not essential for running n8n, using persistent volumes is required for:
 
 * Using nodes that interact with files, such as the binary data node.
-* If you want too persist [manual n8n encryption keys](https://docs.n8n.io/hosting/configuration/#encryption-key) between restarts. This saves a file containing the key into file storage during startup.
+* If you want to persist [manual n8n encryption keys](/hosting/configuration/environment-variables/) between restarts. This saves a file containing the key into file storage during startup.
 
 The `n8n-claim0-persistentvolumeclaim.yaml` manifest creates this, and the n8n Deployment mounts that claim in the `volumes` section of the `n8n-deployment.yaml` manifest.
 

--- a/docs/hosting/installation/server-setups/google-cloud.md
+++ b/docs/hosting/installation/server-setups/google-cloud.md
@@ -90,7 +90,7 @@ The `postgres-deployment.yaml` manifest then uses the values from this manifest 
 While not essential for running n8n, using persistent volumes is required for:
 
 * Using nodes that interact with files, such as the binary data node.
-* If you want to persist [manual n8n encryption keys](/hosting/configuration/environment-variables/) between restarts. This saves a file containing the key into file storage during startup.
+* If you want to persist [manual n8n encryption keys](/hosting/configuration/environment-variables/deployment/) between restarts. This saves a file containing the key into file storage during startup.
 
 The `n8n-claim0-persistentvolumeclaim.yaml` manifest creates this, and the n8n Deployment mounts that claim in the `volumes` section of the `n8n-deployment.yaml` manifest.
 

--- a/docs/hosting/installation/server-setups/heroku.md
+++ b/docs/hosting/installation/server-setups/heroku.md
@@ -30,7 +30,7 @@ Heroku pre-fills the configuration options defined in the `env` section of the `
 
 You can change any of these values to suit your needs. You must change the following values:
 
-- **N8N_ENCRYPTION_KEY**, which n8n uses to [encrypt user account details](/hosting/configuration/environment-variables/) before saving to the database.
+- **N8N_ENCRYPTION_KEY**, which n8n uses to [encrypt user account details](/hosting/configuration/environment-variables/deployment/) before saving to the database.
 - **WEBHOOK_URL** should match the application name you create to ensure that webhooks have the correct URL.
 
 ### Deploy n8n

--- a/docs/hosting/installation/server-setups/heroku.md
+++ b/docs/hosting/installation/server-setups/heroku.md
@@ -30,7 +30,7 @@ Heroku pre-fills the configuration options defined in the `env` section of the `
 
 You can change any of these values to suit your needs. You must change the following values:
 
-- **N8N_ENCRYPTION_KEY**, which n8n uses to [encrypt user account details](/hosting/configuration/#encryption-key) before saving to the database.
+- **N8N_ENCRYPTION_KEY**, which n8n uses to [encrypt user account details](/hosting/configuration/environment-variables/) before saving to the database.
 - **WEBHOOK_URL** should match the application name you create to ensure that webhooks have the correct URL.
 
 ### Deploy n8n

--- a/docs/hosting/logging-monitoring/logging.md
+++ b/docs/hosting/logging-monitoring/logging.md
@@ -11,7 +11,7 @@ n8n Self-hosted Enterprise tier includes [Log streaming](/log-streaming/), in ad
 ///
 ## Setup
 
-To set up logging in n8n, you need to set the following environment variables (you can also set the values in the [configuration file](/hosting/configuration/#configuration-via-file))
+To set up logging in n8n, you need to set the following environment variables (you can also set the values in the [configuration file](/hosting/configuration/environment-variables/))
 
 | Setting in the configuration file | Using environment variables | Description |
 |-----------------------------------|-----------------------------|-------------|

--- a/docs/hosting/scaling/queue-mode.md
+++ b/docs/hosting/scaling/queue-mode.md
@@ -38,7 +38,7 @@ Workers are n8n instances that do the actual work. They receive information from
 
 ### Set encryption key
 
-n8n automatically generates an encryption key upon first startup. You can also provide your own custom key using [environment variable](/hosting/configuration/environment-variables/deployment) if desired.
+n8n automatically generates an encryption key upon first startup. You can also provide your own custom key using [environment variable](/hosting/configuration/environment-variables/) if desired.
 
 The encryption key of the main n8n instance must be shared with all worker and webhooks processor nodes to ensure these worker nodes are able to access credentials stored in the database.
 
@@ -60,7 +60,7 @@ Set the environment variable `EXECUTIONS_MODE` to `queue` using the following co
 export EXECUTIONS_MODE=queue
 ```
 
-Alternatively, you can set `executions.mode` to `queue` in the [configuration file](/hosting/configuration/#configuration-Using-file).
+Alternatively, you can set `executions.mode` to `queue` in the [configuration file](/hosting/configuration/environment-variables/).
 
 ### Start Redis
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8088,7 +8088,7 @@ For a comprehensive list of changes, check out the [commits](https://github.com/
 - Spotify: Added Create a Playlist operation to Playlist resource and Get New Releases to the Album resource
 - Bug fixes
 - Airtable: Fixed a bug with updating and deleting records
-- Added the functionality to expose metrics to Prometheus. Read more about that [here](/hosting/configuration/#prometheus)
+- Added the functionality to expose metrics to Prometheus. Read more about that [here](/hosting/configuration/environment-variables/)
 - Updated fallback values to match the value type
 - Added the functionality to display debugging information for pending workflows on exit
 - Fixed an issue with queue mode for the executions that shouldn't be saved

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -357,7 +357,7 @@ nav:
         - integrations/builtin/core-nodes/n8n-nodes-base.executecommand.md
         - integrations/builtin/core-nodes/n8n-nodes-base.executeworkflow.md
         - integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.executionData.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.executiondata.md
         - integrations/builtin/core-nodes/n8n-nodes-base.extractfromfile.md
         - integrations/builtin/core-nodes/n8n-nodes-base.filter.md
         - integrations/builtin/core-nodes/n8n-nodes-base.ftp.md


### PR DESCRIPTION
Made these updates:

- Adjusted filename for /integrations/builtin/core-nodes/n8n-nodes-base.executionData/ to all lowercase executiondata.md, updated mkdocs.yml to include that change.
- Updated links from https://docs.n8n.io/hosting/configuration/ to /hosting/configuration/environment-variables/ in files and snippets and a general search in code base.
- Updated links from /hosting/scaling/ to /hosting/scaling/overview/ using notes in Notion and a general search in code base.
- Set up redirects for 4xx list in Notion doc.
- Moved JS redirects from 404.html to regular redirects in _redirects, also updated them to the current path for those (since many were pointing to themselves redirected URLs).