### PR TITLE
DOC-1033: Create starter kits section in self-hosting and add AI starter kit

### DIFF
--- a/_snippets/self-hosting/starter-kits/self-hosted-ai-starter-kit.md
+++ b/_snippets/self-hosting/starter-kits/self-hosted-ai-starter-kit.md
@@ -1,3 +1,3 @@
 ## Self-hosted AI Starter Kit
 
-New to working with AI and using self-hosted n8n? Try n8n's [self-hosted AI Starter Kit](/hosting/starter-kits/ai-starter-kit/) to get started with a proof-of-concept or demo playground.
+New to working with AI and using self-hosted n8n? Try n8n's [self-hosted AI Starter Kit](/hosting/starter-kits/ai-starter-kit/) to get started with a proof-of-concept or demo playground using Ollama, Qdrant, and PostgreSQL.

--- a/_snippets/self-hosting/starter-kits/self-hosted-ai-starter-kit.md
+++ b/_snippets/self-hosting/starter-kits/self-hosted-ai-starter-kit.md
@@ -1,0 +1,3 @@
+## Self-hosted AI Starter Kit
+
+New to working with AI and using self-hosted n8n? Try n8n's [self-hosted AI Starter Kit](/hosting/starter-kits/ai-starter-kit/) to get started with a proof-of-concept or demo playground.

--- a/docs/advanced-ai/index.md
+++ b/docs/advanced-ai/index.md
@@ -21,12 +21,17 @@ This feature is available on Cloud and self-hosted n8n, in version 1.19.4 and ab
 
     [:octicons-arrow-right-24: Tutorial](/advanced-ai/intro-tutorial/)
 
+-   __Use a Starter Kit__
+
+    Try n8n's Self-hosted AI Starter Kit to quickly start building AI workflows.
+
+    [:octicons-arrow-right-24: Self-hosted AI Starter Kit](/hosting/starter-kits/ai-starter-kit/)
+
 -   __Explore examples and concepts__
 
 	Browse examples and workflow templates to help you build. Includes explanations of important AI concepts.
 
     [:octicons-arrow-right-24: Examples](/advanced-ai/examples/introduction/)
-
 
 -   __How n8n uses LangChain__
 
