### PR TITLE
DOC-1011: Update Jira credentials to medium template

### DIFF
--- a/docs/integrations/builtin/credentials/jira.md
+++ b/docs/integrations/builtin/credentials/jira.md
@@ -19,8 +19,8 @@ Create a [Jira](https://www.atlassian.com/software/jira){:target=_blank .externa
 
 ## Supported authentication methods
 
-- SW Cloud API token: For use with Jira Software Cloud
-- SW Server account: For use with Jira Software Server
+- [SW Cloud API token](#using-sw-cloud-api-token): Use this method with [Jira Software Cloud](https://www.atlassian.com/software/jira){:target=_blank .external-link}.
+- [SW Server account](#using-sw-server-account): Use this method with [Jira Software Server](https://www.atlassian.com/software/jira/download.){:target=_blank .external-link}.
 
 ## Related resources
 
@@ -28,17 +28,32 @@ Refer to [Jira's API documentation](https://developer.atlassian.com/cloud/jira/p
 
 ## Using SW Cloud API token
 
-To configure this credential, you'll need:
+To configure this credential, you'll need an account on [Jira Software Cloud](https://www.atlassian.com/software/jira){:target=_blank .external-link}.
 
-- The **Email** address associated with your Jira account
-- An **API Token**: Refer to [Manage API tokens for your Atlassian account](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/){:target=_blank .external-link} for instructions to create an API token.
-- The **Domain** you access Jira on
+Then:
+
+1. Log in to your Atlassian profile > **Security > API tokens** page, or jump straight there using this [link](https://id.atlassian.com/manage-profile/security/api-tokens){:target=_blank .external-link}.
+2. Select **Create API Token**.
+3. Enter a good **Label** for your token, like `n8n integration`.
+4. Select **Create**.
+5. Copy the API token.
+6. In n8n, enter the **Email** address associated with your Jira account.
+7. Paste the API token you copied as your **API Token**.
+8. Enter the **Domain** you access Jira on, for example `https://id.atlassian.com`.
+
+Refer to [Manage API tokens for your Atlassian account](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/){:target=_blank .external-link} for more information.
+
+/// note | New tokens
+New tokens may take up to a minute before they work. If your credential verification fails the first time, wait a minute before retrying.
+///
 
 ## Using SW Server account
 
-To configure this credential, you'll need:
+To configure this credential, you'll need an account on [Jira Software Server](https://www.atlassian.com/software/jira/download.){:target=_blank .external-link}.
 
-- The **Email** address associated with your Jira account
-- A **Password** for that account
-- The **Domain** you access Jira on
+Then:
+
+1. Enter the **Email** address associated with your Jira account.
+2. Enter your Jira account **Password**.
+3. Enter the **Domain** you access Jira on.
 


### PR DESCRIPTION
- Small tweaks for readability.
- Numbered steps, including detailed steps on how to get an API token.
- Added most common cloud domain as an example.
