### PR TITLE
Add doc info for custom ca / self signed certs

### DIFF
--- a/docs/hosting/configuration/configuration-examples/custom-certificate-authority.md
+++ b/docs/hosting/configuration/configuration-examples/custom-certificate-authority.md
@@ -5,9 +5,13 @@ description: Customize the n8n container to work with self signed certificates w
 contentType: howto
 ---
 
-# Configure n8n to use your own certificate authority or self signed certificate
+# Configure n8n to use your own certificate authority or self-signed certificate
 
-Since version 1.42.0 it has been possible to add your own certificate authority or self signed certificate to n8n, This means you are able to trust a certain certificate instead of trusting all invalid certificates which is a potential security risk.
+You can add add your own certificate authority (CA) or self-signed certificate to n8n. This means you are able to trust a certain SSL certificate instead of trusting all invalid certificates, which is a potential security risk.
+
+/// note | Available in version 1.42.0
+This feature is only available in version 1.42.0+.
+///
 
 To use this feature you need to place your certificates in a folder and mount the folder to `/opt/custom-certificates` in the container.
 

--- a/docs/hosting/configuration/configuration-examples/custom-certificate-authority.md
+++ b/docs/hosting/configuration/configuration-examples/custom-certificate-authority.md
@@ -7,7 +7,7 @@ contentType: howto
 
 # Configure n8n to use your own certificate authority or self-signed certificate
 
-You can add add your own certificate authority (CA) or self-signed certificate to n8n. This means you are able to trust a certain SSL certificate instead of trusting all invalid certificates, which is a potential security risk.
+You can add your own certificate authority (CA) or self-signed certificate to n8n. This means you are able to trust a certain SSL certificate instead of trusting all invalid certificates, which is a potential security risk.
 
 /// note | Available in version 1.42.0
 This feature is only available in version 1.42.0+.

--- a/docs/hosting/configuration/configuration-examples/custom-certificate-authority.md
+++ b/docs/hosting/configuration/configuration-examples/custom-certificate-authority.md
@@ -1,0 +1,41 @@
+---
+#https://www.notion.so/n8n/Frontmatter-432c2b8dff1f43d4b1c8d20075510fe4
+title: Configure n8n to use your own certificate authority
+description: Customize the n8n container to work with self signed certificates when connecting to services.
+contentType: howto
+---
+
+# Configure n8n to use your own certificate authority or self signed certificate
+
+Since version 1.42.0 it has been possible to add your own certificate authority or self signed certificate to n8n, This means you are able to trust a certain certificate instead of trusting all invalid certificates which is a potential security risk.
+
+To use this feature you need to place your certificates in a folder and mount the folder to `/opt/custom-certificates` in the container.
+
+## Docker
+
+The examples below assume you have a folder called `pki` that contains your certificates in either the directory you run the command from or next to your docker compose file.
+
+### Docker CLI
+When using the CLI you can use the `-v` flag from the command line:
+
+```bash
+docker run -it --rm \
+ --name n8n \
+ -p 5678:5678 \
+ -v ./pki:/opt/custom-certificates \
+ docker.n8n.io/n8nio/n8n
+```
+
+### Docker Compose
+
+```yaml
+name: n8n
+services:
+    n8n:
+        volumes:
+            - ./pki:/opt/custom-certificates
+        container_name: n8n
+        ports:
+            - 5678:5678
+        image: docker.n8n.io/n8nio/n8n
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1194,6 +1194,7 @@ nav:
         - hosting/configuration/configuration-examples/index.md
         - Isolate n8n: hosting/configuration/configuration-examples/isolation.md
         - Configure the Base URL: hosting/configuration/configuration-examples/base-url.md
+        - Configure custom SSL certificate authorities: hosting/configuration/configuration-examples/custom-certificate-authority.md
         - Set a custom encryption key: hosting/configuration/configuration-examples/encryption-key.md
         - Configure workflow timeouts: hosting/configuration/configuration-examples/execution-timeout.md
         - Specify custom nodes location: hosting/configuration/configuration-examples/custom-nodes-location.md


### PR DESCRIPTION
Adds information on how to add self signed certificates / custom CAs to the n8n Docker image. It may need a better name.