### PR TITLE
DOC-1128: Standardize common issues pages

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.gmail/common-issues.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.gmail/common-issues.md
@@ -8,7 +8,7 @@ priority: critical
 
 # Gmail node common issues
 
-Here are some common errors and issues with the [Gmail node](/integrations/builtin/app-nodes/n8n-nodes--base.gmail/) and steps to resolve or troubleshoot them.
+Here are some common errors and issues with the [Gmail node](/integrations/builtin/app-nodes/n8n-nodes-base.gmail/) and steps to resolve or troubleshoot them.
 
 ## Remove the n8n attribution from sent messages
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.gmail/common-issues.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.gmail/common-issues.md
@@ -1,12 +1,12 @@
 ---
 #https://www.notion.so/n8n/Frontmatter-432c2b8dff1f43d4b1c8d20075510fe4
 title: Gmail node common issues 
-description: Documentation for common issues and resolutions in the Gmail node in n8n, a workflow automation platform. Includes details of the issue and suggested resolutions.
+description: Documentation for common issues and questions in the Gmail node in n8n, a workflow automation platform. Includes details of the issue and suggested solutions.
 contentType: integration
 priority: critical
 ---
 
-# Common issues (Gmail node)
+# Gmail node common issues
 
 Here are some common errors and issues with the [Gmail node](/integrations/builtin/app-nodes/n8n-nodes--base.gmail/) and steps to resolve or troubleshoot them.
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.telegram/common-issues.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.telegram/common-issues.md
@@ -8,7 +8,7 @@ priority: critical
 
 # Telegram node common issues
 
-Here are some common errors and issues with the [Telegram node](/integrations/builtin/app-nodes/telegram/) and steps to resolve or troubleshoot them.
+Here are some common errors and issues with the [Telegram node](/integrations/builtin/app-nodes/n8n-nodes-base.telegram/) and steps to resolve or troubleshoot them.
 
 ## Add a bot to a Telegram channel
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.telegram/common-issues.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.telegram/common-issues.md
@@ -1,12 +1,12 @@
 ---
 #https://www.notion.so/n8n/Frontmatter-432c2b8dff1f43d4b1c8d20075510fe4
-title: Telegram node Common Issues 
-description: Documentation for Common Issues and resolutions in the Telegram node in n8n, a workflow automation platform. Includes details of the issue and suggested resolutions.
+title: Telegram node common issues
+description: Documentation for common issues and questions in the Telegram node in n8n, a workflow automation platform. Includes details of the issue and suggested solutions.
 contentType: integration
 priority: critical
 ---
 
-# Common issues (Telegram node)
+# Telegram node common issues
 
 Here are some common errors and issues with the [Telegram node](/integrations/builtin/app-nodes/telegram/) and steps to resolve or troubleshoot them.
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger.md
@@ -21,7 +21,7 @@ Use this trigger:
 
 ## Common issues
 
-Here are some common issues/questions and suggested solutions for the Manual Trigger node.
+Here are some common errors and issues with the Manual Trigger node and steps to resolve or troubleshoot them.
 
 <!-- vale off -->
 ### Only one 'Manual Trigger' node is allowed in a workflow

--- a/document-templates/app-nodes.md
+++ b/document-templates/app-nodes.md
@@ -68,8 +68,10 @@ let users know they can use the HTTP node if their operation isn't supported
 ## Common issues
 
 <!-- 
-If the node is small enough for a single page, add a subheading here for each error, quirk, pain point, or other complex topic that might trip people up. Refer to the common_issues.md template for suggested wording.
-
+if the node is small enough for a single page, add the sentence below. Create a subheading below this for each error, quirk, pain point, or other complex topic that might trip people up
+-->
+Here are some common errors and issues with the _Name_ node and steps to resolve or troubleshoot them.
+<!-- 
 If the node is large enough to warrant subpages, create a separate Common issues page using the common-issues.md template and link to it here using this text:
 
 For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/_relativepath_).

--- a/document-templates/cluster-nodes.md
+++ b/document-templates/cluster-nodes.md
@@ -56,8 +56,10 @@ Refer to [_Name_'s documentation](){:target=_blank .external-link} for more info
 ## Common issues
 
 <!-- 
-If the node is small enough for a single page, add a subheading here for each error, quirk, pain point, or other complex topic that might trip people up. Refer to the common_issues.md template for suggested wording.
-
+if the node is small enough for a single page, add the sentence below. Create a subheading below this for each error, quirk, pain point, or other complex topic that might trip people up
+-->
+Here are some common errors and issues with the _Name_ node and steps to resolve or troubleshoot them.
+<!-- 
 If the node is large enough to warrant subpages, create a separate Common issues page using the common-issues.md template and link to it here using this text:
 
 For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/_relativepath_).

