### PR TITLE
DOC-1071: Update Stripe credentials to medium tier template

### DIFF
--- a/docs/integrations/builtin/credentials/stripe.md
+++ b/docs/integrations/builtin/credentials/stripe.md
@@ -39,9 +39,7 @@ To generate a Secret key in live mode:
 4. Select **Create**. The new API key displays.
 4. Copy the key and enter it in your n8n credential as the **Secret Key**.
 
-/// note | Existing key use
-While you can use the existing Secret key created in your Stripe developer account, n8n recommends creating a Secret key specifically for your integration.
-///
+Refer to Stripe's [Create a secret API key](https://docs.stripe.com/keys#create-api-secret-key){:target=_blank .external-link} for more information.
 
 ### Test mode Secret key
 
@@ -51,7 +49,7 @@ To use a Secret key in test mode, you must copy the existing one:
 2. In the **Standard Keys** section, select **Reveal test key** for the **Secret key**.
 3. Copy the key and enter it in your n8n credential as the **Secret Key**.
 
-Refer to [Create a secret API key](https://docs.stripe.com/keys#create-api-secret-key){:target=_blank .external-link} for more detailed instructions.
+Refer to Stripe's [Create a secret API key](https://docs.stripe.com/keys#create-api-secret-key){:target=_blank .external-link} for more information.
 
 ## Test mode and live mode
 
@@ -72,6 +70,8 @@ Stripes' Secret keys always begin with `sk_`:
 - Live keys begin with `sk_live_`.
 - Test keys begin with `sk_test_`.
 
-Don't use the Publishable keys (prefixed `pk_`).
-
 n8n hasn't tested these credentials with Restricted keys (prefixed `rk_`).
+
+/// warning | Publishable keys
+Don't use the Publishable keys (prefixed `pk_`) with your n8n credential.
+///

--- a/docs/integrations/builtin/credentials/stripe.md
+++ b/docs/integrations/builtin/credentials/stripe.md
@@ -13,12 +13,6 @@ You can use these credentials to authenticate the following nodes:
 - [Stripe Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.stripetrigger/)
 - [Stripe](/integrations/builtin/app-nodes/n8n-nodes-base.stripe/)
 
-## Prerequisites
-
-Create a [Stripe](https://stripe.com/){:target=_blank .external-link} account.
-
-You must have either an admin or developer account.
-
 ## Supported authentication methods
 
 - API key
@@ -29,12 +23,33 @@ Refer to [Stripe's API documentation](https://docs.stripe.com/api){:target=_blan
 
 ## Using API key
 
-To configure this credential, you'll need:
+To configure this credential, you'll need a [Stripe](https://stripe.com/){:target=_blank .external-link} admin or developer account and:
 
-- An API **Secret Key**: Choose whether to generate an API key in live mode or test mode. Refer to [Test mode and live mode](#test-mode-and-live-mode) for more information about the two modes.
-    - For live mode: Go to your [Stripe dashboard](https://dashboard.stripe.com/apikeys){:target=_blank .external-link} to generate a Secret Key. 
-    - For test mode: Go to your [Stripe test mode dashboard](https://dashboard.stripe.com/test/apikeys){:target=_blank .external-link} to generate a Secret Key.
-    - Be sure you create a **Secret Key** and not a **Publishable Key**.
+- An API **Secret Key**
+
+Before you generate an API key, decide whether to generate it in live mode or test mode. Refer to [Test mode and live mode](#test-mode-and-live-mode) for more information about the two modes.
+
+### Live mode Secret key
+
+To generate a Secret key in live mode:
+
+1. Open the [Stripe developer dashboard](https://dashboard.stripe.com/developers){:target=_blank .external-link} and select [**API Keys**](https://dashboard.stripe.com/apikeys){:target=_blank .external-link}.
+2. In the **Standard Keys** section, select **Create secret key**.
+3. Enter a **Key name**, like `n8n integration`.
+4. Select **Create**. The new API key displays.
+4. Copy the key and enter it in your n8n credential as the **Secret Key**.
+
+/// note | Existing key use
+While you can use the existing Secret key created in your Stripe developer account, n8n recommends creating a Secret key specifically for your integration.
+///
+
+### Test mode Secret key
+
+To use a Secret key in test mode, you must copy the existing one:
+
+1. Go to your [Stripe test mode developer dashboard](https://dashboard.stripe.com/test/developers){:target=_blank .external-link} and select [**API Keys**](https://dashboard.stripe.com/test/apikeys){:target=_blank .external-link}.
+2. In the **Standard Keys** section, select **Reveal test key** for the **Secret key**.
+3. Copy the key and enter it in your n8n credential as the **Secret Key**.
 
 Refer to [Create a secret API key](https://docs.stripe.com/keys#create-api-secret-key){:target=_blank .external-link} for more detailed instructions.
 
@@ -42,12 +57,21 @@ Refer to [Create a secret API key](https://docs.stripe.com/keys#create-api-secre
 
 All Stripe API requests happen within either [test mode](https://docs.stripe.com/test-mode) or live mode. Each mode has its own API key. 
 
-Use test mode to access test data and live mode to access actual account data. Objects in one mode aren’t accessible to the other.
+Use test mode to access simulated test data and live mode to access actual account data. Objects in one mode aren’t accessible to the other.
 
-Refer to [API keys](https://docs.stripe.com/keys){:target=_blank .external-link} for more information about what's available in each mode and guidance on when to use which format.
+Refer to [API keys | Test mode versus live mode](https://docs.stripe.com/keys#test-live-modes){:target=_blank .external-link} for more information about what's available in each mode and guidance on when to use each.
 
 /// note | n8n credentials for both modes
 If you want to work with both live mode and test mode keys, store each mode's key in a separate n8n credential.
 ///
 
+## Key prefixes
 
+Stripes' Secret keys always begin with `sk_`:
+
+- Live keys begin with `sk_live_`.
+- Test keys begin with `sk_test_`.
+
+Don't use the Publishable keys (prefixed `pk_`).
+
+n8n hasn't tested these credentials with Restricted keys (prefixed `rk_`).


### PR DESCRIPTION
Remove prerequisites section, convert brief bullet point list to more detailed numbered list. Split out key types and prefixes into separate section for readability.