@@ -40,7 +45,6 @@ This feature is available on Cloud and self-hosted n8n, in version 1.19.4 and ab
 
     [:octicons-arrow-right-24: AI workflows on n8n.io](https://n8n.io/workflows/?categories=25){:target=_blank .external-link}
 
-   
 </div>
 
 ## Related resources

--- a/docs/hosting/index.md
+++ b/docs/hosting/index.md
@@ -37,6 +37,18 @@ See [Community edition features](/hosting/community-edition-features/) for a lis
 
 	[:octicons-arrow-right-24: Scaling](/hosting/scaling/queue-mode/)
 
+- __Securing n8n__
+
+	Secure your n8n instance by setting up SSL, SSO, or 2FA or blocking or opting out of some data collection or features.
+
+	[:octicons-arrow-right-24: Securing n8n guide](/hosting/securing/overview/)
+
+- __Starter kits__
+
+	New to n8n or AI? Try our Self-hosted AI Starter Kit. Curated by n8n, it combines the self-hosted n8n platform with compatible AI products and components to get you started building self-hosted AI workflows.
+
+	[:octicons-arrow-right-24: Starter kits](/hosting/starter-kits/ai-starter-kit/)
+
 </div>
 
 --8<-- "_snippets/self-hosting/warning.md"

--- a/docs/hosting/starter-kits/ai-starter-kit.md
+++ b/docs/hosting/starter-kits/ai-starter-kit.md
@@ -1,0 +1,42 @@
+---
+#https://www.notion.so/n8n/Frontmatter-432c2b8dff1f43d4b1c8d20075510fe4
+title: Self-hosted AI Starter Kit
+description: Use n8n's curated self-hosted AI Starter Kit to get a list of AI elements to quickly start building AI workflows.
+contentType: howto
+---
+
+# Self-hosted AI Starter Kit
+
+The Self-hosted AI Starter Kit is an open, docker compose template that bootstraps a fully featured Local AI and Low Code development environment.
+
+Curated by [n8n](https://github.com/n8n-io), it combines the self-hosted n8n platform with a list of compatible AI products and components to get you started with building self-hosted AI workflows.
+
+## What’s included
+
+✅ [**Self-hosted n8n**](/hosting/): Low-code platform with over 400 integrations and advanced AI components.
+
+✅ [**Ollama**](https://ollama.com/){:target=_blank .external-link}: Cross-platform LLM platform to install and run the latest local LLMs.
+
+✅ [**Qdrant**](https://qdrant.tech/){:target=_blank .external-link}: Open-source, high performance vector store with a comprehensive API.
+
+✅ [**PostgreSQL**](https://www.postgresql.org/){:target=_blank .external-link}: The workhorse of the Data Engineering world, handles large amounts of data safely.
+
+## What you can build
+
+⭐️ AI Agents which can schedule appointments
+
+⭐️ Summaries of company PDFs without leaking data
+
+⭐️ Smarter Slackbots for company communications and IT-ops
+
+⭐️ Private, low-cost analyses of financial documents
+
+## Get the kit
+
+<!-- vale off -->
+Head to [the GitHub repository](https://github.com/n8n-io/self-hosted-ai-starter-kit) to clone the repo and get started!
+<!-- vale on -->
+
+/// note | For testing only
+We designed this starter kit to help you get started with self-hosted AI workflows. While it’s not fully optimized for production environments, it combines robust components that work well together for proof-of-concept projects. Customize it to meet your needs. Secure and harden it before using in production.
+///

--- a/docs/hosting/starter-kits/ai-starter-kit.md
+++ b/docs/hosting/starter-kits/ai-starter-kit.md
@@ -34,7 +34,7 @@ Curated by [n8n](https://github.com/n8n-io), it combines the self-hosted n8n pla
 ## Get the kit
 
 <!-- vale off -->
-Head to [the GitHub repository](https://github.com/n8n-io/self-hosted-ai-starter-kit) to clone the repo and get started!
+Head to [the GitHub repository](https://github.com/n8n-io/self-hosted-ai-starter-kit){:target=_blank .external-link} to clone the repo and get started!
 <!-- vale on -->
 
 /// note | For testing only

--- a/docs/hosting/starter-kits/ai-starter-kit.md
+++ b/docs/hosting/starter-kits/ai-starter-kit.md
@@ -9,7 +9,7 @@ contentType: howto
 
 The Self-hosted AI Starter Kit is an open, docker compose template that bootstraps a fully featured Local AI and Low Code development environment.
 
-Curated by [n8n](https://github.com/n8n-io), it combines the self-hosted n8n platform with a list of compatible AI products and components to get you started with building self-hosted AI workflows.
+Curated by [n8n](https://github.com/n8n-io), it combines the self-hosted n8n platform with a list of compatible AI products and components to get you started building self-hosted AI workflows.
 
 ## What’s included
 
@@ -23,7 +23,7 @@ Curated by [n8n](https://github.com/n8n-io), it combines the self-hosted n8n pla
 
 ## What you can build
 
-⭐️ AI Agents which can schedule appointments
+⭐️ AI Agents that can schedule appointments
 
 ⭐️ Summaries of company PDFs without leaking data
 
@@ -38,5 +38,5 @@ Head to [the GitHub repository](https://github.com/n8n-io/self-hosted-ai-starter
 <!-- vale on -->
 
 /// note | For testing only
-We designed this starter kit to help you get started with self-hosted AI workflows. While it’s not fully optimized for production environments, it combines robust components that work well together for proof-of-concept projects. Customize it to meet your needs. Secure and harden it before using in production.
+n8n designed this kit to help you get started with self-hosted AI workflows. While it’s not fully optimized for production environments, it combines robust components that work well together for proof-of-concept projects. Customize it to meet your needs. Secure and harden it before using in production.
 ///

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreqdrant.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreqdrant.md
@@ -50,3 +50,5 @@ You can find authentication information for this node [here](/integrations/built
 Refer to [LangChain's Qdrant documentation](https://js.langchain.com/docs/integrations/vectorstores/qdrant){:target=_blank .external-link} for more information about the service.
 
 --8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
+
+--8<-- "_snippets/self-hosting/starter-kits/self-hosted-ai-starter-kit.md"

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatollama.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatollama.md
@@ -42,3 +42,5 @@ Refer to [LangChains's Ollama Chat Model documentation](https://js.langchain.com
 
 --8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
 --8<-- "_glossary/ai-glossary.md"
+
+--8<-- "_snippets/self-hosting/starter-kits/self-hosted-ai-starter-kit.md"

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmollama.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmollama.md
@@ -42,3 +42,5 @@ Refer to [LangChains's Ollama documentation](https://js.langchain.com/docs/modul
 
 --8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
 --8<-- "_glossary/ai-glossary.md"
+
+--8<-- "_snippets/self-hosting/starter-kits/self-hosted-ai-starter-kit.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,10 +97,10 @@ markdown_extensions:
   # attr_list is required for several other features. Always enable.
   - attr_list
   # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#automatic-previews
-#  - material.extensions.preview:
-#      sources:
-#        include:
-#          - release-notes.md
+  - material.extensions.preview:
+      sources:
+        include:
+          - release-notes.md
   # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#markdown-in-html
   - md_in_html
   - meta

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,10 +97,10 @@ markdown_extensions:
   # attr_list is required for several other features. Always enable.
   - attr_list
   # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#automatic-previews
-  - material.extensions.preview:
-      sources:
-        include:
-          - release-notes.md
+#  - material.extensions.preview:
+#      sources:
+#        include:
+#          - release-notes.md
   # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#markdown-in-html
   - md_in_html
   - meta
@@ -1241,6 +1241,8 @@ nav:
       - Disable the API: hosting/securing/disable-public-api.md
       - Opt out of data collection: hosting/securing/telemetry-opt-out.md
       - Blocking nodes: hosting/securing/blocking-nodes.md
+    - Starter Kits:
+      - AI Starter Kit: hosting/starter-kits/ai-starter-kit.md
     - Architecture:
       - Overview: hosting/architecture/overview.md
       - Database structure: hosting/architecture/database-structure.md


### PR DESCRIPTION
Summary of changes:

- Added starter kits section to self-hosting navigation
- Added AI starter kit page within that section
- Added starter kits callout to self-hosting overview page
- Added link to starter kit on advanced-ai overview page
- Created snippet referencing the starter kit and added it to the Qdrant and Ollama node docs

[Linear ticket](https://linear.app/n8n/issue/DOC-1033/create-docs-pages-for-self-hosted-ai-starter-kit) for reference