### PR TITLE
Add user change to custom docker image steps

### DIFF
--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.executecommand.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.executecommand.md
@@ -60,9 +60,9 @@ If you want to run the curl command in the Execute Command node, you will have t
 
     ```shell
     FROM docker.n8n.io/n8nio/n8n
-	USER root
+    USER root
     RUN apk --update add curl
-	USER node
+    USER node
     ```
 
 3. In the same folder, execute the command below to build the Docker image.

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.executecommand.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.executecommand.md
@@ -60,7 +60,9 @@ If you want to run the curl command in the Execute Command node, you will have t
 
     ```shell
     FROM docker.n8n.io/n8nio/n8n
+	USER root
     RUN apk --update add curl
+	USER node
     ```
 
 3. In the same folder, execute the command below to build the Docker image.


### PR DESCRIPTION
This updates the custom docker image example to include the change to `root` user before running the `apk` command.

Forum post: https://community.n8n.io/t/docker-build-is-not-able-to-run-apk/54211