### PR TITLE
DOC-1018: Update HubSpot credentials to medium tier template

### DIFF
--- a/docs/integrations/builtin/credentials/hubspot.md
+++ b/docs/integrations/builtin/credentials/hubspot.md
@@ -100,7 +100,7 @@ Some HubSpot accounts don't have access to all the scopes. HubSpot is migrating 
 
 --8<-- "_snippets/integrations/builtin/credentials/cloud-oauth-button.md"
 
-If you're self-hosting n8n, you'll need to configure OAuth2 from scratch by creating a new public app:
+If you're [self-hosting](/hosting/) n8n, you'll need to configure OAuth2 from scratch by creating a new public app:
 
 1. Log into your [HubSpot app developer account](https://developers.hubspot.com/){:target=_blank .external-link}.
 2. Select **Apps** from the main navigation bar.

--- a/docs/integrations/builtin/credentials/hubspot.md
+++ b/docs/integrations/builtin/credentials/hubspot.md
@@ -13,10 +13,6 @@ You can use these credentials to authenticate the following nodes:
 - [HubSpot](/integrations/builtin/app-nodes/n8n-nodes-base.hubspot/)
 - [HubSpot Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.hubspottrigger/)
 
-## Prerequisites
-
-Create a [HubSpot](https://www.hubspot.com/){:target=_blank .external-link} account or [HubSpot developer](https://developers.hubspot.com/){:target=_blank .external-link} account.
-
 ## Supported authentication methods
 
 - App token: Used with [HubSpot](/integrations/builtin/app-nodes/n8n-nodes-base.hubspot/) node
@@ -24,7 +20,7 @@ Create a [HubSpot](https://www.hubspot.com/){:target=_blank .external-link} acco
 - OAuth2: Used with [HubSpot](/integrations/builtin/app-nodes/n8n-nodes-base.hubspot/) node
 
 /// note | API key deprecated
-HubSpot deprecated the API key authentication method. The option still appears in n8n, but you should use the other authentication methods.
+HubSpot deprecated the regular API key authentication method. The option still appears in n8n, but you should use the authentication methods listed above instead. If you have existing integrations using this API key method, refer to HubSpot's [Migrate an API key integration to a private app](https://developers.hubspot.com/docs/api/migrate-an-api-key-integration-to-a-private-app){:target=_blank .external-link} guide and set up an app token.
 ///
 
 ## Related resources
@@ -33,35 +29,68 @@ Refer to [HubSpot's API documentation](https://developers.hubspot.com/docs/api/o
 
 ## Using App token
 
-To configure this credential, you'll need:
+To configure this credential, you'll need a [HubSpot](https://www.hubspot.com/){:target=_blank .external-link} account or [HubSpot developer](https://developers.hubspot.com/){:target=_blank .external-link} account and:
 
-- An **APP Token**: To generate an app token, create a private app in HubSpot. Refer to the [HubSpot Private Apps documentation](https://developers.hubspot.com/docs/api/private-apps){:target=_blank .external-link} for detailed instructions.
+- An **App Token**
 
-Authenticating the credential can fail if you don't use appropriate scopes. See [Required scopes for HubSpot node](#required-scopes-for-hubspot-node) for required scopes for this app.
+To generate an app token, create a private app in HubSpot:
+
+1. In your HubSpot account, select the **settings icon** in the main navigation bar.
+2. In the left sidebar menu, go to **Integrations > Private Apps**.
+3. Select **Create private app**.
+4. On the **Basic Info** tab, enter your app's **Name**.
+5. Hover over the **placeholder logo** and select the upload icon to upload a square image that will serve as the logo for your app.
+6. Enter a **Description** for your app.
+7. Open the **Scopes** tab and add the appropriate scopes. Refer to [Required scopes for HubSpot node](#required-scopes-for-hubspot-node) for a complete list of scopes you should add.
+8. Select **Create app** to finish creating our app.
+9. In the modal, review the info about your app's access token, then select **Continue creating**.
+10. Once our app is created, open the **Access token card** and select **Sho token** to reveal the token.
+11. Cop this token and enter it in our n8n credential.To start making API calls, navigate to the details page of your app.
+
+Refer to the [HubSpot Private Apps documentation](https://developers.hubspot.com/docs/api/private-apps){:target=_blank .external-link} for more information.
 
 ## Using Developer API key
 
-To configure this credential, you'll need:
+To configure this credential, you'll need a [HubSpot developer](https://developers.hubspot.com/){:target=_blank .external-link} account and:
 
-- A **Client ID**: Generated once you create a public app, displayed in the app's **Auth** settings. Refer to the instructions in the [HubSpot Public Apps documentation](https://developers.hubspot.com/docs/api/creating-an-app){:target=_blank .external-link}.
-    - Use the n8n **OAuth Redirect URL** as the **Redirect URL** in your HubSpot app.
-- A **Client Secret**: Generated once you create a public app, displayed in the app's **Auth** settings.
-- A **Developer API Key**: Generated from your Developer Applications dashboard. Refer to [HubSpot Developer API keys](https://legacydocs.hubspot.com/docs/faq/developer-api-keys){:target=_blank .external-link} for more information.
-- An **App ID**: Generated once you create a public app, displayed in the app's **Auth** settings.
+- A **Client ID**: Generated once you create a public app. 
+- A **Client Secret**: Generated once you create a public app.
+- A **Developer API Key**: Generated from your Developer Apps dashboard.
+- An **App ID**: Generated once you create a public app.
 
-Authenticating the credential can fail if you don't use appropriate scopes. See [Required scopes for HubSpot Trigger node](#required-scopes-for-hubspot-trigger-node) for required scopes for this app.
+To create the public app and set up the credential:
+
+1. Log into your [HubSpot app developer account](https://developers.hubspot.com/){:target=_blank .external-link}.
+2. Select **Apps** from the main navigation bar.
+3. Select **Get HubSpot API key**. You may need to select the option to **Show key**.
+4. Copy the key and enter it in n8n as the **Developer API Key**.
+3. Still on the HubSpot **Apps** page, select **Create app**.
+4. On the **App Info** tab, add an **App name**, **Description**, **Logo**, and any support contact info you want to provide. Anyone encountering the app would see these.
+5. Open the **Auth** tab.
+6. Copy the **App ID** and enter it in n8n.
+6. Copy the **Client ID** and enter it in n8n.
+7. Copy the **Client Secret** and enter it in n8n.
+8. In the **Scopes** section, select **Add new scope**.
+9. Add all of the scopes listed in [Required scopes for HubSpot Trigger node](#required-scopes-for-hubspot-trigger-node) to your app.
+10. Select **Update**.
+11. Copy the n8n **OAuth Redirect URL** and enter it as the **Redirect URL** in your HubSpot app.
+12. Select **Create app** to finish creating the HubSpot app.
+
+ Refer to the [HubSpot Public Apps documentation](https://developers.hubspot.com/docs/api/creating-an-app){:target=_blank .external-link} for more detailed instructions.
 
 ### Required scopes for HubSpot Trigger node
 
 If you're creating an app for use with the [HubSpot Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.hubspottrigger/) node, n8n recommends starting with these scopes:
 
-* `oauth`
-* `crm.objects.companies.read`
-* `crm.objects.contacts.read`
-* `crm.objects.deals.read`
-* `crm.schemas.companies.read`
-* `crm.schemas.contacts.read`
-* `crm.schemas.deals.read`
+| **Element** | **Object** | **Permission** | **Scope name** |
+| --- | --- | --- |
+| n/a | n/a | n/a | `oauth` |
+| CRM | Companies | Read | `crm.objects.companies.read` |
+| CRM | Contacts | Read | `crm.objects.contacts.read` |
+| CRM | Deals | Read | `crm.objects.deals.read` |
+| CRM | Companies schemas | Read | `crm.schemas.companies.read` |
+| CRM | Contacts schemas | Read | `crm.schemas.contacts.read` |
+| CRM | Deals schemas| Read | `crm.schemas.deals.read` |
 
 /// warning | HubSpot old accounts
 Some HubSpot accounts don't have access to all the scopes. HubSpot is migrating accounts gradually. If you can't find all the scopes in your current HubSpot developer account, try creating a fresh developer account.
@@ -71,27 +100,40 @@ Some HubSpot accounts don't have access to all the scopes. HubSpot is migrating 
 
 --8<-- "_snippets/integrations/builtin/credentials/cloud-oauth-button.md"
 
-If you need to configure OAuth2 from scratch, you'll need to create a public app. Refer to the instructions in the [HubSpot Public Apps documentation](https://developers.hubspot.com/docs/api/creating-an-app){:target=_blank .external-link}. If you need more detail on what's happening in the OAuth web flow, refer to the [HubSpot Working with OAuth documentation](https://developers.hubspot.com/docs/api/working-with-oauth){:target=_blank .external-link}.
+If you're self-hosting n8n, you'll need to configure OAuth2 from scratch by creating a new public app:
 
-Authenticating the credential can fail if you don't use appropriate scopes. See [Required scopes for HubSpot node](#required-scopes-for-hubspot-node) for required scopes for this app.
+1. Log into your [HubSpot app developer account](https://developers.hubspot.com/){:target=_blank .external-link}.
+2. Select **Apps** from the main navigation bar.
+3. Select **Create app**.
+4. On the **App Info** tab, add an **App name**, **Description**, **Logo**, and any support contact info you want to provide. Anyone encountering the app would see these.
+5. Open the **Auth** tab.
+6. Copy the **App ID** and enter it in n8n.
+6. Copy the **Client ID** and enter it in n8n.
+7. Copy the **Client Secret** and enter it in n8n.
+8. In the **Scopes** section, select **Add new scope**.
+9. Add all of the scopes listed in [Required scopes for HubSpot node](#required-scopes-for-hubspot-node) to your app.
+10. Select **Update**.
+11. Copy the n8n **OAuth Redirect URL** and enter it as the **Redirect URL** in your HubSpot app.
+12. Select **Create app** to finish creating the HubSpot app.
+
+Refer to the [HubSpot Public Apps documentation](https://developers.hubspot.com/docs/api/creating-an-app){:target=_blank .external-link} for more detailed instructions. If you need more detail on what's happening in the OAuth web flow, refer to the [HubSpot Working with OAuth documentation](https://developers.hubspot.com/docs/api/working-with-oauth){:target=_blank .external-link}.
 
 ## Required scopes for HubSpot node
 
 If you're creating an app for use with the [HubSpot](/integrations/builtin/app-nodes/n8n-nodes-base.hubspot/) node, n8n recommends starting with these scopes:
 
-* `oauth`
-* `crm.objects.contacts.read`
-* `crm.objects.contacts.write`
-* `crm.objects.companies.read`
-* `crm.objects.companies.write`
-* `crm.objects.deals.read`
-* `crm.objects.deals.write`
-* `crm.objects.owners.read`
-* `crm.schemas.companies.read`
-* `crm.schemas.contacts.read`
-* `crm.schemas.deals.read`
-* `forms`
-* `tickets`
+| **Element** | **Object** | **Permission** | **Scope name(s)** |
+| --- | --- | --- |
+| n/a | n/a | n/a |  `oauth` |
+| n/a | n/a | n/a |  `forms` |
+| n/a | n/a | n/a |  `tickets` |
+| CRM | Companies | Read, Write | `crm.objects.companies.read` <br> `crm.objects.companies.write`|
+| CRM | Contacts | Read, Write | `crm.objects.contacts.read` <br> `crm.objects.contacts.write`|
+| CRM | Deals | Read, Write | `crm.objects.deals.read` <br> `crm.objects.deals.write`|
+| CRM | Owners | `crm.objects.owners.read` |
+| CRM | Companies schemas | Read | `crm.schemas.companies.read` |
+| CRM | Contacts schemas | Read | `crm.schemas.contacts.read` |
+| CRM | Deals schemas | Read | `crm.schemas.deals.read` |
 
 /// warning | HubSpot old accounts
 Some HubSpot accounts don't have access to all the scopes. HubSpot is migrating accounts gradually. If you can't find all the scopes in your current HubSpot developer account, try creating a fresh developer account.

--- a/docs/integrations/builtin/credentials/hubspot.md
+++ b/docs/integrations/builtin/credentials/hubspot.md
@@ -19,7 +19,7 @@ You can use these credentials to authenticate the following nodes:
 - Developer API key: Use with the [HubSpot Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.hubspottrigger/) node.
 - OAuth2: Use with the [HubSpot](/integrations/builtin/app-nodes/n8n-nodes-base.hubspot/) node.
 
-/// note | API key deprecated
+/// warning | API key deprecated
 HubSpot deprecated the regular **API Key** authentication method. The option still appears in n8n, but you should use the authentication methods listed above instead. If you have existing integrations using this API key method, refer to HubSpot's [Migrate an API key integration to a private app](https://developers.hubspot.com/docs/api/migrate-an-api-key-integration-to-a-private-app){:target=_blank .external-link} guide and set up an app token.
 ///
 

--- a/docs/integrations/builtin/credentials/hubspot.md
+++ b/docs/integrations/builtin/credentials/hubspot.md
@@ -83,7 +83,7 @@ To create the public app and set up the credential:
 If you're creating an app for use with the [HubSpot Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.hubspottrigger/) node, n8n recommends starting with these scopes:
 
 | **Element** | **Object** | **Permission** | **Scope name** |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | n/a | n/a | n/a | `oauth` |
 | CRM | Companies | Read | `crm.objects.companies.read` |
 | CRM | Contacts | Read | `crm.objects.contacts.read` |
@@ -123,7 +123,7 @@ Refer to the [HubSpot Public Apps documentation](https://developers.hubspot.com/
 If you're creating an app for use with the [HubSpot](/integrations/builtin/app-nodes/n8n-nodes-base.hubspot/) node, n8n recommends starting with these scopes:
 
 | **Element** | **Object** | **Permission** | **Scope name(s)** |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 | n/a | n/a | n/a |  `oauth` |
 | n/a | n/a | n/a |  `forms` |
 | n/a | n/a | n/a |  `tickets` |

--- a/docs/integrations/builtin/credentials/hubspot.md
+++ b/docs/integrations/builtin/credentials/hubspot.md
@@ -15,12 +15,12 @@ You can use these credentials to authenticate the following nodes:
 
 ## Supported authentication methods
 
-- App token: Used with [HubSpot](/integrations/builtin/app-nodes/n8n-nodes-base.hubspot/) node
-- Developer API key: Used with [HubSpot Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.hubspottrigger/) node
-- OAuth2: Used with [HubSpot](/integrations/builtin/app-nodes/n8n-nodes-base.hubspot/) node
+- App token: Use with the [HubSpot](/integrations/builtin/app-nodes/n8n-nodes-base.hubspot/) node.
+- Developer API key: Use with the [HubSpot Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.hubspottrigger/) node.
+- OAuth2: Use with the [HubSpot](/integrations/builtin/app-nodes/n8n-nodes-base.hubspot/) node.
 
 /// note | API key deprecated
-HubSpot deprecated the regular API key authentication method. The option still appears in n8n, but you should use the authentication methods listed above instead. If you have existing integrations using this API key method, refer to HubSpot's [Migrate an API key integration to a private app](https://developers.hubspot.com/docs/api/migrate-an-api-key-integration-to-a-private-app){:target=_blank .external-link} guide and set up an app token.
+HubSpot deprecated the regular **API Key** authentication method. The option still appears in n8n, but you should use the authentication methods listed above instead. If you have existing integrations using this API key method, refer to HubSpot's [Migrate an API key integration to a private app](https://developers.hubspot.com/docs/api/migrate-an-api-key-integration-to-a-private-app){:target=_blank .external-link} guide and set up an app token.
 ///
 
 ## Related resources
@@ -42,10 +42,10 @@ To generate an app token, create a private app in HubSpot:
 5. Hover over the **placeholder logo** and select the upload icon to upload a square image that will serve as the logo for your app.
 6. Enter a **Description** for your app.
 7. Open the **Scopes** tab and add the appropriate scopes. Refer to [Required scopes for HubSpot node](#required-scopes-for-hubspot-node) for a complete list of scopes you should add.
-8. Select **Create app** to finish creating our app.
+8. Select **Create app** to finish the process.
 9. In the modal, review the info about your app's access token, then select **Continue creating**.
-10. Once our app is created, open the **Access token card** and select **Sho token** to reveal the token.
-11. Cop this token and enter it in our n8n credential.To start making API calls, navigate to the details page of your app.
+10. Once your app's created, open the **Access token card** and select **Show token** to reveal the token.
+11. Copy this token and enter it in your n8n credential.
 
 Refer to the [HubSpot Private Apps documentation](https://developers.hubspot.com/docs/api/private-apps){:target=_blank .external-link} for more information.
 
@@ -71,7 +71,7 @@ To create the public app and set up the credential:
 6. Copy the **Client ID** and enter it in n8n.
 7. Copy the **Client Secret** and enter it in n8n.
 8. In the **Scopes** section, select **Add new scope**.
-9. Add all of the scopes listed in [Required scopes for HubSpot Trigger node](#required-scopes-for-hubspot-trigger-node) to your app.
+9. Add all the scopes listed in [Required scopes for HubSpot Trigger node](#required-scopes-for-hubspot-trigger-node) to your app.
 10. Select **Update**.
 11. Copy the n8n **OAuth Redirect URL** and enter it as the **Redirect URL** in your HubSpot app.
 12. Select **Create app** to finish creating the HubSpot app.
@@ -111,7 +111,7 @@ If you're self-hosting n8n, you'll need to configure OAuth2 from scratch by crea
 6. Copy the **Client ID** and enter it in n8n.
 7. Copy the **Client Secret** and enter it in n8n.
 8. In the **Scopes** section, select **Add new scope**.
-9. Add all of the scopes listed in [Required scopes for HubSpot node](#required-scopes-for-hubspot-node) to your app.
+9. Add all the scopes listed in [Required scopes for HubSpot node](#required-scopes-for-hubspot-node) to your app.
 10. Select **Update**.
 11. Copy the n8n **OAuth Redirect URL** and enter it as the **Redirect URL** in your HubSpot app.
 12. Select **Create app** to finish creating the HubSpot app.

--- a/docs/integrations/builtin/credentials/hubspot.md
+++ b/docs/integrations/builtin/credentials/hubspot.md
@@ -86,10 +86,10 @@ If you're creating an app for use with the [HubSpot Trigger](/integrations/built
 | --- | --- | --- | --- |
 | n/a | n/a | n/a | `oauth` |
 | CRM | Companies | Read | `crm.objects.companies.read` |
-| CRM | Contacts | Read | `crm.objects.contacts.read` |
-| CRM | Deals | Read | `crm.objects.deals.read` |
 | CRM | Companies schemas | Read | `crm.schemas.companies.read` |
+| CRM | Contacts | Read | `crm.objects.contacts.read` |
 | CRM | Contacts schemas | Read | `crm.schemas.contacts.read` |
+| CRM | Deals | Read | `crm.objects.deals.read` |
 | CRM | Deals schemas| Read | `crm.schemas.deals.read` |
 
 /// warning | HubSpot old accounts
@@ -127,13 +127,13 @@ If you're creating an app for use with the [HubSpot](/integrations/builtin/app-n
 | n/a | n/a | n/a |  `oauth` |
 | n/a | n/a | n/a |  `forms` |
 | n/a | n/a | n/a |  `tickets` |
-| CRM | Companies | Read, Write | `crm.objects.companies.read` <br> `crm.objects.companies.write`|
-| CRM | Contacts | Read, Write | `crm.objects.contacts.read` <br> `crm.objects.contacts.write`|
-| CRM | Deals | Read, Write | `crm.objects.deals.read` <br> `crm.objects.deals.write`|
-| CRM | Owners | `crm.objects.owners.read` |
+| CRM | Companies | Read <br> Write | `crm.objects.companies.read` <br> `crm.objects.companies.write`|
 | CRM | Companies schemas | Read | `crm.schemas.companies.read` |
 | CRM | Contacts schemas | Read | `crm.schemas.contacts.read` |
+| CRM | Contacts | Read <br> Write | `crm.objects.contacts.read` <br> `crm.objects.contacts.write`|
+| CRM | Deals | Read <br> Write | `crm.objects.deals.read` <br> `crm.objects.deals.write`|
 | CRM | Deals schemas | Read | `crm.schemas.deals.read` |
+| CRM | Owners | Read | `crm.objects.owners.read` |
 
 /// warning | HubSpot old accounts
 Some HubSpot accounts don't have access to all the scopes. HubSpot is migrating accounts gradually. If you can't find all the scopes in your current HubSpot developer account, try creating a fresh developer account.


### PR DESCRIPTION
Summary of changes:

- Convert high-level bullet point lists to more detailed numbered lists.
- Convert scopes lists to tables.
- Add link to migration guide for deprecated API key method.