### PR TITLE
Add end-of-service note to line notify node and credential

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.line.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.line.md
@@ -8,6 +8,12 @@ priority: medium
 
 # Line node
 
+<!-- vale off -->
+/// warning | Deprecated: End of service
+LINE Notify is discontinuing service as of April 1st 2025 and this node will no longer work after that date. View Line Notify's [end of service announement](https://notify-bot.line.me/closing-announce){:target=_blank .external-link} for more information.
+///
+<!-- vale on -->
+
 Use the Line node to automate work in Line, and integrate Line with other applications. n8n has built-in support for a wide range of Line features, including sending notifications. 
 
 On this page, you'll find a list of operations the Line node supports and links to more resources.

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.line.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.line.md
@@ -10,7 +10,7 @@ priority: medium
 
 <!-- vale off -->
 /// warning | Deprecated: End of service
-LINE Notify is discontinuing service as of April 1st 2025 and this node will no longer work after that date. View Line Notify's [end of service announement](https://notify-bot.line.me/closing-announce){:target=_blank .external-link} for more information.
+LINE Notify is discontinuing service as of April 1st 2025 and this node will no longer work after that date. View LINE Notify's [end of service announement](https://notify-bot.line.me/closing-announce){:target=_blank .external-link} for more information.
 ///
 <!-- vale on -->
 

--- a/docs/integrations/builtin/credentials/line.md
+++ b/docs/integrations/builtin/credentials/line.md
@@ -8,6 +8,12 @@ priority: medium
 
 # Line credentials
 
+<!-- vale off -->
+/// warning | Deprecated: End of service
+LINE Notify is discontinuing service as of April 1st 2025 and this node will no longer work after that date. View Line Notify's [end of service announement](https://notify-bot.line.me/closing-announce){:target=_blank .external-link} for more information.
+///
+<!-- vale on -->
+
 You can use these credentials to authenticate the following nodes:
 
 - [Line](/integrations/builtin/app-nodes/n8n-nodes-base.line/)

--- a/docs/integrations/builtin/credentials/line.md
+++ b/docs/integrations/builtin/credentials/line.md
@@ -10,7 +10,7 @@ priority: medium
 
 <!-- vale off -->
 /// warning | Deprecated: End of service
-LINE Notify is discontinuing service as of April 1st 2025 and this node will no longer work after that date. View Line Notify's [end of service announement](https://notify-bot.line.me/closing-announce){:target=_blank .external-link} for more information.
+LINE Notify is discontinuing service as of April 1st 2025 and this node will no longer work after that date. View LINE Notify's [end of service announement](https://notify-bot.line.me/closing-announce){:target=_blank .external-link} for more information.
 ///
 <!-- vale on -->
 


### PR DESCRIPTION
Adding a deprecation note on the Line node and credential since the service is shutting down next year.