### PR TITLE
Update ciscowebex.md fix typos in membership scopes

### DIFF
--- a/docs/integrations/builtin/credentials/ciscowebex.md
+++ b/docs/integrations/builtin/credentials/ciscowebex.md
@@ -37,8 +37,8 @@ n8n recommends using the following **Scopes** for your integration:
 * `spark:rooms_read`
 * `spark:messages_write`
 * `spark:messages_read`
-* `spark:membership_read`
-* `spark_membership_write`
+* `spark:memberships_read`
+* `spark:memberships_write`
 * `meeting:recordings_write`
 * `meeting:recordings_read`
 * `meeting:preferences_read`


### PR DESCRIPTION
Membership scopes in Webex are "memberships", not "membership". Also fixed use of an underscore instead of a colon.