### PR TITLE
DOC-1006: Update MongoDB credentials to medium tier template

### DIFF
--- a/docs/integrations/builtin/credentials/mongodb.md
+++ b/docs/integrations/builtin/credentials/mongodb.md
@@ -57,7 +57,7 @@ To configure this credential, you'll need the [Prerequisites](#prerequisites) li
 3. Enter the **Database** name.
 4. Enter the **User** you'd like to log in as.
 5. Enter the user's **Password**.
-6. Enter the **Port** to connect over. This should be the port number your server uses to listen for incoming connections.
+6. Enter the **Port** to connect over. This is the port number your server uses to listen for incoming connections.
 7. Select whether to **Use TLS**: Turn on to use TLS. You must have your MongoDB database configured to use TLS and have an x.509 certificate generated. Add information for these certificate fields in n8n:
     - **CA Certificate**
     - **Public Client Certificate**

--- a/docs/integrations/builtin/credentials/mongodb.md
+++ b/docs/integrations/builtin/credentials/mongodb.md
@@ -30,35 +30,38 @@ Refer to the [MongoDBs Atlas documentation](https://www.mongodb.com/docs/atlas/)
 
 ## Using database connection - Connection string
 
-To configure this credential, you'll need:
+To configure this credential, you'll need the [Prerequisites](#prerequisites) listed above. Then:
 
-- Select **Connection String** as the **Configuration Type**.
-- A **Connection String**: To get your connection string in MongoDB, go to **Database > Connect**.
-    - Select **Drivers**.
-    - Copy the code you see in **Add your connection string into your application code**. It will be something like: `mongodb+srv://yourName:yourPassword@clusterName.mongodb.net/?retryWrites=true&w=majority`.
-    - Replace the `<password>` and `<username>` in the connection string with the database user's credentials you'll be using.
-    - Enter that connection string into n8n.
-    - Refer to [Connection String](https://www.mongodb.com/docs/manual/reference/connection-string/){:target=_blank .external-link} for information on finding and formatting your connection string.
-- A **Database** name: this should be the name of the database that the user whose details you added to the connection string is logging into.
-- Select whether to **Use TLS**: Turn on to use TLS. You must have your MongoDB database configured to use TLS and have an x.509 certificate generated. Refer to [MongoDB's x.509 documentation](https://www.mongodb.com/docs/manual/core/security-x.509/#std-label-client-x509-certificates-requirements) for more information. Add information for these certificate fields in n8n:
+1. Select **Connection String** as the **Configuration Type**.
+2. Enter your MongoDB **Connection String**. To get your connection string in MongoDB, go to **Database > Connect**.
+    1. Select **Drivers**.
+    2. Copy the code you see in **Add your connection string into your application code**. It will be something like: `mongodb+srv://yourName:yourPassword@clusterName.mongodb.net/?retryWrites=true&w=majority`.
+    3. Replace the `<password>` and `<username>` in the connection string with the database user's credentials you'll be using.
+    4. Enter that connection string into n8n.
+    5. Refer to [Connection String](https://www.mongodb.com/docs/manual/reference/connection-string/){:target=_blank .external-link} for information on finding and formatting your connection string.
+3. Enter your **Database** name. This is the name of the database that the user whose details you added to the connection string is logging into.
+4. Select whether to **Use TLS**: Turn on to use TLS. You must have your MongoDB database configured to use TLS and have an x.509 certificate generated. Add information for these certificate fields in n8n:
     - **CA Certificate**
     - **Public Client Certificate**
     - **Private Client Key**
     - **Passphrase**
+
+Refer to [MongoDB's x.509 documentation](https://www.mongodb.com/docs/manual/core/security-x.509/#std-label-client-x509-certificates-requirements) for more information on working with x.509 certificates.
 
 ## Using database connection - Values
 
-To configure this credential, you'll need:
+To configure this credential, you'll need the [Prerequisites](#prerequisites) listed above. Then:
 
-- Select **Values** as the **Configuration Type**.
-- The **Host** for the database
-- The **Database** name
-- A **User** ID
-- A user **Password**
-- The **Port** to connect over: This should be the port number your server uses to listen for incoming connections.
-- Select whether to **Use TLS**: Turn on to use TLS. You must have your MongoDB database configured to use TLS and have an x.509 certificate generated. Refer to [MongoDB's x.509 documentation](https://www.mongodb.com/docs/manual/core/security-x.509/#std-label-client-x509-certificates-requirements) for more information. Add information for these certificate fields in n8n:
+1. Select **Values** as the **Configuration Type**.
+2. Enter the database **Host** name or address.
+3. Enter the **Database** name.
+4. Enter the **User** you'd like to log in as.
+5. Enter the user's **Password**.
+6. Enter the **Port** to connect over. This should be the port number your server uses to listen for incoming connections.
+7. Select whether to **Use TLS**: Turn on to use TLS. You must have your MongoDB database configured to use TLS and have an x.509 certificate generated. Add information for these certificate fields in n8n:
     - **CA Certificate**
     - **Public Client Certificate**
     - **Private Client Key**
     - **Passphrase**
 
+Refer to [MongoDB's x.509 documentation](https://www.mongodb.com/docs/manual/core/security-x.509/#std-label-client-x509-certificates-requirements) for more information on working with x.509 certificates.


### PR DESCRIPTION
Opted to keep the prerequisites section since it has so much stuff in it.

Updated to use a numbered list instead of bullet points.