### PR TITLE
DOC-1075: Update Calendly credentials to medium tier template

### DIFF
--- a/docs/integrations/builtin/credentials/calendly.md
+++ b/docs/integrations/builtin/credentials/calendly.md
@@ -58,7 +58,7 @@ To get both, create a new OAuth app in Calendly:
 3. In **Environment type**, select the environment that corresponds to your usage, either **Sandbox** or **Production**.
     - Calendly recommends starting with **Sandbox** for development and creating a second application for **Production** when you're ready to go live.
 4. Copy the **OAuth Redirect URL** from n8n and enter it as a **Redirect URI** in the OAuth app.
-5. Select **Save & Continue**. The app details are displayed.
+5. Select **Save & Continue**. The app details display.
 5. Copy the **Client ID** and enter this as your n8n **Client ID**.
 6. Copy the **Client secret** and enter this as your n8n **Client Secret**.
 1. Select **Connect my account** in n8n and follow the on-screen prompts to finish authorizing the credential.

--- a/docs/integrations/builtin/credentials/calendly.md
+++ b/docs/integrations/builtin/credentials/calendly.md
@@ -33,8 +33,8 @@ To configure this credential, you'll need a [Calendly](https://www.calendly.com/
 
 To get your access token:
 
-1. Go to the Calendly [Integrations & apps](https://calendly.com/integrations){:target=_blank .external-link} page.
-2. Select [API & Webhooks](https://calendly.com/integrations/api_webhooks){:target=_blank .external-link}.
+1. Go to the Calendly [**Integrations & apps**](https://calendly.com/integrations){:target=_blank .external-link} page.
+2. Select [**API & Webhooks**](https://calendly.com/integrations/api_webhooks){:target=_blank .external-link}.
 3. In **Your Personal Access Tokens**, select **Generate new token**.
 4. Enter a **Name** for your access token, like `n8n integration`.
 5. Select **Create token**.

--- a/docs/integrations/builtin/credentials/calendly.md
+++ b/docs/integrations/builtin/credentials/calendly.md
@@ -12,9 +12,9 @@ You can use these credentials to authenticate the following nodes:
 
 - [Calendly Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.calendlytrigger/)
 
-## Prerequisites
-
-Create a [Calendly](https://www.calendly.com/){:target=_blank .external-link} premium account.
+/// warning | Supported Calendly plans
+The Calendly Trigger node relies on Calendly webhooks. Calendly only offers access to webhooks in their paid plans.
+///
 
 ## Supported authentication methods
 
@@ -27,28 +27,40 @@ Refer to [Calendly's API documentation](https://developer.calendly.com/getting-s
 
 ## Using API access token
 
-To configure this credential, you'll need:
+To configure this credential, you'll need a [Calendly](https://www.calendly.com/){:target=_blank .external-link} account and:
 
-- An API Key or **Personal Access Token**: Refer to [Calendly's API authentication documentation](https://developer.calendly.com/how-to-authenticate-with-personal-access-tokens){:target=_blank .external-link} for information on generating a personal access token (PAT).
+- An API Key or **Personal Access Token**
 
+To get your access token:
+
+1. Go to the Calendly [Integrations & apps](https://calendly.com/integrations){:target=_blank .external-link} page.
+2. Select [API & Webhooks](https://calendly.com/integrations/api_webhooks){:target=_blank .external-link}.
+3. In **Your Personal Access Tokens**, select **Generate new token**.
+4. Enter a **Name** for your access token, like `n8n integration`.
+5. Select **Create token**.
+6. Select **Copy token** and enter it in your n8n credential.
+
+Refer to [Calendly's API authentication documentation](https://developer.calendly.com/how-to-authenticate-with-personal-access-tokens){:target=_blank .external-link} for more information.
 
 ## Using OAuth2
 
-To configure this credential, you'll need:
+To configure this credential, you'll need a [Calendly developer](https://developer.calendly.com){:target=_blank .external-link} account and:
 
-- A **Client ID**: Generated when you create a new OAuth app.
-- A **Client Secret**: Generated when you create a new OAuth app.
+- A **Client ID**
+- A **Client Secret**
 
-To create a new OAuth app after logging in to [Calendly's developer portal](https://developer.calendly.com/console/apps){:target=_blank .external-link}, go to **Account > My Apps > Create new app**.
+To get both, create a new OAuth app in Calendly:
 
-To set up the integration: 
+1. Log in to Calendly's developer portal and go to [**My apps**](https://developer.calendly.com/console/apps){:target=_blank .external-link}.
+1. Select **Create new app**.
+1. Enter a **Name of app**, like `n8n integration`.
+2. In **Kind of app**, select **Web**.
+3. In **Environment type**, select the environment that corresponds to your usage, either **Sandbox** or **Production**.
+    - Calendly recommends starting with **Sandbox** for development and creating a second application for **Production** when you're ready to go live.
+4. Copy the **OAuth Redirect URL** from n8n and enter it as a **Redirect URI** in the OAuth app.
+5. Select **Save & Continue**. The app details are displayed.
+5. Copy the **Client ID** and enter this as your n8n **Client ID**.
+6. Copy the **Client secret** and enter this as your n8n **Client Secret**.
+1. Select **Connect my account** in n8n and follow the on-screen prompts to finish authorizing the credential.
 
- 1. Give your app a name like **n8n Automation**.
- 2. Set **Kind of app** to **Web**.
- 3. Set **Environment type** to **Sandbox** or **Production**.
- 4. Copy the **OAuth Redirect URL** from n8n and enter it as a **Redirect URI** in the OAuth app.
- 5. Copy the **Client ID** for the Calendly app and enter this as your n8n **Client ID**.
- 6. Copy the **Client secret** from Calendly and enter this as your n8n **Client Secret**.
- 
- 
- Refer to [Registering your application with Calendly](https://developer.calendly.com/create-a-developer-account){:target=_blank .external-link} for more information.
+Refer to [Registering your application with Calendly](https://developer.calendly.com/create-a-developer-account){:target=_blank .external-link} for more information.


### PR DESCRIPTION
Remove prerequisites, add warning about webhooks only on paid plans, convert bullet points to much more detailed numbered list.