### PR TITLE
Add instructions on registering testing and prod webhooks to single webhook nodes

### DIFF
--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.facebookleadadstrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.facebookleadadstrigger.md
@@ -30,3 +30,23 @@ View [example workflows and related content](https://n8n.io/integrations/faceboo
 
 Refer to [Facebook Lead Ads' documentation](https://developers.facebook.com/docs/marketing-api/guides/lead-ads/){:target=_blank .external-link} for details about their API.
 
+## Common issues
+
+Here are some common errors and issues with the Facebook Lead Ads Trigger node and steps to resolve or troubleshoot them.
+
+### Workflow only works in testing or production
+
+Facebook Lead Ads only allows you to register a single webhook per app. This means that every time you switch from using the testing URL to the production URL (and vice versa), Facebook Lead Ads overwrites the registered webhook URL. 
+
+You may have trouble with this if you try to test a workflow that's also active in production. Facebook Lead Ads will only send events to one of the two webhook URLs, so the other will never receive event notifications.
+
+To work around this, you can disable your workflow when testing:
+
+/// warning | Halts production traffic
+This workaround temporarily disables your production workflow for testing. Your workflow will no longer receive production traffic while it's deactivated.
+///
+
+1. Go to your workflow page.
+2. Toggle the **Active** switch in the top panel to disable the workflow temporarily.
+3. Test your workflow using the test webhook URL.
+4. When you finish testing, toggle the **Inactive** toggle to enable the workflow again. The production webhook URL should resume working.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
@@ -68,3 +68,26 @@ To use this node, you need to create an application in Slack and enable event su
 You must add the appropriate scopes to your Slack app for this trigger node to work.
 
 The node requires scopes for the [conversations.list](https://api.slack.com/methods/conversations.list){:target=blank .external-link} and [users.list](https://api.slack.com/methods/users.list){:target=blank .external-link} methods at minimum. Check out the [Scopes | Slack credentials](/integrations/builtin/credentials/slack/#scopes) list for a more complete list of scopes.
+
+## Common issues
+
+Here are some common errors and issues with the Slack Trigger node and steps to resolve or troubleshoot them.
+
+### Workflow only works in testing or production
+
+Slack only allows you to register a single webhook per app. This means that you can't switch from using the testing URL to the production URL (and vice versa) without reconfiguring the registered webhook URL. 
+
+You may have trouble with this if you try to test a workflow that's also active in production. Slack will only send events to one of the two webhook URLs, so the other will never receive event notifications.
+
+To work around this, you can disable your workflow when testing:
+
+/// warning | Halts production traffic
+This temporarily disables your production workflow for testing. Your workflow will no longer receive production traffic while it's deactivated.
+///
+
+1. Go to your workflow page.
+2. Toggle the **Active** switch in the top panel to disable the workflow temporarily.
+3. Edit the **Request URL** in your the [Slack Trigger configuration](/integrations/builtin/credentials/slack/#slack-trigger-configuration) to use the testing webhook URL instead of the production webhook URL.
+4. Test your workflow using the test webhook URL.
+5. When you finish testing, edit the **Request URL** in your the [Slack Trigger configuration](/integrations/builtin/credentials/slack/#slack-trigger-configuration) to use the production webhook URL instead of the testing webhook URL.
+6. Toggle the **Inactive** toggle to enable the workflow again. The production webhook URL should resume working.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.thehive5trigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.thehive5trigger.md
@@ -61,13 +61,22 @@ Refer to TheHive's [documentation](https://docs.strangebee.com/){:target=_blank 
 
 To configure the webhook for your TheHive instance:
 
-1. Copy the webhook URL from TheHive Trigger node.
-2. Add the following lines to the application.conf file. This is TheHive configuration file.
+1. Copy the testing and production webhook URLs from TheHive Trigger node.
+2. Add the following lines to the `application.conf` file. This is TheHive configuration file:
+
 	```
 	notification.webhook.endpoints = [
 		{
-			name: WEBHOOK_NAME
-			url: WEBHOOK_URL
+			name: TESTING_WEBHOOK_NAME
+			url: TESTING_WEBHOOK_URL
+			version: 0
+			wsConfig: {}
+			includedTheHiveOrganisations: ["ORGANIZATION_NAME"]
+			excludedTheHiveOrganisations: []
+		},
+		{
+			name: PRODUCTION_WEBHOOK_NAME
+			url: PRODUCTION_WEBHOOK_URL
 			version: 0
 			wsConfig: {}
 			includedTheHiveOrganisations: ["ORGANIZATION_NAME"]
@@ -75,9 +84,11 @@ To configure the webhook for your TheHive instance:
 		}
 	]
 	```
-3. Replace `WEBHOOK_URL` with the URL you copied in the previous step.
-4. Replace `ORGANIZATION_NAME` with your organization name.
-5. Execute the following cURL command to enable notifications:
+
+3. Replace `TESTING_WEBHOOK_URL` and `PRODUCTION_WEBHOOK_URL` with the URLs you copied in the previous step.
+4. Replace `TESTING_WEBHOOK_NAME` and `PRODUCTION_WEBHOOK_NAME` with your preferred endpoint names.
+5. Replace `ORGANIZATION_NAME` with your organization name.
+6. Execute the following cURL command to enable notifications:
 	```sh
 	curl -XPUT -uTHEHIVE_USERNAME:THEHIVE_PASSWORD -H 'Content-type: application/json' THEHIVE_URL/api/config/organisation/notification -d '
 	{
@@ -85,7 +96,12 @@ To configure the webhook for your TheHive instance:
 			{
 			"delegate": false,
 			"trigger": { "name": "AnyEvent"},
-			"notifier": { "name": "webhook", "endpoint": "WEBHOOK_NAME" }
+			"notifier": { "name": "webhook", "endpoint": "TESTING_WEBHOOK_NAME" }
+			},
+			{
+			"delegate": false,
+			"trigger": { "name": "AnyEvent"},
+			"notifier": { "name": "webhook", "endpoint": "PRODUCTION_WEBHOOK_NAME" }
 			}
 		]
 	}'

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.thehivetrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.thehivetrigger.md
@@ -56,13 +56,22 @@ Refer to TheHive's documentation for more information about the service:
 
 To configure the webhook for your TheHive instance:
 
-1. Copy the webhook URL from TheHive Trigger node.
-2. Add the following lines to the application.conf file. This is TheHive configuration file.
+1. Copy the testing and production webhook URLs from TheHive Trigger node.
+2. Add the following lines to the `application.conf` file. This is TheHive configuration file:
+
 	```
 	notification.webhook.endpoints = [
 		{
-			name: WEBHOOK_NAME
-			url: WEBHOOK_URL
+			name: TESTING_WEBHOOK_NAME
+			url: TESTING_WEBHOOK_URL
+			version: 0
+			wsConfig: {}
+			includedTheHiveOrganisations: ["ORGANIZATION_NAME"]
+			excludedTheHiveOrganisations: []
+		},
+		{
+			name: PRODUCTION_WEBHOOK_NAME
+			url: PRODUCTION_WEBHOOK_URL
 			version: 0
 			wsConfig: {}
 			includedTheHiveOrganisations: ["ORGANIZATION_NAME"]
@@ -70,9 +79,11 @@ To configure the webhook for your TheHive instance:
 		}
 	]
 	```
-3. Replace `WEBHOOK_URL` with the URL you copied in the previous step.
-4. Replace `ORGANIZATION_NAME` with your organization name.
-5. Execute the following cURL command to enable notifications:
+
+3. Replace `TESTING_WEBHOOK_URL` and `PRODUCTION_WEBHOOK_URL` with the URLs you copied in the previous step.
+4. Replace `TESTING_WEBHOOK_NAME` and `PRODUCTION_WEBHOOK_NAME` with your preferred endpoint names.
+5. Replace `ORGANIZATION_NAME` with your organization name.
+6. Execute the following cURL command to enable notifications:
 	```sh
 	curl -XPUT -uTHEHIVE_USERNAME:THEHIVE_PASSWORD -H 'Content-type: application/json' THEHIVE_URL/api/config/organisation/notification -d '
 	{
@@ -80,7 +91,12 @@ To configure the webhook for your TheHive instance:
 			{
 			"delegate": false,
 			"trigger": { "name": "AnyEvent"},
-			"notifier": { "name": "webhook", "endpoint": "WEBHOOK_NAME" }
+			"notifier": { "name": "webhook", "endpoint": "TESTING_WEBHOOK_NAME" }
+			},
+			{
+			"delegate": false,
+			"trigger": { "name": "AnyEvent"},
+			"notifier": { "name": "webhook", "endpoint": "PRODUCTION_WEBHOOK_NAME" }
 			}
 		]
 	}'

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.whatsapptrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.whatsapptrigger.md
@@ -40,3 +40,24 @@ n8n provides an app node for WhatsApp. You can find the node docs [here](/integr
 View [example workflows and related content](https://n8n.io/integrations/whatsapp-trigger/){:target=_blank .external-link} on n8n's website.
 
 Refer to [WhatsApp's documentation](https://developers.facebook.com/docs/whatsapp/cloud-api){:target=_blank .external-link} for details about their API.
+
+## Common issues
+
+Here are some common errors and issues with the WhatsApp Trigger node and steps to resolve or troubleshoot them.
+
+### Workflow only works in testing or production
+
+WhatsApp only allows you to register a single webhook per app. This means that every time you switch from using the testing URL to the production URL (and vice versa), WhatsApp overwrites the registered webhook URL. 
+
+You may have trouble with this if you try to test a workflow that's also active in production. WhatsApp will only send events to one of the two webhook URLs, so the other will never receive event notifications.
+
+To work around this, you can disable your workflow when testing:
+
+/// warning | Halts production traffic
+This workaround temporarily disables your production workflow for testing. Your workflow will no longer receive production traffic while it's deactivated.
+///
+
+1. Go to your workflow page.
+2. Toggle the **Active** switch in the top panel to disable the workflow temporarily.
+3. Test your workflow using the test webhook URL.
+4. When you finish testing, toggle the **Inactive** toggle to enable the workflow again. The production webhook URL should resume working.


### PR DESCRIPTION
This PR adds info to trigger nodes that can only handle a single webhook at a time. This can cause problems when switching between the testing and production webhooks.

Affected nodes fall into a few different categories:

* Only supports one webhook at a time, but can register the new webhook automatically on first use:
    * Telegram ([already live](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.telegramtrigger/common-issues/#workflow-only-works-in-testing-or-production) and not included in this PR)
    * Facebook Lead Ads
    * WhatsApp
* Only support one webhook at a time and must be manually configured with a new webhook:
    * Slack
* Supports multiple webhooks at the same time, but requires initial manual configuration:
    * TheHive
    * TheHive5