### PR TITLE
DOC-1009: Update Anthropic credentials to medium tier template

### DIFF
--- a/docs/integrations/builtin/credentials/anthropic.md
+++ b/docs/integrations/builtin/credentials/anthropic.md
@@ -11,10 +11,6 @@ You can use these credentials to authenticate the following nodes:
 
 - [Anthropic Chat Model](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatanthropic/)
 
-## Prerequisites
-
-[Request access to Claude](https://docs.anthropic.com/claude/docs/getting-access-to-claude){:target=_blank .external-link} from Anthropic.
-
 ## Supported authentication methods
 
 - API key
@@ -27,7 +23,14 @@ Refer to [Anthropic's documentation](https://docs.anthropic.com/claude/reference
 
 ## Using API key
 
-To configure this credential, you'll need:
+To configure this credential, you'll need an [Anthropic Console account](https://console.anthropic.com){:target=_blank .external-link} with access to Claude.
 
-- An **API Key**: Refer to the Anthropic documentation to [generate an API key](https://docs.anthropic.com/claude/docs/getting-access-to-claude#step-3-generate-an-api-key){:target=_blank .external-link}.
+Then:
 
+1. In the Anthropic Console, open **Settings >** [**API Keys**](https://console.anthropic.com/settings/keys){:target=_blank .external-link}.
+2. Select **+ Create Key**.
+3. Give your key a **Name**, like `n8n-integration`.
+4. Select **Copy Key** to copy the key.
+5. Enter this as the **API Key** in your n8n credential.
+
+Refer to Anthropic's [Intro to Claude](https://docs.anthropic.com/en/docs/intro-to-claude){:target=_blank .external-link} and [Quickstart](https://docs.anthropic.com/en/docs/quickstart){:target=_blank .external-link} for more information.


### PR DESCRIPTION
Summary of changes:

- Merged prerequisite into the Using API key section.
- Added detailed step-by-step instructions on getting the API key.
- Removed references to "getting access to Claude" since you can now just sign up for a trial account easily.