### PR TITLE
Improve instructions for Docker Compose users

### DIFF
--- a/docs/hosting/installation/docker.md
+++ b/docs/hosting/installation/docker.md
@@ -103,6 +103,12 @@ From your Docker Desktop, navigate to the **Images** tab and select **Pull** fro
 You can also use the command line to pull the latest, or a specific version:
 
 ```sh
+# Switch to the docker user
+su - docker
+
+# Navigate to the n8n-caddy folder
+cd n8n-caddy-docker
+
 # Pull latest (stable) version
 docker pull docker.n8n.io/n8nio/n8n
 


### PR DESCRIPTION
Added steps to switch to the Docker user and navigate to the n8n-caddy folder.