### PR TITLE
added permissions instruction to docker custom CA docs

### DIFF
--- a/docs/hosting/configuration/configuration-examples/custom-certificate-authority.md
+++ b/docs/hosting/configuration/configuration-examples/custom-certificate-authority.md
@@ -47,5 +47,5 @@ services:
 You should also give the right permissions to the imported certs. You can do this once the container is running:
 
 ```bash
-docker exec --user 0 n8n chown -R /opt/custom-certificates
+docker exec --user 0 n8n chown -R 1000:1000 /opt/custom-certificates
 ```

--- a/docs/hosting/configuration/configuration-examples/custom-certificate-authority.md
+++ b/docs/hosting/configuration/configuration-examples/custom-certificate-authority.md
@@ -44,7 +44,7 @@ services:
         image: docker.n8n.io/n8nio/n8n
 ```
 
-You should also give the right permissions to the imported certs. You can do this once the container is running:
+You should also give the right permissions to the imported certs. You can do this once the container is running (assuming n8n as the container name):
 
 ```bash
 docker exec --user 0 n8n chown -R 1000:1000 /opt/custom-certificates

--- a/docs/hosting/configuration/configuration-examples/custom-certificate-authority.md
+++ b/docs/hosting/configuration/configuration-examples/custom-certificate-authority.md
@@ -43,3 +43,9 @@ services:
             - 5678:5678
         image: docker.n8n.io/n8nio/n8n
 ```
+
+You should also give the right permissions to the imported certs. You can do this once the container is running:
+
+```bash
+docker exec --user 0 n8n chown -R /opt/custom-certificates
+```


### PR DESCRIPTION
https://docs.n8n.io/hosting/configuration/configuration-examples/custom-certificate-authority/

Currently missing instructions on how to correctly set the permissions for the imported CA files