### PR TITLE
Add clarity around variables used with scheduled triggers

### DIFF
--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/common-issues.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/common-issues.md
@@ -38,3 +38,7 @@ To set the timezone for an individual workflow:
 1. Select **Settings**.
 1. Change the **Timezone** setting.
 1. Select **Save**.
+
+### Variables not working as expected
+
+While variables can be used in the scheduled trigger, their values only get evaluated when the workflow is activated. After activating the worfklow, you can alter a variable's value in the settings but it won't change how often the workflow runs. To work around this, you must stop and then re-activate the workflow to apply the updated variable value.

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/common-issues.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/common-issues.md
@@ -42,3 +42,9 @@ To set the timezone for an individual workflow:
 ### Variables not working as expected
 
 While variables can be used in the scheduled trigger, their values only get evaluated when the workflow is activated. After activating the worfklow, you can alter a variable's value in the settings but it won't change how often the workflow runs. To work around this, you must stop and then re-activate the workflow to apply the updated variable value.
+
+### Changing the trigger interval
+
+You can update the scheduled trigger interval at any time but it only gets updated when the workflow is activated. If you change the trigger interval after the workflow is active, the changes won't take effect until you stop and then re-activate the workflow.
+
+Also, the schedule begins from the time when you activate the workflow. For example, if you had originally set a schedule of every 1 hour and it should execute at 12:00, if you changed it to a 2 hour schedule and re-activated the workflow at 11:30, the next execution will be at 13:30, 2 hours from when you activated it.

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/index.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/index.md
@@ -100,6 +100,10 @@ To generate a Cron expression, you can use [crontab guru](https://crontab.guru){
 |Quarterly|`0 0 1 1,4,7,10 *`|At midnight on the 1st of January, April, July, and October.|
 <!-- vale from-write-good.Weasel = YES -->
 
+/// warning | Using variables in the Cron expression
+While variables can be used in the scheduled trigger, their values only get evaluated when the workflow is activated. If you alter a variable's value in the settings after a workflow is activated, the changes won't alter the cron schedule.
+/// 
+
 #### Why there are six asterisks in the Cron expression
 
 The sixth asterisk in the Cron expression represents seconds. Setting this is optional. The node will execute even if you don't set the value for seconds.

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/index.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/index.md
@@ -101,7 +101,7 @@ To generate a Cron expression, you can use [crontab guru](https://crontab.guru){
 <!-- vale from-write-good.Weasel = YES -->
 
 /// warning | Using variables in the Cron expression
-While variables can be used in the scheduled trigger, their values only get evaluated when the workflow is activated. If you alter a variable's value in the settings after a workflow is activated, the changes won't alter the cron schedule.
+While variables can be used in the scheduled trigger, their values only get evaluated when the workflow is activated. If you alter a variable's value in the settings after a workflow is activated, the changes won't alter the cron schedule. To re-evaluate the variable, set the workflow to **Inactive** and then back to **Active** again
 /// 
 
 #### Why there are six asterisks in the Cron expression


### PR DESCRIPTION
Add some clarity around how variables don't work as expected with scheduled triggers:

- Update scheduled trigger page to include a warning around using variables in cron expressions
- Update scheduled triggers common issues page to include details of variables not working as expected