### PR TITLE
DOC-1004: Update FTP credential to medium tier template

### DIFF
--- a/docs/integrations/builtin/credentials/ftp.md
+++ b/docs/integrations/builtin/credentials/ftp.md
@@ -29,14 +29,7 @@ File Transfer Protocol (FTP) and Secure Shell File Transfer Protocol (SFTP) are 
 
 Use this method if your FTP server doesn't support SSH tunneling or encrypted connections.
 
-To configure this credential, you'll need:
-
-- A **Host**
-- A **Port**
-- A **Username**
-- A **Password**
-
-To set up the credential:
+To configure this credential, you'll need to:
 
 1. Enter the name or IP address of your FTP server's **Host**.
 2. Enter the **Port** number the connection should use.
@@ -49,16 +42,7 @@ Review your FTP server provider's documentation for instructions on getting the 
 
 Use this method if your FTP server supports SSH tunneling and encrypted connections.
 
-To configure this credential, you'll need:
-
-- A **Host**
-- A **Port**
-- A **Username**
-- A **Password**
-- A **Private Key**
-- A **Passphrase**
-
-To set up the credential:
+To configure this credential, you'll need to:
 
 1. Enter the name or IP address of your FTP server's **Host**.
 2. Enter the **Port** number the connection should use.

--- a/docs/integrations/builtin/credentials/ftp.md
+++ b/docs/integrations/builtin/credentials/ftp.md
@@ -18,8 +18,8 @@ Create an account on a File Transfer Protocol (FTP) server.
 
 ## Supported authentication methods
 
-- FTP account: Use this method if your FTP server doesn't support SSH tunneling or encrypted connections.
-- SFTP account: Use this method if your FTP server supports SSH tunneling and encrypted connections.
+- **FTP account**: Use this method if your FTP server doesn't support SSH tunneling or encrypted connections.
+- **SFTP account**: Use this method if your FTP server supports SSH tunneling and encrypted connections.
 
 ## Related resources
 
@@ -27,24 +27,46 @@ File Transfer Protocol (FTP) and Secure Shell File Transfer Protocol (SFTP) are 
 
 ## Using FTP account
 
+Use this method if your FTP server doesn't support SSH tunneling or encrypted connections.
+
 To configure this credential, you'll need:
 
-- A **Host**: Enter the name or IP address of your FTP server's host.
-- A **Port**: Enter the port number the connection should use.
-- A **Username**: Enter the name of the user the connection should use.
-- A **Password**: Enter the user's password.
+- A **Host**
+- A **Port**
+- A **Username**
+- A **Password**
+
+To set up the credential:
+
+1. Enter the name or IP address of your FTP server's **Host**.
+2. Enter the **Port** number the connection should use.
+3. Enter the **Username** the credential should connect as.
+4. Enter the user's **Password**.
 
 Review your FTP server provider's documentation for instructions on getting the information you need.
 
 ## Using SFTP account
 
+Use this method if your FTP server supports SSH tunneling and encrypted connections.
+
 To configure this credential, you'll need:
 
-- A **Host**: Enter the name or IP address of your FTP server's host.
-- A **Port**: Enter the port number the connection should use.
-- A **Username**: Enter the name of the user the connection should use.
-- A **Password**: Enter the user's password.
-- A **Private Key**: Enter a string for either key-based or host-based user authentication (OpenSSH format).
-- A **Passphrase**: If the **Private Key** is encrypted, enter the passphrase used to decrypt it.
+- A **Host**
+- A **Port**
+- A **Username**
+- A **Password**
+- A **Private Key**
+- A **Passphrase**
+
+To set up the credential:
+
+1. Enter the name or IP address of your FTP server's **Host**.
+2. Enter the **Port** number the connection should use.
+3. Enter the **Username** the credential should connect as.
+4. Enter the user's **Password**.
+5. For the **Private Key**, enter a string for either key-based or host-based user authentication
+    - Enter your Private Key in OpenSSH format. This is most often generated using the ssh-keygen `-o` parameter, for example: `ssh-keygen -o -a 100 -t ed25519`.
+6. If the **Private Key** is encrypted, enter the **Passphrase** used to decrypt it.
+    - If the **Private Key** doesn't use a passphrase, leave this field blank.
 
 Review your FTP server provider's documentation for instructions on getting the information you need.

--- a/docs/integrations/builtin/credentials/ftp.md
+++ b/docs/integrations/builtin/credentials/ftp.md
@@ -14,7 +14,7 @@ You can use these credentials to authenticate the following nodes:
 
 ## Prerequisites
 
-Create an account on a File Transfer Protocol (FTP) server.
+Create an account on a File Transfer Protocol (FTP) server like [OpenSSH](http://www.openssh.com/){:target=_blank .external-link} or [FileZilla Server](https://filezilla-project.org/){:target=_blank .external-link}.
 
 ## Supported authentication methods
 

--- a/docs/integrations/builtin/credentials/ftp.md
+++ b/docs/integrations/builtin/credentials/ftp.md
@@ -14,7 +14,7 @@ You can use these credentials to authenticate the following nodes:
 
 ## Prerequisites
 
-Create an account on a File Transfer Protocol (FTP) server like [OpenSSH](http://www.openssh.com/){:target=_blank .external-link} or [FileZilla Server](https://filezilla-project.org/){:target=_blank .external-link}.
+Create an account on a File Transfer Protocol (FTP) server like [JSCAPE](https://mft.jscape.com/lp/ftp-server){:target=_blank .external-link}, [OpenSSH](http://www.openssh.com/){:target=_blank .external-link}, or [FileZilla Server](https://filezilla-project.org/){:target=_blank .external-link}.
 
 ## Supported authentication methods
 


### PR DESCRIPTION
Summary of changes:

- Added examples of FTP servers.
- Removed bullet point list entirely and converted to numbered list.
- Added guidance about when to use each type into the "Using xxx" sections.
- Added an example of how to generate private key in OpenSSH format.