### PR TITLE
adds template and disclaimer

### DIFF
--- a/docs/code/cookbook/builtin/get-workflow-static-data.md
+++ b/docs/code/cookbook/builtin/get-workflow-static-data.md
@@ -13,7 +13,8 @@ contentType: reference
 This gives access to the static workflow data.
 
 /// note | Experimental feature
-Static data isn't available when testing workflows. The workflow must be active and called by a trigger or webhook to save static data.
+- Static data isn't available when testing workflows. The workflow must be active and called by a trigger or webhook to save static data.
+- This feature may behave unreliable under high frequent workflow executions. 
 ///
 You can save data directly in the workflow. This data should be small.
 
@@ -87,4 +88,7 @@ Example with node data:
 	delete nodeStaticData.lastExecution
 	```
 
+## Templates and examples
 
+<!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->
+[[ workflowDemo("https://api.n8n.io/workflows/templates/2538") ]]

--- a/docs/code/cookbook/builtin/get-workflow-static-data.md
+++ b/docs/code/cookbook/builtin/get-workflow-static-data.md
@@ -14,7 +14,7 @@ This gives access to the static workflow data.
 
 /// note | Experimental feature
 - Static data isn't available when testing workflows. The workflow must be active and called by a trigger or webhook to save static data.
-- This feature may behave unreliable under high frequent workflow executions. 
+- This feature may behave unreliably under high-frequency workflow executions.
 ///
 You can save data directly in the workflow. This data should be small.
 


### PR DESCRIPTION
This PR adds a demo workflow template to demonstrate how to use `staticData`. It also adds a disclaimer for using this feature. 

- https://linear.app/n8n/issue/DOC-1222/reference-demo-template-for-staticdata-in-documentation-include
- https://linear.app/n8n/issue/CAT-166/static-data-is-unreliable#comment-7b2434dd