--- a/document-templates/core-nodes.md
+++ b/document-templates/core-nodes.md
@@ -58,8 +58,10 @@ You should not include: basic usage examples
 ## Common issues
 
 <!-- 
-If the node is small enough for a single page, add a subheading here for each error, quirk, pain point, or other complex topic that might trip people up. Refer to the common_issues.md template for suggested wording.
-
+if the node is small enough for a single page, add the sentence below. Create a subheading below this for each error, quirk, pain point, or other complex topic that might trip people up
+-->
+Here are some common errors and issues with the _Name_ node and steps to resolve or troubleshoot them.
+<!-- 
 If the node is large enough to warrant subpages, create a separate Common issues page using the common-issues.md template and link to it here using this text:
 
 For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/_relativepath_).

--- a/document-templates/credentials.md
+++ b/document-templates/credentials.md
@@ -89,8 +89,10 @@ Refer to [_Name_'s OAuth documentation](){:target=_blank .external-link} for mor
 ## Common issues
 
 <!-- 
-If the node is small enough for a single page, add a subheading here for each error, quirk, pain point, or other complex topic that might trip people up. Refer to the common_issues.md template for suggested wording.
-
+if the node is small enough for a single page, add the sentence below. Create a subheading below this for each error, quirk, pain point, or other complex topic that might trip people up
+-->
+Here are some common errors and issues with the _Name_ node and steps to resolve or troubleshoot them.
+<!-- 
 If the node is large enough to warrant subpages, create a separate Common issues page using the common-issues.md template and link to it here using this text:
 
 For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/_relativepath_).

--- a/document-templates/trigger-nodes.md
+++ b/document-templates/trigger-nodes.md
@@ -59,8 +59,10 @@ Refer to [_Name_'s documentation](){:target=_blank .external-link} for details a
 ## Common issues
 
 <!-- 
-If the node is small enough for a single page, add a subheading here for each error, quirk, pain point, or other complex topic that might trip people up. Refer to the common_issues.md template for suggested wording.
-
+if the node is small enough for a single page, add the sentence below. Create a subheading below this for each error, quirk, pain point, or other complex topic that might trip people up
+-->
+Here are some common errors and issues with the _Name_ node and steps to resolve or troubleshoot them.
+<!-- 
 If the node is large enough to warrant subpages, create a separate Common issues page using the common-issues.md template and link to it here using this text:
 
 For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/_relativepath_).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -494,6 +494,7 @@ nav:
           - Label operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/label-operations.md
           - Message operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/message-operations.md
           - Thread operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/thread-operations.md
+          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.gmail/common-issues.md
         - Google Ads: integrations/builtin/app-nodes/n8n-nodes-base.googleads.md
         - Google Analytics: integrations/builtin/app-nodes/n8n-nodes-base.googleanalytics.md
         - Google BigQuery: integrations/builtin/app-nodes/n8n-nodes-base.googlebigquery.md
@@ -658,6 +659,7 @@ nav:
           - Callback operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/callback-operations.md
           - File operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/file-operations.md
           - Message operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/message-operations.md
+          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.telegram/common-issues.md
         - TheHive: integrations/builtin/app-nodes/n8n-nodes-base.thehive.md
         - TheHive 5: integrations/builtin/app-nodes/n8n-nodes-base.thehive5.md
         - TimescaleDB: integrations/builtin/app-nodes/n8n-nodes-base.timescaledb.md
@@ -739,7 +741,7 @@ nav:
         - Gmail Trigger:
           - integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/index.md
           - Poll Mode options: integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/poll-mode-options.md
-          - Common Issues: integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/common-issues.md
+          - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/common-issues.md
         - Google Calendar Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googlecalendartrigger.md
         - Google Drive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googledrivetrigger.md
         - Google Sheets Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googlesheetstrigger.md
@@ -808,7 +810,7 @@ nav:
             - ReAct Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/react-agent.md
             - SQL Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/sql-agent.md
             - Tools Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
-            - Common Issues: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/common-issues.md
+            - Common issues: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/common-issues.md
           - Basic LLM Chain: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainllm.md
           - Question and Answer Chain: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainretrievalqa.md
           - Summarization Chain: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainsummarization.md
@@ -853,7 +855,7 @@ nav:
           - Chat Memory Manager: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorymanager.md
           - Window Buffer Memory: 
             - integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorybufferwindow/index.md
-            - Common Issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorybufferwindow/common-issues.md
+            - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorybufferwindow/common-issues.md
           - Motorhead: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorymotorhead.md
           - Redis Chat Memory: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memoryredischat.md
           - Postgres Chat Memory: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorypostgreschat.md


### PR DESCRIPTION
I lost two of the common issues pages from nav due to poorly handled merge conflicts, and also realized they had the older title format.

This branch does some quick fixes to get those pages into nav and align them with our current common issues template, and makes the common issues section of the existing docs templates slightly easier to use.

Should be a fast review, I hope!