### PR TITLE
adds documentation for `N8N_LICENSE_TENANT_ID`

### DIFF
--- a/docs/hosting/configuration/environment-variables/licenses.md
+++ b/docs/hosting/configuration/environment-variables/licenses.md
@@ -20,6 +20,7 @@ To enable enterprise features, you need to add your enterprise license key. You 
 | :------- | :---- | :------- | :---------- |
 | `N8N_HIDE_USAGE_PAGE` | boolean | `false` | Hide the usage and plans page in the app. |
 | `N8N_LICENSE_ACTIVATION_KEY` | String | `''` | Activation key to initialize license. Not applicable if the n8n instance was already activated. |
+| `N8N_LICENSE_TENANT_ID` | Number | `1` | Tenant ID associated with the license. Only set this variable if explicitly instructed by n8n. |
 | `N8N_LICENSE_AUTO_RENEW_ENABLED` | Boolean | `true` | Enables (true) or disables (false) autorenewal for licenses. <br>If disabled, you need to manually renew the license every 10 days by navigating to **Settings** > **Usage and plan**, and pressing `F5`. Failure to renew the license will disable Enterprise features. |
 | `N8N_LICENSE_AUTO_RENEW_OFFSET` | Number | `60 * 60 * 72` (72 hours) | Time in seconds before expiry a license should automatically renew. |
 | `N8N_LICENSE_SERVER_URL` | String | `http://license.n8n.io/v1` | Server URL to retrieve license. |

--- a/docs/hosting/configuration/environment-variables/licenses.md
+++ b/docs/hosting/configuration/environment-variables/licenses.md
@@ -20,9 +20,9 @@ To enable enterprise features, you need to add your enterprise license key. You 
 | :------- | :---- | :------- | :---------- |
 | `N8N_HIDE_USAGE_PAGE` | boolean | `false` | Hide the usage and plans page in the app. |
 | `N8N_LICENSE_ACTIVATION_KEY` | String | `''` | Activation key to initialize license. Not applicable if the n8n instance was already activated. |
-| `N8N_LICENSE_TENANT_ID` | Number | `1` | Tenant ID associated with the license. Only set this variable if explicitly instructed by n8n. |
 | `N8N_LICENSE_AUTO_RENEW_ENABLED` | Boolean | `true` | Enables (true) or disables (false) autorenewal for licenses. <br>If disabled, you need to manually renew the license every 10 days by navigating to **Settings** > **Usage and plan**, and pressing `F5`. Failure to renew the license will disable Enterprise features. |
 | `N8N_LICENSE_AUTO_RENEW_OFFSET` | Number | `60 * 60 * 72` (72 hours) | Time in seconds before expiry a license should automatically renew. |
 | `N8N_LICENSE_SERVER_URL` | String | `http://license.n8n.io/v1` | Server URL to retrieve license. |
+| `N8N_LICENSE_TENANT_ID` | Number | `1` | Tenant ID associated with the license. Only set this variable if explicitly instructed by n8n. |
 | `HTTP_PROXY_LICENSE_SERVER` | String | `http://use:pass@proxy:port`| Proxy server URL for HTTP requests to retrieve license. |
 | `HTTPS_PROXY_LICENSE_SERVER` | String | `https://use:pass@proxy:port` | Proxy server URL for HTTPS requests to retrieve license. |


### PR DESCRIPTION
As mentioned here: https://github.com/n8n-io/n8n/blob/master/packages/%40n8n/benchmark/scripts/run-for-n8n-setup.mjs#L42

This PR adds documentation for the license env variable `N8N_LICENSE_TENANT_ID`