### PR TITLE
Add solarwinds observability credential

### DIFF
--- a/docs/integrations/builtin/credentials/solarwindsobservability.md
+++ b/docs/integrations/builtin/credentials/solarwindsobservability.md
@@ -1,0 +1,28 @@
+---
+#https://www.notion.so/n8n/Frontmatter-432c2b8dff1f43d4b1c8d20075510fe4
+title: SolarWinds Observability SaaS credentials
+description: Documentation for the SolarWinds Observability SaaS credential, Use these credentials to authenticate SolarWinds Observability SaaS in n8n, a workflow automation platform
+contentType: integration
+---
+
+# SolarWinds Observability SaaS credentials
+
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
+
+## Supported authentication methods
+
+* API Token
+
+## Related resources
+
+Refer to [SolarWinds Observability SaaS's API documentation](https://documentation.solarwinds.com/en/success_center/observability/content/api/api-swagger.htm){:target=_blank .external-link} for more information about the service.
+
+
+## Using API Token
+
+To configure this credential, you'll need a SolarWinds Observability SaaS account and:
+
+- URL - The URL you use to access the SolarWinds Observability SaaS platform
+- API Token - An API token found under `Settings > Api Tokens`
+
+Refer to [SolarWinds Observability SaaS's API documentation](https://documentation.solarwinds.com/en/success_center/observability/content/settings/api-tokens.htm){:target=_blank .external-link} for more information about authenticating to the service.

--- a/docs/integrations/builtin/credentials/solarwindsobservability.md
+++ b/docs/integrations/builtin/credentials/solarwindsobservability.md
@@ -23,6 +23,6 @@ Refer to [SolarWinds Observability SaaS's API documentation](https://documentati
 To configure this credential, you'll need a SolarWinds Observability SaaS account and:
 
 - **URL**: The URL you use to access the SolarWinds Observability SaaS platform
-- API Token - An API token found under `Settings > Api Tokens`
+- **API Token**: An API token found in the SolarWinds Observability SaaS platform under **Settings > Api Tokens**
 
 Refer to [SolarWinds Observability SaaS's API documentation](https://documentation.solarwinds.com/en/success_center/observability/content/settings/api-tokens.htm){:target=_blank .external-link} for more information about authenticating to the service.

--- a/docs/integrations/builtin/credentials/solarwindsobservability.md
+++ b/docs/integrations/builtin/credentials/solarwindsobservability.md
@@ -22,7 +22,7 @@ Refer to [SolarWinds Observability SaaS's API documentation](https://documentati
 
 To configure this credential, you'll need a SolarWinds Observability SaaS account and:
 
-- URL - The URL you use to access the SolarWinds Observability SaaS platform
+- **URL**: The URL you use to access the SolarWinds Observability SaaS platform
 - API Token - An API token found under `Settings > Api Tokens`
 
 Refer to [SolarWinds Observability SaaS's API documentation](https://documentation.solarwinds.com/en/success_center/observability/content/settings/api-tokens.htm){:target=_blank .external-link} for more information about authenticating to the service.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1162,12 +1162,12 @@ nav:
         - integrations/builtin/credentials/serp.md
         - integrations/builtin/credentials/servicenow.md
         - integrations/builtin/credentials/sms77.md
-        - integrations/builtin/credentials/solarwindsobservability.md
         - integrations/builtin/credentials/shopify.md
         - integrations/builtin/credentials/shuffler.md
         - integrations/builtin/credentials/signl4.md
         - integrations/builtin/credentials/slack.md
         - integrations/builtin/credentials/snowflake.md
+        - integrations/builtin/credentials/solarwindsobservability.md
         - integrations/builtin/credentials/splunk.md
         - integrations/builtin/credentials/spontit.md
         - integrations/builtin/credentials/spotify.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1162,6 +1162,7 @@ nav:
         - integrations/builtin/credentials/serp.md
         - integrations/builtin/credentials/servicenow.md
         - integrations/builtin/credentials/sms77.md
+        - integrations/builtin/credentials/solarwindsobservability.md
         - integrations/builtin/credentials/shopify.md
         - integrations/builtin/credentials/shuffler.md
         - integrations/builtin/credentials/signl4.md


### PR DESCRIPTION
This is the docs for new credential only node found here: https://github.com/n8n-io/n8n/pull/11805

**API Token Docs:** https://documentation.solarwinds.com/en/success_center/observability/content/settings/api-tokens.htm

**Fields required**
- URL
- API Token

---
The PR has been merged and this credential will be available in `1.73.0`