### PR TITLE
Webhook & HTTP Request credentials overhaul

### DIFF
--- a/_snippets/integrations/builtin/credentials/generic-auth/basic-auth.md
+++ b/_snippets/integrations/builtin/credentials/generic-auth/basic-auth.md
@@ -1,8 +1,8 @@
 ## Using basic auth
 
-Use this generic authentications if your app or service supports basic authentication.
+Use this generic authentication if your app or service supports basic authentication.
 
-To configure this credential, you'll need:
+To configure this credential, enter:
 
 - The **Username** you use to access the app or service your HTTP Request is targeting
 - The **Password** that goes with that username

--- a/_snippets/integrations/builtin/credentials/generic-auth/basic-auth.md
+++ b/_snippets/integrations/builtin/credentials/generic-auth/basic-auth.md
@@ -1,0 +1,8 @@
+## Using basic auth
+
+Use this generic authentications if your app or service supports basic authentication.
+
+To configure this credential, you'll need:
+
+- The **Username** you use to access the app or service your HTTP Request is targeting
+- The **Password** that goes with that username

--- a/_snippets/integrations/builtin/credentials/generic-auth/digest-auth.md
+++ b/_snippets/integrations/builtin/credentials/generic-auth/digest-auth.md
@@ -1,0 +1,8 @@
+## Using digest auth
+
+Use this generic authentication if your app or service supports digest authentication.
+
+To configure this credential, you'll need:
+
+- The **Username** you use to access the app or service your HTTP Request is targeting
+- The **Password** that goes with that username

--- a/_snippets/integrations/builtin/credentials/generic-auth/digest-auth.md
+++ b/_snippets/integrations/builtin/credentials/generic-auth/digest-auth.md
@@ -2,7 +2,7 @@
 
 Use this generic authentication if your app or service supports digest authentication.
 
-To configure this credential, you'll need:
+To configure this credential, enter:
 
 - The **Username** you use to access the app or service your HTTP Request is targeting
 - The **Password** that goes with that username

