### PR TITLE
Sync insiders submodule to latest version

### DIFF
--- a/docs-site-feature-tests/index.md
+++ b/docs-site-feature-tests/index.md
@@ -43,7 +43,7 @@ Other images like this should expand on click:
 
 ## Links
 
-[This link should open in a new tab](https://example.com/){:target=_blank .external-link}
+[This link should open in a new tab](https://example.com/)
 
 [This link should open in the same tab](/try-it-out/quickstart/)
 
@@ -74,3 +74,5 @@ You should see a list of 5 HTTP Request templates
 You should see the AI Glossary below
 
 --8<-- "_glossary/ai-glossary.md"
+
+Link to [workflows](/glossary/#workflow-n8n){ data-preview } glossary definition with preview.


### PR DESCRIPTION
This updates the insiders submodule to the latest version. Everything seems to be working fine from my testing (refer to [this doc](https://www.notion.so/n8n/Updating-the-docs-theme-36f0c242b5b74c34b3752f1346c71493) for testing options).

I also tested upgrading the `mkdocs-macros-plugin`, but am unsure whether to include that in this PR or a separate one.