### PR TITLE
fix: fix typo in link to Slack trigger on credentials page

### DIFF
--- a/docs/integrations/builtin/credentials/slack.md
+++ b/docs/integrations/builtin/credentials/slack.md
@@ -11,7 +11,7 @@ priority: high
 You can use these credentials to authenticate the following nodes:
 
 - [Slack](/integrations/builtin/app-nodes/n8n-nodes-base.slack/)
-- [Slack Trigger](/integrations/builtin/trigger-ndoes/n8n-nodes-base.slacktrigger/)
+- [Slack Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger/)
 
 ## Supported authentication methods
 


### PR DESCRIPTION
Fixes the typo in the URL to Slack Trigger on the Slack credentials page which caused a 404 error.
