### PR TITLE
fix(Form Trigger node): remove depreacted option

### DIFF
--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
@@ -109,7 +109,6 @@ Choose when n8n sends a response to the form submission. You can respond when:
 
 - **Form Is Submitted**: Send a response to the user as soon as they submit the form.
 - **Workflow Finishes**: Use this if you want the workflow to complete its execution before you send a response to the user. If the workflow errors, it sends a response to the user telling them there was a problem submitting the form.
-- **Using 'Respond to Webhook' Node**: Use this for the form trigger to respond as defined in the [Respond to Webhook](/integrations/builtin/core-nodes/n8n-nodes-base.respondtowebhook/) node.
 
 ## Node options
 


### PR DESCRIPTION
Using 'Respond to Webhook' Node option isn't shown in v2.2 + above and this pr removes it from the docs to prevent [confusion](https://community.n8n.io/t/respond-to-webhook-node-in-form-is-missing/63075). 