### PR TITLE
DOC-952: Update redirects to include /reference/security.html

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -10,7 +10,7 @@
 /reference/security/   /privacy-security/security/
 /reference/reference.html   /
 /integrations/builtin/core-nodes/n8n-nodes-base.executionData  /integrations/builtin/core-nodes/n8n-nodes-base.executiondata/
-
+/reference/security.html    /privacy-security/security/ 
 
 # Moved from 404.html
 /getting-started/key-concepts/   /flow-logic/


### PR DESCRIPTION
Somehow missed this during the rest of the SEO updates.