### PR TITLE
Upgrade mkdocs-macros-plugin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs-exclude==1.0.2
 mkdocs-glightbox
-mkdocs-macros-plugin==1.0.4
+mkdocs-macros-plugin==1.3.7


### PR DESCRIPTION
This bumps the [`mkdocs-macros-plugin` version](https://github.com/fralau/mkdocs-macros-plugin/releases). The new version doesn't necessarily seem to focus on performance improvements, but is a bit more well-tested.