### PR TITLE
slack credentials may fail when token rotation turned on

### DIFF
--- a/_snippets/integrations/builtin/credentials/slack/token-rotation.md
+++ b/_snippets/integrations/builtin/credentials/slack/token-rotation.md
@@ -1,0 +1,7 @@
+Slack offers **token rotation** that can be turned on for bot and user tokens. This will make the token expire every 12 hours. While this may be useful for testing, it will cause the n8n credential to fail after expiry. If you want to use your slack credentials in production, this feature needs to be turned **off**. 
+
+To check if you have token rotation turned on for your slack app, please refer to the [Slack API Documentation | Token Rotation](https://api.slack.com/authentication/rotation){:target=_blank .external-link} for instructions.
+
+/// note | If Token Rotation has been activated
+Please note, token rotation may not be turned off again and you will have to create a new slack app instead. 
+///

--- a/_snippets/integrations/builtin/credentials/slack/token-rotation.md
+++ b/_snippets/integrations/builtin/credentials/slack/token-rotation.md
@@ -1,7 +1,7 @@
-Slack offers **token rotation** that can be turned on for bot and user tokens. This will make the token expire every 12 hours. While this may be useful for testing, it will cause the n8n credential to fail after expiry. If you want to use your slack credentials in production, this feature needs to be turned **off**. 
+Slack offers **token rotation** that you can turn on for bot and user tokens. This makes every tokens expire after 12 hours. While this may be useful for testing, n8n credentials using tokens with this enabled will fail after expiry. If you want to use your Slack credentials in production, you need to turn this feature **off**.
 
-To check if you have token rotation turned on for your slack app, please refer to the [Slack API Documentation | Token Rotation](https://api.slack.com/authentication/rotation){:target=_blank .external-link} for instructions.
+To check if your Slack app has token rotation turned on, refer to the [Slack API Documentation | Token Rotation](https://api.slack.com/authentication/rotation){:target=_blank .external-link}.
 
-/// note | If Token Rotation has been activated
-Please note, token rotation may not be turned off again and you will have to create a new slack app instead. 
+/// note | If your app uses token rotation
+Please note, if your Slack app uses token rotation, you can't turn it off again. You need to create a new Slack app with token rotation disabled instead. 
 ///

--- a/_snippets/integrations/builtin/credentials/slack/token-rotation.md
+++ b/_snippets/integrations/builtin/credentials/slack/token-rotation.md
@@ -1,4 +1,4 @@
-Slack offers **token rotation** that you can turn on for bot and user tokens. This makes every tokens expire after 12 hours. While this may be useful for testing, n8n credentials using tokens with this enabled will fail after expiry. If you want to use your Slack credentials in production, you need to turn this feature **off**.
+Slack offers **token rotation** that you can turn on for bot and user tokens. This makes every tokens expire after 12 hours. While this may be useful for testing, n8n credentials using tokens with this enabled will fail after expiry. If you want to use your Slack credentials in production, this feature must be **off**.
 
 To check if your Slack app has token rotation turned on, refer to the [Slack API Documentation | Token Rotation](https://api.slack.com/authentication/rotation){:target=_blank .external-link}.
 

--- a/docs/integrations/builtin/credentials/slack.md
+++ b/docs/integrations/builtin/credentials/slack.md
@@ -126,3 +126,9 @@ Here's the list of scopes the OAuth credential requires, which are a good starti
 | `users.profile:read` | |
 | `users.profile:write` | Not available as a bot token scope |
 | `users:read` | |
+
+## Troubleshooting
+
+### Token Expired
+
+--8<-- "_snippets/integrations/builtin/credentials/slack/token-rotation.md"

--- a/docs/integrations/builtin/credentials/slack.md
+++ b/docs/integrations/builtin/credentials/slack.md
@@ -127,8 +127,8 @@ Here's the list of scopes the OAuth credential requires, which are a good starti
 | `users.profile:write` | Not available as a bot token scope |
 | `users:read` | |
 
-## Troubleshooting
+## Common issues
 
-### Token Expired
+### Token expired
 
 --8<-- "_snippets/integrations/builtin/credentials/slack/token-rotation.md"

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
@@ -69,7 +69,6 @@ You must add the appropriate scopes to your Slack app for this trigger node to w
 
 The node requires scopes for the [conversations.list](https://api.slack.com/methods/conversations.list){:target=blank .external-link} and [users.list](https://api.slack.com/methods/users.list){:target=blank .external-link} methods at minimum. Check out the [Scopes | Slack credentials](/integrations/builtin/credentials/slack/#scopes) list for a more complete list of scopes.
 
-<<<<<<< Updated upstream
 ## Common issues
 
 Here are some common errors and issues with the Slack Trigger node and steps to resolve or troubleshoot them.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
@@ -69,6 +69,7 @@ You must add the appropriate scopes to your Slack app for this trigger node to w
 
 The node requires scopes for the [conversations.list](https://api.slack.com/methods/conversations.list){:target=blank .external-link} and [users.list](https://api.slack.com/methods/users.list){:target=blank .external-link} methods at minimum. Check out the [Scopes | Slack credentials](/integrations/builtin/credentials/slack/#scopes) list for a more complete list of scopes.
 
+<<<<<<< Updated upstream
 ## Common issues
 
 Here are some common errors and issues with the Slack Trigger node and steps to resolve or troubleshoot them.
@@ -91,3 +92,7 @@ This temporarily disables your production workflow for testing. Your workflow wi
 4. Test your workflow using the test webhook URL.
 5. When you finish testing, edit the **Request URL** in your the [Slack Trigger configuration](/integrations/builtin/credentials/slack/#slack-trigger-configuration) to use the production webhook URL instead of the testing webhook URL.
 6. Toggle the **Inactive** toggle to enable the workflow again. The production webhook URL should resume working.
+
+### Token Expired
+
+--8<-- "_snippets/integrations/builtin/credentials/slack/token-rotation.md"

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
@@ -92,6 +92,6 @@ This temporarily disables your production workflow for testing. Your workflow wi
 5. When you finish testing, edit the **Request URL** in your the [Slack Trigger configuration](/integrations/builtin/credentials/slack/#slack-trigger-configuration) to use the production webhook URL instead of the testing webhook URL.
 6. Toggle the **Inactive** toggle to enable the workflow again. The production webhook URL should resume working.
 
-### Token Expired
+### Token expired
 
 --8<-- "_snippets/integrations/builtin/credentials/slack/token-rotation.md"


### PR DESCRIPTION
This PR adds information on why slack credentials may fail if the `token rotation` feature was turned on in the slack app. 
I made a snippet so it can be used in two places: the `slack credentials` page and the `slack trigger node` page, as these are the most common places that users might look for help. 

Please feel free to rephrase my wordings :) Thanks for the review!