### PR TITLE
Fix task runner GENERIC_TIMEZONE description

### DIFF
--- a/docs/hosting/configuration/task-runners.md
+++ b/docs/hosting/configuration/task-runners.md
@@ -83,6 +83,6 @@ Set the following environment variables for the container, adjusted to fit your 
 | `N8N_RUNNERS_TASK_BROKER_URI=localhost:5679` | The address of the task broker server within the n8n instance. |
 | `N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT=15` | Number of seconds of inactivity to wait before shutting down the task runner process. The launcher will automatically start the runner again when there are new tasks to execute. Set to `0` to disable automatic shutdown. |
 | `NODE_OPTIONS=--max-old-space-size=<limit>` | The memory limit for the task runner Node.js process. This should be lower than the limit for container so that the runner runs out of memory before the container. That way, the launcher is able to monitor the runner. |
-| `GENERIC_TIMEZONE` | * | `America/New_York` | The [same default timezone as configured for the n8n instance](/hosting/configuration/environment-variables/timezone-localization/). |
+| `GENERIC_TIMEZONE` | The [same default timezone as configured for the n8n instance](/hosting/configuration/environment-variables/timezone-localization/). |
 
 For full list of environment variables see [task runner environment variables](/hosting/configuration/environment-variables/task-runners/).


### PR DESCRIPTION
Now it looks like:

![image](https://github.com/user-attachments/assets/d1990e35-12f4-444b-8a07-929b3214762b)

This was due to me copy pasting it and not fixing correctly
