### PR TITLE
adds request type and required body

### DIFF
--- a/docs/source-control-environments/using/copy-work.md
+++ b/docs/source-control-environments/using/copy-work.md
@@ -35,7 +35,7 @@ A common pattern is:
 You can automate parts of the process of copying work, using the `/source-control/pull` API endpoint. Call the API after merging the changes:
 
 ```curl
-curl --request POST
+curl --request POST \
 	--location '<YOUR-INSTANCE-URL>/api/v1/source-control/pull' \
 	--header 'Content-Type: application/json' \
 	--header 'X-N8N-API-KEY: <YOUR-API-KEY>' \

--- a/docs/source-control-environments/using/copy-work.md
+++ b/docs/source-control-environments/using/copy-work.md
@@ -35,9 +35,11 @@ A common pattern is:
 You can automate parts of the process of copying work, using the `/source-control/pull` API endpoint. Call the API after merging the changes:
 
 ```curl
-curl --location '<YOUR-INSTANCE-URL>/api/v1/source-control/pull' \
+curl --request POST
+	--location '<YOUR-INSTANCE-URL>/api/v1/source-control/pull' \
 	--header 'Content-Type: application/json' \
-	--header 'X-N8N-API-KEY: <YOUR-API-KEY>'
+	--header 'X-N8N-API-KEY: <YOUR-API-KEY>' \
+	--data '{"force": true}'
 ```
 
 This means you can use a GitHub Action or GitLab CI/CD to automatically pull changes to the production instance on merge.


### PR DESCRIPTION
This PR updates our docs to make sure that users include the `POST` request and a body as required from the API: https://docs.n8n.io/api/api-reference/#tag/SourceControl when pulling from source control