### PR TITLE
Add SolarWinds IPAM credential

### DIFF
--- a/docs/integrations/builtin/credentials/solarwindsipam.md
+++ b/docs/integrations/builtin/credentials/solarwindsipam.md
@@ -21,7 +21,7 @@ Refer to [SolarWinds IPAM's API documentation](https://github.com/solarwinds/Ori
 To configure this credential, you'll need a SolarWinds IPAM account and:
 
 - URL - The base url for your SolarWinds IPAM server
-- Username - The username you use to access SolarWinds IPAM
+- **Username**: The username you use to access SolarWinds IPAM
 - **Password**: The password you use to access SolarWinds IPAM
 
 Refer to [SolarWinds IPAM's API documentation](https://github.com/solarwinds/OrionSDK/wiki/REST){:target=_blank .external-link} for more information about authenticating to the service.

--- a/docs/integrations/builtin/credentials/solarwindsipam.md
+++ b/docs/integrations/builtin/credentials/solarwindsipam.md
@@ -22,6 +22,6 @@ To configure this credential, you'll need a SolarWinds IPAM account and:
 
 - URL - The base url for your SolarWinds IPAM server
 - Username - The username you use to access SolarWinds IPAM
-- Password - The password you use to access SolarWinds IPAM
+- **Password**: The password you use to access SolarWinds IPAM
 
 Refer to [SolarWinds IPAM's API documentation](https://github.com/solarwinds/OrionSDK/wiki/REST){:target=_blank .external-link} for more information about authenticating to the service.

--- a/docs/integrations/builtin/credentials/solarwindsipam.md
+++ b/docs/integrations/builtin/credentials/solarwindsipam.md
@@ -20,7 +20,7 @@ Refer to [SolarWinds IPAM's API documentation](https://github.com/solarwinds/Ori
 
 To configure this credential, you'll need a SolarWinds IPAM account and:
 
-- URL - The base url for your SolarWinds IPAM server
+- **URL**: The base URL of your SolarWinds IPAM server
 - **Username**: The username you use to access SolarWinds IPAM
 - **Password**: The password you use to access SolarWinds IPAM
 

--- a/docs/integrations/builtin/credentials/solarwindsipam.md
+++ b/docs/integrations/builtin/credentials/solarwindsipam.md
@@ -1,0 +1,27 @@
+---
+#https://www.notion.so/n8n/Frontmatter-432c2b8dff1f43d4b1c8d20075510fe4
+title: SolarWinds IPAM credentials
+description: Documentation for the SolarWinds IPAM credentials. Use these credentials to authenticate SolarWinds IPAM in n8n, a workflow automation platform.
+contentType: integration
+---
+# SolarWinds IPAM credentials
+
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
+
+## Supported authentication methods
+
+* Username & Password
+
+## Related resources
+
+Refer to [SolarWinds IPAM's API documentation](https://github.com/solarwinds/OrionSDK/wiki/REST){:target=_blank .external-link} for more information about the service.
+
+## Using Username & Password
+
+To configure this credential, you'll need a SolarWinds IPAM account and:
+
+- URL - The base url for your SolarWinds IPAM server
+- Username - The username you use to access SolarWinds IPAM
+- Password - The password you use to access SolarWinds IPAM
+
+Refer to [SolarWinds IPAM's API documentation](https://github.com/solarwinds/OrionSDK/wiki/REST){:target=_blank .external-link} for more information about authenticating to the service.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1162,6 +1162,7 @@ nav:
         - integrations/builtin/credentials/serp.md
         - integrations/builtin/credentials/servicenow.md
         - integrations/builtin/credentials/sms77.md
+        - integrations/builtin/credentials/solarwindsipam.md
         - integrations/builtin/credentials/shopify.md
         - integrations/builtin/credentials/shuffler.md
         - integrations/builtin/credentials/signl4.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1162,12 +1162,12 @@ nav:
         - integrations/builtin/credentials/serp.md
         - integrations/builtin/credentials/servicenow.md
         - integrations/builtin/credentials/sms77.md
-        - integrations/builtin/credentials/solarwindsipam.md
         - integrations/builtin/credentials/shopify.md
         - integrations/builtin/credentials/shuffler.md
         - integrations/builtin/credentials/signl4.md
         - integrations/builtin/credentials/slack.md
         - integrations/builtin/credentials/snowflake.md
+        - integrations/builtin/credentials/solarwindsipam.md
         - integrations/builtin/credentials/splunk.md
         - integrations/builtin/credentials/spontit.md
         - integrations/builtin/credentials/spotify.md


### PR DESCRIPTION
This adds the SolarWinds IPAM credential

API Docs: https://github.com/solarwinds/OrionSDK/wiki/REST

PR: https://github.com/n8n-io/n8n/pull/12005

---
This node will be available in `1.73.0`