### PR TITLE
Updated invalid URL for starter repo

### DIFF
--- a/docs/integrations/creating-nodes/build/declarative-style-node.md
+++ b/docs/integrations/creating-nodes/build/declarative-style-node.md
@@ -33,7 +33,7 @@ n8n provides a starter repository for node development. Using the starter ensure
 
 Clone the repository and navigate into the directory:
 
-1. [Generate a new repository](https://github.com/n8n-io/n8n-nodes-starter/generate) from the template repository.
+1. [Generate a new repository](https://github.com/n8n-io/n8n-nodes-starter) from the template repository.
 2. Clone your new repository:
 		```shell
 		git clone https://github.com/<your-organization>/<your-repo-name>.git n8n-nodes-nasa-pics


### PR DESCRIPTION
The URL for starter repository does not exists and returns error 404 so this PR fixes the invalid URL