### PR TITLE
Add info on tools agent dynamic parameters

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
@@ -102,7 +102,7 @@ Refer to the main AI Agent node's [Templates and examples](/integrations/builtin
 When configuring tools connected to the Tools Agent, you can use the `$fromAI()` function to dynamically populate parameter values using the AI model. The AI model will fill in appropriate data given the context from the task and information from other connected tools.
 
 /// note | Only for the Node Tools
-The `$fromAI()` function is only available for app node tools connected to the Tools Agent. It isn't possible to use the `$fromAI()` function with the [Call n8n Workflow](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow/), [Code](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcode/), or [HTTP Request](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolhttprequest/) tools.
+The `$fromAI()` function is only available for [app node](/integrations/builtin/app-nodes/) tools connected to the Tools Agent. It isn't possible to use the `$fromAI()` function with the [Call n8n Workflow](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow/), [Code](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcode/), [HTTP Request](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolhttprequest/), or [other cluster sub-nodes](/integrations/builtin/cluster-nodes/sub-nodes/).
 ///
 
 The `$fromAI()` function accepts the following parameters:

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
@@ -101,8 +101,8 @@ Refer to the main AI Agent node's [Templates and examples](/integrations/builtin
 
 When configuring tools connected to the Tools Agent, you can use the `$fromAI()` function to dynamically populate parameter values using the AI model. The AI model will fill in appropriate data given the context from the task and information from other connected tools.
 
-/// note | Only for the Tools Agent
-The `$fromAI()` function is only available for tools connected to the Tools Agent. You also can't use the `$fromAI()` function with the [Call n8n Workflow](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow/) tool.
+/// note | Only for the Node Tools
+The `$fromAI()` function is only available for app node tools connected to the Tools Agent. It isn't possible to use the `$fromAI()` function with the [Call n8n Workflow](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow/), [Code](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcode/), or [HTTP Request](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolhttprequest/) tools.
 ///
 
 The `$fromAI()` function accepts the following parameters:
@@ -121,7 +121,7 @@ The `$fromAI()` function accepts the following parameters:
 As an example, you could use the following `$fromAI()` expression to dynamically populate a field with a name:
 
 ```javascript
-$fromAI("name", "The commenter's name", "string", "")
+$fromAI("name", "The commenter's name", "string", "Jane Doe")
 ```
 
 If you don't need the optional parameters, you could simplify this as:

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
@@ -26,6 +26,39 @@ This agent supports the following chat models:
 * [Anthropic Chat Model](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatanthropic/)
 * [Azure OpenAI Chat Model](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatazureopenai/)
 
+The Tools Agent can use the following tools:
+
+* [Call n8n Workflow](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow/)
+* [Code](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcode/)
+* [HTTP Request](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolhttprequest/)
+* [Airtable](/integrations/builtin/app-nodes/n8n-nodes-base.airtable/)
+* [Baserow](/integrations/builtin/app-nodes/n8n-nodes-base.baserow/)
+* [Calculator](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcalculator/)
+* [Gmail](/integrations/builtin/app-nodes/n8n-nodes-base.gmail/)
+* [Google Calendar](/integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/)
+* [Google Docs](/integrations/builtin/app-nodes/n8n-nodes-base.googledocs/)
+* [Google Drive](/integrations/builtin/app-nodes/n8n-nodes-base.googledrive/)
+* [Google Sheets](/integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/)
+* [Hacker News](/integrations/builtin/app-nodes/n8n-nodes-base.hackernews/)
+* [Jira Software](/integrations/builtin/app-nodes/n8n-nodes-base.jira/)
+* [Microsoft Outlook](/integrations/builtin/app-nodes/n8n-nodes-base.microsoftoutlook/)
+* [Microsoft SQL](/integrations/builtin/app-nodes/n8n-nodes-base.microsoftsql/)
+* [MongoDB](/integrations/builtin/app-nodes/n8n-nodes-base.mongodb/)
+* [MySQL](/integrations/builtin/app-nodes/n8n-nodes-base.mysql/)
+* [NocoDB](/integrations/builtin/app-nodes/n8n-nodes-base.nocodb/)
+* [Notion](/integrations/builtin/app-nodes/n8n-nodes-base.notion/)
+* [Postgres](/integrations/builtin/app-nodes/n8n-nodes-base.postgres/)
+* [Redis](/integrations/builtin/app-nodes/n8n-nodes-base.redis/)
+* [Send Email](/integrations/builtin/core-nodes/n8n-nodes-base.sendemail/)
+* [SerpApi (Google Search)](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolserpapi/)
+* [Slack](/integrations/builtin/app-nodes/n8n-nodes-base.slack/)
+* [Supabase](/integrations/builtin/app-nodes/n8n-nodes-base.supabase/)
+* [Telegram](/integrations/builtin/app-nodes/n8n-nodes-base.telegram/)
+* [Vector Store](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolvectorstore/)
+* [Wikipedia](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolwikipedia/)
+* [Wolfram|Alpha](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolwolframalpha/)
+* [WooCommerce](/integrations/builtin/app-nodes/n8n-nodes-base.woocommerce/)
+
 ## Node parameters
 
 Configure the Tools Agent using the following parameters.
@@ -63,6 +96,45 @@ Refine the Tools Agent node's behavior using these options:
 ## Templates and examples
 
 Refer to the main AI Agent node's [Templates and examples](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/index/#templates-and-examples) section.
+
+## Dynamic parameters for tools
+
+When configuring tools connected to the Tools Agent, you can use the `$fromAI()` function to dynamically populate parameter values using the AI model. The AI model will fill in appropriate data given the context from the task and information from other connected tools.
+
+/// note | Only for the Tools Agent
+The `$fromAI()` function is only available for tools connected to the Tools Agent. You also can't use the `$fromAI()` function with the [Call n8n Workflow](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow/) tool.
+///
+
+The `$fromAI()` function accepts the following parameters:
+
+<!-- vale off -->
+
+| Parameter | Type | Required? | Description |
+| --------- | ---- | --------- | ----------- |
+| `key` | string | :white_check_mark: | A string representing the key or name of the argument. This must be between 1 and 64 characters in length and can only contain lowercase letters, uppercase letters, numbers, underscores, and hyphens. |
+| `description` | string | :x: | A string describing the argument. |
+| `type` | string | :x: | A string specifying the data type. Can be string, number, boolean, or json (defaults to string). |
+| `defaultValue` | any | :x: | The default value to use for the argument. |
+
+<!-- vale on -->
+
+As an example, you could use the following `$fromAI()` expression to dynamically populate a field with a name:
+
+```javascript
+$fromAI("name", "The commenter's name", "string", "")
+```
+
+If you don't need the optional parameters, you could simplify this as:
+
+```javascript
+$fromAI("name")
+```
+
+To dynamically populate the number of items you have in stock, you could use a `$fromAI()` expression like this:
+
+```javascript
+$fromAI("numItemsInStock", "Number of items in stock", "number", 5)
+```
 
 ## Common issues
 


### PR DESCRIPTION
This PR adds info about how to use the `$fromAI()` function with tools connected to the AI Tools Agent.  While this isn't something that it usable in the Tools Agent itself, it is usable by almost all of the tools that you can attach.

Additionally, I've added a list of the tool nodes you can connect from the Tools Agent.  I could use some help validating whether the links I'm using are correct.