### PR TITLE
Add error to common issues for OpenAI for exceeding your acount quota

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
@@ -129,13 +129,13 @@ There are two ways to work around this issue:
 
 ## Insufficient quota
 
-This error displays when your OpenAI account doesn't have enough credits to fulfill your request. This may mean that your OpenAI trial period has ended, that your OpenAI account needs more credit, or that your OpenAI account has reached its current usage limits.
+This error displays when your OpenAI account doesn't have enough credits or capacity to fulfill your request. This may mean that your OpenAI trial period has ended, that your account needs more credit, or that you've gone over a usage limit.
 
 To troubleshoot this error, in your OpenAI organization:
 
 * check that your [OpenAI account](https://platform.openai.com/settings/organization/billing/overview){:target=_blank .external-link} has enough credit
 * check that you haven't exceeded your organization's [usage limits](https://platform.openai.com/account/rate-limits){:target=_blank .external-link}
-* check that you haven't exceeded your OpenAI project's usage limits by selecting the project in your [organization settings](https://platform.openai.com/settings/organization){:target=_blank .external-link} and viewing the project limits
+* check that you haven't passed your OpenAI project's usage limits. Select the project in your [organization settings](https://platform.openai.com/settings/organization){:target=_blank .external-link} and view or change the project limits.
 
 In n8n:
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
@@ -133,8 +133,9 @@ This error displays when your OpenAI account doesn't have enough credits to fulf
 
 To troubleshoot this error:
 
-* check the OpenAI account associated with your OpenAI credentials has enough credit
-* make sure to connect the OpenAI node to the correct [OpenAI credentials](/integrations/builtin/credentials/openai/)
+* check that your [OpenAI account](https://platform.openai.com/settings/organization/billing/overview){:target=_blank .external-link} has enough credit
+* check that the [OpenAI credentials](/integrations/builtin/credentials/openai/) use a valid [OpenAI API key](https://platform.openai.com/api-keys){:target=_blank .external-link} for your funded account
+* ensure that you connect the [OpenAI node](/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/) to the correct [OpenAI credentials](/integrations/builtin/credentials/openai/)
 
 If you find yourself frequently running out of account credits, consider turning on auto recharge in your [OpenAI billing settings](https://platform.openai.com/settings/organization/billing/overview){:target=_blank .external-link} to automatically reload your account with credits when your balance reaches $0.
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
@@ -136,6 +136,8 @@ To troubleshoot this error:
 * check the OpenAI account associated with your OpenAI credentials has enough credit
 * make sure to connect the OpenAI node to the correct [OpenAI credentials](/integrations/builtin/credentials/openai/)
 
+If you find yourself frequently running out of account credits, consider turning on auto recharge in your [OpenAI billing settings](https://platform.openai.com/settings/organization/billing/overview){:target=_blank .external-link} to automatically reload your account with credits when your balance reaches $0.
+
 ## Bad request - please check your parameters
 
 This error displays when the request results in an error but the OpenAI node wasn't able to interpret the error message from OpenAI.

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
@@ -134,7 +134,7 @@ This error displays when your OpenAI account doesn't have enough credits to fulf
 To troubleshoot this error:
 
 * check that your [OpenAI account](https://platform.openai.com/settings/organization/billing/overview){:target=_blank .external-link} has enough credit
-* check that the [OpenAI credentials](/integrations/builtin/credentials/openai/) use a valid [OpenAI API key](https://platform.openai.com/api-keys){:target=_blank .external-link} for your funded account
+* check that the [OpenAI credentials](/integrations/builtin/credentials/openai/) use a valid [OpenAI API key](https://platform.openai.com/api-keys){:target=_blank .external-link} for the account you've added money to
 * ensure that you connect the [OpenAI node](/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/) to the correct [OpenAI credentials](/integrations/builtin/credentials/openai/)
 
 If you find yourself frequently running out of account credits, consider turning on auto recharge in your [OpenAI billing settings](https://platform.openai.com/settings/organization/billing/overview){:target=_blank .external-link} to automatically reload your account with credits when your balance reaches $0.

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
@@ -127,9 +127,18 @@ There are two ways to work around this issue:
     ```
 2. Use the [HTTP Request](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) node with the built-in batch-limit option against the [OpenAI API](https://platform.openai.com/docs/quickstart){:target=_blank .external-link} instead of using the OpenAI node.
 
+## OpenAI: Insufficient quota
+
+This error displays when your OpenAI account has insufficient quota. This may mean that your OpenAI trial period has ended or that your OpenAI account needs more credit.
+
+To troubleshoot this error:
+
+* ensure that you connect the correct [OpenAI credentials](/integrations/builtin/credentials/openai/) to the OpenAI node
+* check the OpenAI account associated with your OpenAI credentials has enough credit
+
 ## Bad request - please check your parameters
 
-This error displays when the request errored but the OpenAI node wasn't able to interpret the error message from OpenAI.
+This error displays when the request results in an error but the OpenAI node wasn't able to interpret the error message from OpenAI.
 
 To begin troubleshooting, try running the same operation using the [HTTP Request](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) node, which should provide a more detailed error message.
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
@@ -127,14 +127,14 @@ There are two ways to work around this issue:
     ```
 2. Use the [HTTP Request](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/) node with the built-in batch-limit option against the [OpenAI API](https://platform.openai.com/docs/quickstart){:target=_blank .external-link} instead of using the OpenAI node.
 
-## OpenAI: Insufficient quota
+## Insufficient quota
 
-This error displays when your OpenAI account has insufficient quota. This may mean that your OpenAI trial period has ended or that your OpenAI account needs more credit.
+This error displays when your OpenAI account has doesn't have enough credits to fulfill your request. This may mean that your OpenAI trial period has ended or that your OpenAI account needs more credit.
 
 To troubleshoot this error:
 
-* ensure that you connect the correct [OpenAI credentials](/integrations/builtin/credentials/openai/) to the OpenAI node
 * check the OpenAI account associated with your OpenAI credentials has enough credit
+* make sure to connect the OpenAI node to the correct [OpenAI credentials](/integrations/builtin/credentials/openai/)
 
 ## Bad request - please check your parameters
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
@@ -129,11 +129,16 @@ There are two ways to work around this issue:
 
 ## Insufficient quota
 
-This error displays when your OpenAI account doesn't have enough credits to fulfill your request. This may mean that your OpenAI trial period has ended or that your OpenAI account needs more credit.
+This error displays when your OpenAI account doesn't have enough credits to fulfill your request. This may mean that your OpenAI trial period has ended, that your OpenAI account needs more credit, or that your OpenAI account has reached its current usage limits.
 
-To troubleshoot this error:
+To troubleshoot this error, in your OpenAI organization:
 
 * check that your [OpenAI account](https://platform.openai.com/settings/organization/billing/overview){:target=_blank .external-link} has enough credit
+* check that your OpenAI organization is within its [usage limits](https://platform.openai.com/docs/guides/rate-limits/usage-tiers){:target=_blank .external-link} by visiting your organization [limits](https://platform.openai.com/account/rate-limits){:target=_blank .external-link}
+* check that your OpenAI project is within its usage limits by selecting your project in your [organization settings](https://platform.openai.com/settings/organization){:target=_blank .external-link} and viewing or changing the project limits
+
+In n8n:
+
 * check that the [OpenAI credentials](/integrations/builtin/credentials/openai/) use a valid [OpenAI API key](https://platform.openai.com/api-keys){:target=_blank .external-link} for the account you've added money to
 * ensure that you connect the [OpenAI node](/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/) to the correct [OpenAI credentials](/integrations/builtin/credentials/openai/)
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
@@ -129,7 +129,7 @@ There are two ways to work around this issue:
 
 ## Insufficient quota
 
-This error displays when your OpenAI account has doesn't have enough credits to fulfill your request. This may mean that your OpenAI trial period has ended or that your OpenAI account needs more credit.
+This error displays when your OpenAI account doesn't have enough credits to fulfill your request. This may mean that your OpenAI trial period has ended or that your OpenAI account needs more credit.
 
 To troubleshoot this error:
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
@@ -134,8 +134,8 @@ This error displays when your OpenAI account doesn't have enough credits to fulf
 To troubleshoot this error, in your OpenAI organization:
 
 * check that your [OpenAI account](https://platform.openai.com/settings/organization/billing/overview){:target=_blank .external-link} has enough credit
-* check that your OpenAI organization is within its [usage limits](https://platform.openai.com/docs/guides/rate-limits/usage-tiers){:target=_blank .external-link} by visiting your organization [limits](https://platform.openai.com/account/rate-limits){:target=_blank .external-link}
-* check that your OpenAI project is within its usage limits by selecting your project in your [organization settings](https://platform.openai.com/settings/organization){:target=_blank .external-link} and viewing or changing the project limits
+* check that you haven't exceeded your organization's [usage limits](https://platform.openai.com/account/rate-limits){:target=_blank .external-link}
+* check that you haven't exceeded your OpenAI project's usage limits by selecting the project in your [organization settings](https://platform.openai.com/settings/organization){:target=_blank .external-link} and viewing the project limits
 
 In n8n:
 


### PR DESCRIPTION
This adds an error to the OpenAI node common issues for when the connected OpenAI account has insufficient quota to process the request.