### PR TITLE
DOC-1052: Update MQTT credentials to medium tier template

### DIFF
--- a/docs/integrations/builtin/credentials/mqtt.md
+++ b/docs/integrations/builtin/credentials/mqtt.md
@@ -51,7 +51,7 @@ To set things up:
 5. Enter that user's **Password**.
 6. If you want to receive QoS 1 and 2 messages while offline, turn off the **Clean Session** toggle.
 7. Enter a **Client ID** you'd like the credential to use. If you leave this blank, n8n will generate one for you. You can use a fixed or expression-based Client ID.
-    - Client IDs can be useful to identify and track connection access. n8n recommends using something with `n8n` in it so you know the connections are coming from n8n.
+    - Client IDs can be useful to identify and track connection access. n8n recommends using something with `n8n` in it for easier auditing.
 8. If your MQTT broker uses SSL, turn the **SSL** toggle on. Once you turn it on:
     1. Select whether to use **Passwordless** connection with certificates, which is like the SASL mechanism EXTERNAL. If turned on:
         1. Select whether to **Reject Unauthorized Certificate**: If turned off, n8n will connect even if the certificate validation fails.

--- a/docs/integrations/builtin/credentials/mqtt.md
+++ b/docs/integrations/builtin/credentials/mqtt.md
@@ -41,7 +41,7 @@ To configure this credential, you'll need:
 
 To set things up:
 
-1. Select the broker's **Protocol**: This determines the URL n8n should use. The protocol is the start of the URL. Options include:
+1. Select the broker's **Protocol**, which determines the URL n8n uses. Options include:
     - **Mqtt**: Begin the URL with the standard `mqtt:` protocol.
     - **Mqtts**: Begin the URL with the secure `mqtts:` protocol.
     - **Ws**: Begin the URL with the WebSocket `ws:` protocol.

--- a/docs/integrations/builtin/credentials/mqtt.md
+++ b/docs/integrations/builtin/credentials/mqtt.md
@@ -15,7 +15,7 @@ You can use these credentials to authenticate the following nodes:
 
 ## Prerequisites
 
-Install an [MQTT broker](https://mqtt.org/).
+Install an [MQTT broker](https://mqtt.org/){:target=_blank .external-link}.
 
 MQTT provides a list of Servers/Brokers at [MQTT Software](https://mqtt.org/software/){:target=_blank .external-link}.
 
@@ -33,20 +33,30 @@ Refer to your broker provider's documentation for more detailed configuration an
 
 To configure this credential, you'll need:
 
-- Select the broker's **Protocol**: This helps n8n determine the URL it should use. The Protocol is the start of the URL. Options include:
-    - **Mqtt**: Begin the URL with the standard `mqtt:` protocol
-    - **Mqtts**: Begin the URL with the secure `mqtts:` protocol
-    - **Ws**: Begin the URL with the websocket `ws:` protocol
-- A **Host**: Enter your broker host.
-- A **Port**: Enter the port number n8n should use to connect to the broker host.
-- A **Username**: Enter the username to authenticate to the broker.
-- A **Password**: Enter that user's password.
-- Select whether to use **Clean Session**: Turn off to receive QoS 1 and 2 messages while offline.
-- A **Client ID**: If this field is blank, n8n autogenerates a Client ID for you.
-- Select whether to connect using **SSL**. If turned on, also enter:
-    - Whether to use **Passwordless** connection with certificates, equivalent to SASL mechanism EXTERNAL. If turned on, also enter:
-        - Select whether to **Reject Unauthorized Certificate**: If turned on, n8n will connect even if the certificate validation fails.
-        - Add an SSL **Client Certificate**.
-        - Add an SSL **Client Key** for the Client Certificate.
-    - One or more SSL **CA Certificates**.
+- Your MQTT broker's **Protocol**
+- The **Host**
+- The **Port**
+- A **Username** and **Password** to authenticate with
+- If you're using **SSL**, the relevant certificates and keys
 
+To set things up:
+
+1. Select the broker's **Protocol**: This determines the URL n8n should use. The protocol is the start of the URL. Options include:
+    - **Mqtt**: Begin the URL with the standard `mqtt:` protocol.
+    - **Mqtts**: Begin the URL with the secure `mqtts:` protocol.
+    - **Ws**: Begin the URL with the WebSocket `ws:` protocol.
+2. Enter your broker **Host**.
+3. Enter the **Port** number n8n should use to connect to the broker host.
+4. Enter the **Username** to log into the broker as.
+5. Enter that user's **Password**.
+6. If you want to receive QoS 1 and 2 messages while offline, turn off the **Clean Session** toggle.
+7. Enter a **Client ID** you'd like the credential to use. If you leave this blank, n8n will generate one for you. You can use a fixed or expression-based Client ID.
+    - Client IDs can be useful to identify and track connection access. n8n recommends using something with `n8n` in it so you know the connections are coming from n8n.
+8. If your MQTT broker uses SSL, turn the **SSL** toggle on. Once you turn it on:
+    1. Select whether to use **Passwordless** connection with certificates, which is like the SASL mechanism EXTERNAL. If turned on:
+        1. Select whether to **Reject Unauthorized Certificate**: If turned off, n8n will connect even if the certificate validation fails.
+        2. Add an SSL **Client Certificate**.
+        3. Add an SSL **Client Key** for the Client Certificate.
+    2. One or more SSL **CA Certificates**.
+
+Refer to your MQTT broker provider's documentation for more detailed configuration instructions.


### PR DESCRIPTION
Convert to detailed numbered instructions. These are still fairly generic since there are a ton of providers they could be using.