### PR TITLE
Add cred only node for Microsoft Azure Monitor

### DIFF
--- a/docs/integrations/builtin/credentials/microsoftazuremonitor.md
+++ b/docs/integrations/builtin/credentials/microsoftazuremonitor.md
@@ -1,0 +1,33 @@
+---
+#https://www.notion.so/n8n/Frontmatter-432c2b8dff1f43d4b1c8d20075510fe4
+title: Microsoft Azure Monitor credentials
+description: Documentation for the Microsoft Azure Monitor credentials. Use these credentials to authenticate Microsoft Azure Monitor in n8n, a workflow automation platform.
+contentType: integration
+---
+# Microsoft Azure Monitor credentials
+
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
+
+## Prerequisites
+
+* Create a Microsoft Azure account or subscription
+* An app registered in Microsoft Entra ID
+
+## Supported authentication methods
+
+* OAuth2
+
+## Related resources
+
+Refer to [Microsoft Azure Monitor's API documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/azure-monitor-rest-api-index){:target=_blank .external-link} for more information about the service.
+
+## Using OAuth2
+
+To configure this credential, you'll need a Microsoft Azure account and:
+
+- A **Client ID**
+- A **Client Secret**
+- A **Tenant ID**
+- The **Resource** you plan to access
+
+Refer to [Microsoft Azure Monitor's API documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/api/access-api?tabs=rest#set-up-authentication){:target=_blank .external-link} for more information about authenticating to the service.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1096,6 +1096,7 @@ nav:
         - integrations/builtin/credentials/medium.md
         - integrations/builtin/credentials/messagebird.md
         - integrations/builtin/credentials/metabase.md
+        - integrations/builtin/credentials/microsoftazuremonitor.md
         - integrations/builtin/credentials/microsoft.md
         - integrations/builtin/credentials/microsoftentra.md
         - integrations/builtin/credentials/microsoftsql.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1097,7 +1097,7 @@ nav:
         - integrations/builtin/credentials/messagebird.md
         - integrations/builtin/credentials/metabase.md
         - integrations/builtin/credentials/microsoft.md
-	- integrations/builtin/credentials/microsoftazuremonitor.md
+        - integrations/builtin/credentials/microsoftazuremonitor.md
         - integrations/builtin/credentials/microsoftentra.md
         - integrations/builtin/credentials/microsoftsql.md
         - integrations/builtin/credentials/mindee.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1096,8 +1096,8 @@ nav:
         - integrations/builtin/credentials/medium.md
         - integrations/builtin/credentials/messagebird.md
         - integrations/builtin/credentials/metabase.md
-        - integrations/builtin/credentials/microsoftazuremonitor.md
         - integrations/builtin/credentials/microsoft.md
+	- integrations/builtin/credentials/microsoftazuremonitor.md
         - integrations/builtin/credentials/microsoftentra.md
         - integrations/builtin/credentials/microsoftsql.md
         - integrations/builtin/credentials/mindee.md


### PR DESCRIPTION
Adds docs for credential only node, Dev PR: https://github.com/n8n-io/n8n/pull/12645

API Docs: https://learn.microsoft.com/en-us/azure/azure-monitor/azure-monitor-rest-api-index
Credential Docs: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/api/access-api?tabs=rest#set-up-authentication