### PR TITLE
Programmatic Style: Minor typo fix

### DIFF
--- a/docs/integrations/creating-nodes/build/programmatic-style-node.md
+++ b/docs/integrations/creating-nodes/build/programmatic-style-node.md
@@ -263,7 +263,7 @@ For this tutorial, you'll add two additional fields, to allow users to enter the
 
 ### Step 4: Add the execute method
 
-Step 5 set up the node UI and basic information. It's time to map the node UI to API requests, and make the node actually do something.
+You've set up the node UI and basic information. It's time to map the node UI to API requests, and make the node actually do something.
 
 The `execute` method runs every time the node runs. In this method, you have access to the input items and to the parameters that the user set in the UI, including the credentials.
 


### PR DESCRIPTION
Spotted a typo while following the documentation on the [Programmatic Style page](https://docs.n8n.io/integrations/creating-nodes/build/programmatic-style-node/#step-36-add-optional-fields):
> **Step 4: Add the execute method**
> Step 5 set up the node UI and basic information. It's time to map the node UI to API requests, and make the node actually do something.

This commit updates "Step 5 set up..." -> "You've set up..."