### PR TITLE
New Node: Add okta node doc and update okta credential doc

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.okta.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.okta.md
@@ -1,0 +1,37 @@
+---
+#https://www.notion.so/n8n/Frontmatter-432c2b8dff1f43d4b1c8d20075510fe4
+title: Okta
+description: Documentation for the Okta node in n8n, a workflow automation platform. Includes details of operations and configuration, and links to examples and credentials information.
+contentType: integration
+---
+
+# Okta
+
+Use the Okta node to automate work in Okta and integrate Okta with other applications. n8n has built-in support for a wide range of Okta features, which includes creating, updating, and deleting users.
+
+On this page, you'll find a list of operations the Okta node supports, and links to more resources.
+
+///  note  | Credentials
+You can find authentication information for this node [here](/integrations/builtin/credentials/okta/).
+///
+
+## Operations
+
+- User
+    - Create a new user
+    - Delete an existing user
+    - Get details of a user
+    - Get many users
+    - Update an existing user
+
+## Templates and examples
+
+<!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->
+[[ templatesWidget(title, okta) ]]
+
+## Related resources
+
+<!-- add a link to the service's documentation. This should usually go direct to the API docs -->
+Refer to [Okta's documentation](https://developer.okta.com/docs/guides/){:target=_blank .external-link} for more information about the service.
+
+--8<-- "_snippets/integrations/builtin/app-nodes/operation-not-supported.md"

--- a/docs/integrations/builtin/credentials/okta.md
+++ b/docs/integrations/builtin/credentials/okta.md
@@ -7,7 +7,9 @@ contentType: integration
 
 # Okta credentials
 
---8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
+You can use these credentials to authenticate the following nodes:
+
+- [Okta](/integrations/builtin/app-nodes/n8n-nodes-base.okta/)
 
 ## Prerequisites
 
@@ -20,8 +22,6 @@ Create an [Okta free trial](https://www.okta.com/free-trial/){:target=_blank .ex
 ## Related resources
 
 Refer to [Okta's documentation](https://developer.okta.com/docs/reference/){:target=_blank .external-link} for more information about the service.
-
-This is a credential-only node. Refer to [Custom API operations](/integrations/custom-operations/) to learn more. View [example workflows and related content](https://n8n.io/integrations/okta/){:target=_blank .external-link} on n8n's website.
 
 ## Using SSWS API access token
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -570,6 +570,7 @@ nav:
         - integrations/builtin/app-nodes/n8n-nodes-base.notion.md
         - integrations/builtin/app-nodes/n8n-nodes-base.npm.md
         - integrations/builtin/app-nodes/n8n-nodes-base.odoo.md
+        - integrations/builtin/app-nodes/n8n-nodes-base.okta.md
         - integrations/builtin/app-nodes/n8n-nodes-base.onesimpleapi.md
         - integrations/builtin/app-nodes/n8n-nodes-base.onfleet.md
         - integrations/builtin/app-nodes/n8n-nodes-langchain.openai.md


### PR DESCRIPTION
Related PR: https://github.com/n8n-io/n8n/pull/10278

### Changes
- Add app-node page for Okta (previously only available as a credential node) 
- Update the Okta credential page to link to the new node doc

Note: Node tier was unclear so used the app-node template and kept it minimal for now. 