### PR TITLE
fix typo in Wait Node Docs #Time-based operations

### DIFF
--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.wait.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.wait.md
@@ -178,5 +178,5 @@ If turned on, also set:
 
 For the time-based resume operations, note that:
 
-* For wait times less than 65 seconds, the workflow doesn't offload execution data offloaded to the database. Instead, the process continues to run and execution resumes after the specified interval passes.
+* For wait times less than 65 seconds, the workflow doesn't offload execution data to the database. Instead, the process continues to run and the execution resumes after the specified interval passes.
 * The n8n server time is always used regardless of the timezone setting. Workflow timezone settings, and any changes made to them, don't affect the Wait node interval or specified time. 


### PR DESCRIPTION
just a quick typo fix found in the Wait Node Docs
https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.wait/#time-based-operations

![image](https://github.com/user-attachments/assets/62ed2f35-6125-4d02-9da4-717c226ef0c9)

- [x] tested with `mkdocs`