--- a/_snippets/integrations/builtin/credentials/generic-auth/header-auth.md
+++ b/_snippets/integrations/builtin/credentials/generic-auth/header-auth.md
@@ -1,0 +1,14 @@
+## Using header auth
+
+Use this generic authentication if your app or service supports header authentication.
+
+To configure this credential, you'll need:
+
+- The header **Name** you need to pass to the app or service your HTTP request is targeting
+- The **Value** for the header 
+
+Read more about [HTTP headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#authentication){:target=_blank .external-link}.
+
+/// note | Credential data can vary
+The credential data required for header auth credentials depends on the type used. For example, if you need to provide an `Authorization: Bearer <token>` header, the credential data `Name` will be `Authorization` and the `Value` will be `Bearer <token>`.
+///		

--- a/_snippets/integrations/builtin/credentials/generic-auth/header-auth.md
+++ b/_snippets/integrations/builtin/credentials/generic-auth/header-auth.md
@@ -2,7 +2,7 @@
 
 Use this generic authentication if your app or service supports header authentication.
 
-To configure this credential, you'll need:
+To configure this credential, enter:
 
 - The header **Name** you need to pass to the app or service your HTTP request is targeting
 - The **Value** for the header 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.httprequest.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.httprequest.md
@@ -42,30 +42,34 @@ n8n recommends using the **Predefined Credential Type** option when it's availab
 
 #### Predefined credentials
 
-Select **Predefined Credential Type**. This allows you to perform custom operations, without additional authentication setup. For example, n8n has an Asana node, and supports using your Asana credentials in the HTTP Request node. Refer to [Custom API operations](/integrations/custom-operations/) for more information.
+These credentials are for integrations that n8n supports. This includes credentials for both built-in and community nodes available on your n8n instance. n8n provides built-in support for these authentication processes. 
+
+Select **Predefined Credential Type** to perform custom operations, without additional authentication setup. For example, n8n has an Asana node, and supports using your Asana credentials in the HTTP Request node. Refer to [Custom API operations](/integrations/custom-operations/) for more information.
 
 #### Generic credentials
 
+These credentials are for integrations that n8n doesn't support. You'll need to manually configure the authentication process, including specifying the required API endpoints, authentication method, and other necessary configurations.
+
 Select **Generic Credential Type** to set up authentication using one of the following methods:
 
-* Basic Auth
-* Custom Auth
-* Digest Auth
-* Header Auth
+* Basic auth
+* Custom auth
+* Digest auth
+* Header auth
 * OAuth1 API
 * OAuth2 API
-* Query Auth
+* Query auth
 
 
 Refer to [HTTP request credentials](/integrations/builtin/credentials/httprequest/) for more information setting up each credential type.
 
 ### Parameters, headers, and body
 
-You can choose to send additional information with your request. The data you need to send depends on the API you're interacting with, and the type of request you're making. Refer to your service's API documentation for detailed guidance.
+You can choose to send extra information with your request. The data you need to send depends on the API you're interacting with, and the request you're making. Refer to your service's API documentation for detailed guidance.
 
-* **Send Query Parameters**: include query parameters. Query parameters are usually used as filters or searches on your query.
+* **Send Query Parameters**: include query parameters. Query parameters are used as filters or searches on your query.
 * **Send Headers**: include request headers. Headers contain metadata about your request.
-* **Send Body**: send additional information in the body of your request.
+* **Send Body**: send extra information in the body of your request.
 
 ## Node options
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.httprequest.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.httprequest.md
@@ -60,7 +60,7 @@ You can select one of the following methods:
 * Query auth
 
 
-Refer to [HTTP request credentials](/integrations/builtin/credentials/httprequest/) for more information setting up each credential type.
+Refer to [HTTP request credentials](/integrations/builtin/credentials/httprequest/) for more information on setting up each credential type.
 
 ### Parameters, headers, and body
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.httprequest.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.httprequest.md
@@ -66,21 +66,21 @@ Refer to [HTTP request credentials](/integrations/builtin/credentials/httpreques
 
 You can choose to send extra information with your request. The data you need to send depends on the API you're interacting with, and the request you're making. Refer to your service's API documentation for detailed guidance.
 
-* **Send Query Parameters**: include query parameters. Use query parameters as filters or searches on your query.
-* **Send Headers**: include request headers. Headers contain metadata about your request.
-* **Send Body**: send extra information in the body of your request.
+* **Send Query Parameters**: Include query parameters. Use query parameters as filters or searches on your query.
+* **Send Headers**: Include request headers. Headers contain metadata about your request.
+* **Send Body**: Send extra information in the body of your request.
 
 ## Node options
 
 Select **Add Option** to view and select these options.
 
-- **Batching**: control how to batch large numbers of input items.
-- **Ignore SSL Issues**: download the response even if SSL validation isn't possible.
-- **Redirects**: choose whether to follow redirects. Enabled by default.
-- **Response**: provide settings about the expected API response.
-- **Pagination**: handle query results that are too big for the API to return in a single call. Refer to [Pagination](#pagination) for more information.
-- **Proxy**: use this if you need to specify an HTTP proxy.
-- **Timeout**: set a timeout for the request.
+- **Batching**: Control how to batch large numbers of input items.
+- **Ignore SSL Issues**: Download the response even if SSL certificate validation fails.
+- **Redirects**: Choose whether to follow redirects. Enabled by default.
+- **Response**: Provide settings about the expected API response.
+- **Pagination**: Handle query results that are too big for the API to return in a single call. Refer to [Pagination](#pagination) for more information.
+- **Proxy**: Use this if you need to specify an HTTP proxy.
+- **Timeout**: Set a timeout for the request in milliseconds.
 
 ### Pagination
 
@@ -99,9 +99,9 @@ Some options for pagination require knowledge of the data returned by the API yo
 Configure the pagination settings:
 
 * **Pagination Mode**:
-	* **Off**: turn off pagination.
-	* **Update a Parameter in Each Request**: use this when you need to dynamically set parameters for each request.
-	* **Response Contains Next URL**: use this when the API response includes the URL of the next page. Use an expression to set **Next URL**.
+	* **Off**: Turn off pagination.
+	* **Update a Parameter in Each Request**: Use this when you need to dynamically set parameters for each request.
+	* **Response Contains Next URL**: Use this when the API response includes the URL of the next page. Use an expression to set **Next URL**.
 
 For example setups, refer to [HTTP Request node cookbook | Pagination](/code/cookbook/http-node/pagination/).
 
@@ -130,7 +130,7 @@ Import a curl command:
 
 ## Ask AI to configure the HTTP node
 
-From version 1.40.0, you can use AI to configure the node parameters:
+From n8n version 1.40.0, you can use AI to configure the node parameters:
 
 1. Select **Ask AI**.
 1. Enter the **Service** and **Request** you want to use. For example, to use the NASA API to get their picture of the day, enter `NASA` in **Service** and `get picture of the day` in **Request**.
@@ -138,5 +138,5 @@ From version 1.40.0, you can use AI to configure the node parameters:
 
 For Cloud users, n8n provides a customized knowledge base of API specifications for the AI to draw on to provide good results. For services that aren't in the knowledge base, n8n falls back on OpenAI GPT-4's default knowledge. You can view the [list of services in the knowledge base](https://github.com/n8n-io/n8n/blob/master/packages/cli/src/services/ai/resources/api-knowledgebase.json){:target=_blank .external-link}.
 
-Self-hosted users need to [enable AI features and provide their own API keys](/hosting/configuration/environment-variables/ai/). On self-hosted you don't have access to n8n's API specifications knowledge base, so all responses from the AI use OpenAI GPT-4's default knowledge.
+Self-hosted users need to [enable AI features and provide their own API keys](/hosting/configuration/environment-variables/ai/). On self-hosted, you don't have access to n8n's API specifications knowledge base, so all responses from the AI use OpenAI GPT-4's default knowledge.
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.httprequest.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.httprequest.md
@@ -42,15 +42,14 @@ n8n recommends using the **Predefined Credential Type** option when it's availab
 
 #### Predefined credentials
 
-These credentials are for integrations that n8n supports. This includes credentials for both built-in and community nodes available on your n8n instance. n8n provides built-in support for these authentication processes. 
+Credentials for integrations supported by n8n, including both built-in and community nodes. Use **Predefined Credential Type** for custom operations without extra setup. Refer to [Custom API operations](/integrations/custom-operations/) for more information.
 
-Select **Predefined Credential Type** to perform custom operations, without additional authentication setup. For example, n8n has an Asana node, and supports using your Asana credentials in the HTTP Request node. Refer to [Custom API operations](/integrations/custom-operations/) for more information.
 
 #### Generic credentials
 
-These credentials are for integrations that n8n doesn't support. You'll need to manually configure the authentication process, including specifying the required API endpoints, authentication method, and other necessary configurations.
+Credentials for integrations not supported by n8n. You'll need to manually configure the authentication process, including specifying the required API endpoints, necessary parameters, and the authentication method. 
 
-Select **Generic Credential Type** to set up authentication using one of the following methods:
+You can select one of the following methods:
 
 * Basic auth
 * Custom auth
@@ -67,7 +66,7 @@ Refer to [HTTP request credentials](/integrations/builtin/credentials/httpreques
 
 You can choose to send extra information with your request. The data you need to send depends on the API you're interacting with, and the request you're making. Refer to your service's API documentation for detailed guidance.
 
-* **Send Query Parameters**: include query parameters. Query parameters are used as filters or searches on your query.
+* **Send Query Parameters**: include query parameters. Use query parameters as filters or searches on your query.
 * **Send Headers**: include request headers. Headers contain metadata about your request.
 * **Send Body**: send extra information in the body of your request.
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.webhook.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.webhook.md
@@ -42,7 +42,10 @@ These are the main node configuration fields.
 
 The Webhook node has two URLs: test URL and production URL. n8n displays the URLs at the top of the node panel. Select **Test URL** or **Production URL** to toggle which URL n8n displays.
 
-![Screenshot of the webhook URLs](/_images/integrations/builtin/core-nodes/webhook/webhook-urls.png)
+<figure markdown="span">
+![Sample Webhook URLs in the Webhook node's Parameters tab display a Test URL and Production URL](/_images/integrations/builtin/core-nodes/webhook/webhook-urls.png)
+<figcaption>Sample Webhook URLs in the Webhook node's Parameters tab</figcaption>
+</figure>
 
 * **Test**: n8n registers a test webhook when you select **Listen for Test Event** or **Test workflow**, if the workflow isn't active. When you call the webhook URL, n8n displays the data in the workflow.
 * **Production**: n8n registers a production webhook when you activate the workflow. When using the production URL, n8n doesn't display the data in the workflow. You can still view workflow data for a production execution: select the **Executions** tab in the workflow, then select the workflow execution you want to view.
@@ -74,7 +77,7 @@ The **Path** field can take the following formats:
 
 ### Supported authentication methods
 
-You can require authentication for any service calling your webhook URL. 
+You can require authentication for any service calling your webhook URL. Choose from these authentication methods:
 
 - Basic auth
 - Header auth

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.webhook.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.webhook.md
@@ -84,7 +84,7 @@ You can require authentication for any service calling your webhook URL. Choose 
 - JWT auth
 - None
 
-Refer to [Webhook credentials](/integrations/builtin/credentials/webhook/) for more information setting up each credential type.
+Refer to [Webhook credentials](/integrations/builtin/credentials/webhook/) for more information on setting up each credential type.
 
 ### Respond
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.webhook.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.webhook.md
@@ -72,19 +72,16 @@ The **Path** field can take the following formats:
 - `/:variable1/path/:variable2`
 - `/:variable1/:variable2`
 
-### Authentication
+### Supported authentication methods
 
-You can require authentication for any service calling your webhook URL.
+You can require authentication for any service calling your webhook URL. 
 
-* [**Basic Auth**](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication){:target=_blank .external-link}: a method of authentication where calls to the webhook URL must include the username and password in the request header. Create or select a basic auth credential for the node to use. Refer to the HTTP Request node [Using basic auth](/integrations/builtin/credentials/httprequest/#using-basic-auth-or-digest-auth) documentation for more information.
-* [**Header Auth**](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization){:target=_blank .external-link}: a method of authentication where calls to the webhook URL must include the specified header parameter. For example, use this method when you want to authenticate using an API key or an access token. Create or select a header auth credential with a name/value pair for the node to use. Refer to the HTTP Request node [Using header auth](/integrations/builtin/credentials/httprequest/#using-header-auth) documentation for more information.
-		
-    /// note | Credential data can vary
-	The **Credential Data** required for header auth credentials depends on the type used. For example, if you need to provide an `Authorization: Bearer <token>` header, the Credential Data `Name` will be `Authorization` and the `Value` will be `Bearer <token>`.
-	///		
+- Basic auth
+- Header auth
+- JWT auth
+- None
 
-* [**JWT Auth**](https://jwt.io/introduction/){:target=_blank .external-link}: a method of authentication that uses JSON Web Tokens (JWT) to digitally sign data. This authentication method uses the [JWT credential](/integrations/builtin/credentials/jwt/) and can use either a **Passphrase** or **PEM Key** key type.
-* **None**: The node won't use authentication.
+Refer to [Webhook credentials](/integrations/builtin/credentials/webhook/) for more information setting up each credential type.
 
 ### Respond
 
@@ -119,7 +116,7 @@ Select **Add Option** to view more configuration options. The available options 
 * **Raw Body**: Specify that the Webhook node will receive data in a raw format, such as JSON or XML.
 * **Response Content-Type**: Choose the format for the webhook body.
 * **Response Data**: Send custom data with the response.
-* **Response Headers**: Send additional headers in the Webhook response. Refer to [MDN Web Docs | Response header](https://developer.mozilla.org/en-US/docs/Glossary/Response_header){:target=_blank .external-link} to learn more about response headers.
+* **Response Headers**: Send extra headers in the Webhook response. Refer to [MDN Web Docs | Response header](https://developer.mozilla.org/en-US/docs/Glossary/Response_header){:target=_blank .external-link} to learn more about response headers.
 * **Property Name**: by default, n8n returns all available data. You can choose to return a specific JSON key, so that n8n returns the value.
 
 | Option | Required node configuration |

--- a/docs/integrations/builtin/credentials/httprequest.md
+++ b/docs/integrations/builtin/credentials/httprequest.md
@@ -44,25 +44,11 @@ You can use [Predefined credential types](/integrations/custom-operations/#prede
 
 Refer to [Custom API operations](/integrations/custom-operations/) for more information.
 
-## Using basic auth or digest auth
+--8<-- "_snippets/integrations/builtin/credentials/generic-auth/basic-auth.md"
 
-Use one of these generic authentications if your app or service supports basic or digest authentication.
+--8<-- "_snippets/integrations/builtin/credentials/generic-auth/digest-auth.md"
 
-To configure this credential, you'll need:
-
-- The **Username** you use to access the app or service your HTTP Request is targeting
-- The **Password** that goes with that username
-
-## Using header auth
-
-Use this generic authentication if your app or service supports header authentication.
-
-To configure this credential, you'll need:
-
-- The header **Name** you need to pass to the app or service your HTTP request is targeting
-- The **Value** for the header 
-
-Read more about [HTTP headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#authentication){:target=_blank .external-link}.
+--8<-- "_snippets/integrations/builtin/credentials/generic-auth/header-auth.md"
 
 ## Using OAuth1
 

--- a/docs/integrations/builtin/credentials/httprequest.md
+++ b/docs/integrations/builtin/credentials/httprequest.md
@@ -54,7 +54,7 @@ Refer to [Custom API operations](/integrations/custom-operations/) for more info
 
 Use this generic authentication if your app or service supports OAuth1 authentication.
 
-To configure this credential, you'll need:
+To configure this credential, enter:
 
 - An **Authorization URL**: Also known as the Resource Owner Authorization URI. This URL typically ends in `/oauth1/authorize`. The temporary credentials are sent here to prompt a user to complete authorization.
 - An **Access Token URL**: This is the URI used for the initial request for temporary credentials. This URL typically ends in `/oauth1/request` or `/oauth1/token`.
@@ -76,7 +76,7 @@ Use this generic authentication if your app or service supports OAuth2 authentic
 
 Requirements to configure this credential depend on the **Grant Type** selected. Refer to [OAuth Grant Types](https://oauth.net/2/grant-types/) for more information on each grant type.
 
-For most OAuth2 integrations, you'll need to configure an app, service, or integration to generate the values for most of these fields. Use the **OAuth Redirect URL** in n8n as the redirect URL or redirect URI for such a service.
+For most OAuth2 integrations, you'll need to configure an app, service, or integration. Use the **OAuth Redirect URL** in n8n as the redirect URL or redirect URI for such a service.
 
 Read more about [OAuth2](https://oauth.net/2/){:target=_blank .external-link}.
 
@@ -86,7 +86,7 @@ Use Authorization Code grant type to exchange an authorization code for an acces
 
 To configure this credential, select **Authorization Code** as the **Grant Type**.
 
-Then you'll need:
+Then enter:
 
 - An **Authorization URL**
 - An **Access Token URL**
@@ -95,8 +95,8 @@ Then you'll need:
 - _Optional:_ Enter one or more **Scope**s for the credential. If unspecified, the credential will request all scopes available to the client.
 - _Optional:_ Some services require more query parameters. If your service does, add them as **Auth URI Query Parameters**.
 - An **Authentication** type: Select the option that best suits your use case. Options include:
-	- **Header**: Will send the credentials as a basic auth header
-	- **Body**: Will send credentials in the body of the request
+	- **Header**: Send the credentials as a basic auth header.
+	- **Body**: Send the credentials in the body of the request.
 - _Optional:_ Choose whether to **Ignore SSL Issues**. If turned on, n8n will connect even if SSL validation fails.
 
 ### Client Credentials grant type
@@ -105,15 +105,15 @@ Use the Client Credentials grant type when applications request an access token 
 
 To configure this credential, select **Client Credentials** as the **Grant Type**.
 
-Then you'll need:
+Then enter:
 
 - An **Access Token URL**: The URL to hit to begin the OAuth2 flow. Typically this URL ends in `/token`.
 - A **Client ID**: The ID or username to use to log in to the client.
 - A **Client Secret**: The secret or password used to log in to the client.
 - _Optional:_ Enter one or more **Scope**s for the credential. Most services don't support scopes for Client Credentials grant types; only enter scopes here if yours does.
 - An **Authentication** type: Select the option that best suits your use case. Options include:
-	- **Header**: Will send the credentials as a basic auth header
-	- **Body**: Will send credentials in the body of the request
+	- **Header**: Send the credentials as a basic auth header.
+	- **Body**: Send the credentials in the body of the request.
 - _Optional:_ Choose whether to **Ignore SSL Issues**. If turned on, n8n will connect even if SSL validation fails.
 
 ### PKCE grant type
@@ -122,7 +122,7 @@ Proof Key for Code Exchange (PKCE) grant type is an extension to the Authorizati
 
 To configure this credential, select **PKCE** as the **Grant Type**.
 
-Then you'll need:
+Then enter:
 
 - An **Authorization URL**
 - An **Access Token URL**
@@ -131,15 +131,15 @@ Then you'll need:
 - _Optional:_ Enter one or more **Scope**s for the credential. If unspecified, the credential will request all scopes available to the client.
 - _Optional:_ Some services require more query parameters. If your service does, add them as **Auth URI Query Parameters**.
 - An **Authentication** type: Select the option that best suits your use case. Options include:
-	- **Header**: Will send the credentials as a basic auth header
-	- **Body**: Will send credentials in the body of the request
+	- **Header**: Send the credentials as a basic auth header.
+	- **Body**: Send the credentials in the body of the request.
 - _Optional:_ Choose whether to **Ignore SSL Issues**. If turned on, n8n will connect even if SSL validation fails.
 
 ## Using query auth
 
 Use this generic authentication if your app or service supports passing authentication as a single key/value query parameter. (For multiple query parameters, use [Custom Auth](#using-custom-auth).)
 
-To configure this credential, you'll need:
+To configure this credential, enter:
 
 - A query parameter key or **Name**
 - A query parameter **Value**
@@ -148,7 +148,7 @@ To configure this credential, you'll need:
 
 Use this generic authentication if your app or service supports passing authentication as multiple key/value query parameters or you need more flexibility than the other generic auth options.
 
-The **Custom Auth** credential expects JSON data to define your credential. You can use `headers`, `qs`, `body` or a mix. See the examples below to get started.
+The **Custom Auth** credential expects JSON data to define your credential. You can use `headers`, `qs`, `body` or a mix. Review the examples below to get started.
 
 ### Sending two headers
 ```

--- a/docs/integrations/builtin/credentials/jwt.md
+++ b/docs/integrations/builtin/credentials/jwt.md
@@ -24,20 +24,19 @@ For a more verbose introduction, refer to the [JWT website Introduction to JSON 
 
 ## Using Passphrase
 
-To configure this credential, select the **Key Type** of **Passphrase**:
+To configure this credential:
 
-- **Key Type**: **Passphrase**
-- The Passphrase **Secret**
-- Select the **Algorithm** used to sign the assertion. Refer to [Available algorithms](#available-algorithms) below for a list of supported algorithms.
+1. Select the **Key Type** of **Passphrase**.
+2. Enter the Passphrase **Secret**
+3. Select the **Algorithm** used to sign the assertion. Refer to [Available algorithms](#available-algorithms) below for a list of supported algorithms.
 
 ## Using private key (PEM key)
 
-To configure this credential, select the **Key Type** of **PEM Key**:
-
-- **Key Type**: **PEM**
-- A **Private Key**: Obtained from generating a Key Pair. Refer to [Generate RSA Key Pair](https://auth0.com/docs/secure/application-credentials/generate-rsa-key-pair){:target=_blank .external-link} for an example.
-- A **Public Key**: Obtained from generating a Key Pair. Refer to [Generate RSA Key Pair](https://auth0.com/docs/secure/application-credentials/generate-rsa-key-pair){:target=_blank .external-link} for an example.
-- Select the **Algorithm** used to sign the assertion. Refer to [Available algorithms](#available-algorithms) below for a list of supported algorithms.
+To configure this credential:
+1. Select the **Key Type** of **PEM Key**.
+2. A **Private Key**: Obtained from generating a Key Pair. Refer to [Generate RSA Key Pair](https://auth0.com/docs/secure/application-credentials/generate-rsa-key-pair){:target=_blank .external-link} for an example.
+3. A **Public Key**: Obtained from generating a Key Pair. Refer to [Generate RSA Key Pair](https://auth0.com/docs/secure/application-credentials/generate-rsa-key-pair){:target=_blank .external-link} for an example.
+4. Select the **Algorithm** used to sign the assertion. Refer to [Available algorithms](#available-algorithms) below for a list of supported algorithms.
 
 ## Available algorithms
 

--- a/docs/integrations/builtin/credentials/jwt.md
+++ b/docs/integrations/builtin/credentials/jwt.md
@@ -9,7 +9,7 @@ description: Documentation for the JWT credentials. Use these credentials to aut
 You can use these credentials to authenticate the following nodes:
 
 - [JWT](/integrations/builtin/core-nodes/n8n-nodes-base.jwt/)
-
+- [Webhook](/integrations/builtin/core-nodes/n8n-nodes-base.webhook/)
 
 ## Supported authentication methods
 

--- a/docs/integrations/builtin/credentials/webhook.md
+++ b/docs/integrations/builtin/credentials/webhook.md
@@ -1,0 +1,34 @@
+---
+#https://www.notion.so/n8n/Frontmatter-432c2b8dff1f43d4b1c8d20075510fe4
+title: Webhook credentials
+description: Documentation for Webhook credentials. Use these credentials to authenticate Webhook in n8n, a workflow automation platform.
+contentType: integration
+priority: critical
+---
+
+# Webhook credentials
+
+You can use these credentials to authenticate the following nodes:
+
+- [Webhook](/integrations/builtin/core-nodes/n8n-nodes-base.webhook/)
+
+## Prerequisites
+
+You must use the authentication method required by the app or service you want to query.
+
+## Supported authentication methods
+
+- Basic auth
+- Header auth
+- JWT auth
+- None
+
+Refer to [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication){:target=_blank .external-link} for more information relating to generic credential types.
+
+--8<-- "_snippets/integrations/builtin/credentials/generic-auth/basic-auth.md"
+
+--8<-- "_snippets/integrations/builtin/credentials/generic-auth/header-auth.md"
+
+## Using JWT auth
+
+[**JWT Auth**](https://jwt.io/introduction/){:target=_blank .external-link} is a method of authentication that uses JSON Web Tokens (JWT) to digitally sign data. This authentication method uses the **JWT credential** and can use either a **Passphrase** or **PEM Key** as key type. Refer to [JWT credential](/integrations/builtin/credentials/jwt/) for more information.

--- a/docs/integrations/builtin/credentials/webhook.md
+++ b/docs/integrations/builtin/credentials/webhook.md
@@ -23,8 +23,6 @@ You must use the authentication method required by the app or service you want t
 - JWT auth
 - None
 
-Refer to [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication){:target=_blank .external-link} for more information relating to generic credential types.
-
 --8<-- "_snippets/integrations/builtin/credentials/generic-auth/basic-auth.md"
 
 --8<-- "_snippets/integrations/builtin/credentials/generic-auth/header-auth.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1082,6 +1082,7 @@ nav:
         - integrations/builtin/credentials/vonage.md
         - integrations/builtin/credentials/ciscowebex.md
         - integrations/builtin/credentials/webflow.md
+        - integrations/builtin/credentials/webhook.md
         - integrations/builtin/credentials/wekan.md
         - integrations/builtin/credentials/whatsapp.md
         - integrations/builtin/credentials/wise.md


### PR DESCRIPTION
Changes made:
- Create a separate Webhook credential page
- Create new docs snippets for each generic_auth type 
- Update both Webhook credential and HTTP Request credential to use those snippets so that we’re consistently describing these generic auth types in both places without copying, rewriting, or cross-referencing content between them 