### PR TITLE
DOC-942: Add debug info tool to the Get Help page

### DIFF
--- a/docs/help-community/help.md
+++ b/docs/help-community/help.md
@@ -32,7 +32,7 @@ If you're using an earlier version of n8n, n8n recommends manually providing thi
 
 * n8n version
 * Database
-* n8n EXECUTIONS_PROCESS setting (default: own, main)
+* n8n EXECUTIONS_PROCESS setting
 * Running n8n via (Docker, npm, n8n cloud, desktop app)
 * Operating system
 ///

--- a/docs/help-community/help.md
+++ b/docs/help-community/help.md
@@ -33,6 +33,6 @@ If you're using an earlier version of n8n, n8n recommends manually providing thi
 * n8n version
 * Database
 * n8n EXECUTIONS_PROCESS setting
-* Running n8n via (Docker, npm, n8n cloud, desktop app)
+* Running n8n via (Docker, npm, n8n cloud)
 * Operating system
 ///

--- a/docs/help-community/help.md
+++ b/docs/help-community/help.md
@@ -31,7 +31,7 @@ The **Copy debug** option is available beginning in n8n version 1.49.0.
 If you're using an earlier version of n8n, n8n recommends manually providing this information:
 
 * n8n version
-* Database (default: SQLite)
+* Database
 * n8n EXECUTIONS_PROCESS setting (default: own, main)
 * Running n8n via (Docker, npm, n8n cloud, desktop app)
 * Operating system

--- a/docs/help-community/help.md
+++ b/docs/help-community/help.md
@@ -12,4 +12,27 @@ If you need more help with n8n, you can ask for support in the [forum](https://c
 
 If your Cloud instance is having issues, or if you're an enterprise customer who needs support, you can contact [help@n8n.io](mailto:help@n8n.io).
 
+## Use the About n8n debug tool
 
+Whether you're posting to the forum or emailing customer support, you'll get help faster if you provide details about your n8n instance in your first post or email.
+
+The fastest way to do this is to use the **About n8n** debug tool:
+
+1. Open the left-side panel.
+2. Select **Help**.
+3. Select **About n8n**.
+4. The **About n8n** modal opens to display your current information.
+5. Select **Copy debug information** to copy your information.
+6. n8n recommends pasting this information into your forum post or support email.
+
+/// note | Don't see **Copy debug**?
+The **Copy debug** option is available beginning in n8n version 1.49.0.
+
+If you're using an earlier version of n8n, n8n recommends manually providing this information:
+
+* n8n version
+* Database (default: SQLite)
+* n8n EXECUTIONS_PROCESS setting (default: own, main)
+* Running n8n via (Docker, npm, n8n cloud, desktop app)
+* Operating system
+///


### PR DESCRIPTION
- Added instructions for tool
- Also added a callout with version availability and the info people would need to provide if they don't have the tool

I wasn't seeing this option in Cloud even after updating to v1.49.0 and I don't have access to the Slack thread that was referenced, so I used the notes in the Linear issue for the steps. Checking in Slack to see if there's some other step or nuance that I'm missing here, but figured I'd put the PR up for now in case there isn't.