### PR TITLE
Fix broken links identified by new build output

### DIFF
--- a/_snippets/source-control-environments/multi-instance-one-branch-pros-cons.md
+++ b/_snippets/source-control-environments/multi-instance-one-branch-pros-cons.md
@@ -2,5 +2,5 @@ The advantage of this pattern is that work is instantly available to other envir
 
 The disadvantages are:
 
-* If you push by mistake, there is a risk the work will make it into your production instance. If you [use a GitHub Action to automate pulls](#optional-use-a-github-action-to-automate-pulls) to production, you must either use the multi-instance, multi-branch pattern, or be careful to never push work that you don't want in production.
+* If you push by mistake, there is a risk the work will make it into your production instance. If you [use a GitHub Action to automate pulls](/source-control-environments/create-environments/#optional-use-a-github-action-to-automate-pulls) to production, you must either use the multi-instance, multi-branch pattern, or be careful to never push work that you don't want in production.
 * Pushing and pulling to the same instance can cause data loss as changes are overridden when performing these actions. You should set up processes to ensure content flows in one direction.

--- a/docs/code/cookbook/luxon.md
+++ b/docs/code/cookbook/luxon.md
@@ -15,7 +15,7 @@ n8n passes dates between nodes as strings, so you need to parse them. Luxon make
 Luxon is a JavaScript library. The two convenience [variables](#variables) created by n8n are available when using Python in the Code node, but their functionality is limited:
 
 * You can't perform Luxon operations on these variables. For example, there is no Python equivalent for `$today.minus(...)`.
-* The generic Luxon functionality, such as [Convert date string to Luxon](#convert-date-string-to-Luxon), isn't available for Python users.
+* The generic Luxon functionality, such as [Convert date string to Luxon](#convert-date-string-to-luxon), isn't available for Python users.
 ///	
 
 

--- a/docs/embed/managing-workflows.md
+++ b/docs/embed/managing-workflows.md
@@ -376,8 +376,8 @@ Passing the additional value `active` in your JSON payload:
 
 There are four steps to follow to implement this method:
 
-* Obtain the credentials for each user, and any additional parameters that may be required based on the workflow. See [Obtain user credentials](#obtain-user-credentials) above.
-* Create the n8n credentials for this user. See [Create user credentials](#create-user-credentials) above.
+* Obtain the credentials for each user, and any additional parameters that may be required based on the workflow. See [Obtain user credentials](#1-obtain-user-credentials) above.
+* Create the n8n credentials for this user. See [Create user credentials](#2-create-user-credentials) above.
 * Create the workflow.
 * Call the workflow as needed.
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.respondtowebhook.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.respondtowebhook.md
@@ -11,7 +11,7 @@ priority: critical
 Use the Respond to Webhook node to control the response to incoming webhooks. This node works with the [Webhook](/integrations/builtin/core-nodes/n8n-nodes-base.webhook/) node.
 
 /// note | Runs once for the first data item
-The Respond to Webhook node runs once, using the first incoming data item. Refer to [Return more than one data item](#return-more-than-one-data-item) for more information.
+The Respond to Webhook node runs once, using the first incoming data item. Refer to [Return more than one data item](#return-more-than-one-data-item-deprecated) for more information.
 ///
 
 ## How to use Respond to Webhook

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.ssh.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.ssh.md
@@ -35,7 +35,7 @@ Configure this operation with these parameters:
 ### Download File
 
 - **Credential to connect with**: Select an existing or create a new [SSH credential](/integrations/builtin/credentials/ssh/) to connect with.
-- **Path**: Enter the path for the file you want to download. This path must include the file name. The downloaded file will use this file name. To use a different name, use the **File Name** option. Refer to [Node options](#node-options) for more information.
+- **Path**: Enter the path for the file you want to download. This path must include the file name. The downloaded file will use this file name. To use a different name, use the **File Name** option. Refer to [Download File options](#download-file-options) for more information.
 - **File Property**: Enter the name of the object property that holds the binary data you want to download.
 
 #### Download File options
@@ -46,7 +46,7 @@ You can further configure this operation with the **File Name** option. Use this
 
 - **Credential to connect with**: Select an existing or create a new [SSH credential](/integrations/builtin/credentials/ssh/) to connect with.
 - **Input Binary Field**: Enter the name of the input binary field that contains the file you want to upload.
-- **Target Directory**: The directory to upload the file to. The name of the file is taken from the binary data file name. To enter a different name, use the **File Name** option. Refer to [Node options](#node-options) for more information.
+- **Target Directory**: The directory to upload the file to. The name of the file is taken from the binary data file name. To enter a different name, use the **File Name** option. Refer to [Upload File options](#upload-file-options) for more information.
 
 #### Upload File options
 

--- a/docs/integrations/builtin/credentials/getresponse.md
+++ b/docs/integrations/builtin/credentials/getresponse.md
@@ -41,7 +41,7 @@ To configure this credential, you'll need:
 When you register your application, copy the **OAuth Redirect URL** from n8n and add it as the **Redirect URL** in GetResponse.
 
 /// note | Redirect URL with localhost
-The Redirect URL should be a URL in your domain, for example: `https://mytemplatemaker.example.com/gr_callback`. GetResponse doesn't accept a localhost callback URL. Refer to the [FAQs](#how-do-i-configure-oauth2-credentials-for-a-local-environment) to configure the credentials for the local environment.
+The Redirect URL should be a URL in your domain, for example: `https://mytemplatemaker.example.com/gr_callback`. GetResponse doesn't accept a localhost callback URL. Refer to the [FAQs](#configure-oauth2-credentials-for-a-local-environment) to configure the credentials for the local environment.
 ///
 
 ## Configure OAuth2 credentials for a local environment

--- a/docs/integrations/community-nodes/installation/manual-install.md
+++ b/docs/integrations/community-nodes/installation/manual-install.md
@@ -51,7 +51,7 @@ npm uninstall n8n-nodes-nodeName
 ## Upgrade a community node
 
 /// warning | Breaking changes in versions
-Node developers may introduce breaking changes in new versions of their nodes. A breaking change is an update that breaks previous functionality. Depending on the node versioning approach that a node developer chooses, upgrading to a version with a breaking change could cause all workflows using the node to break. Be careful when upgrading your nodes. If you find that an upgrade causes issues, you can [downgrade](#downgrade-a-community-node).
+Node developers may introduce breaking changes in new versions of their nodes. A breaking change is an update that breaks previous functionality. Depending on the node versioning approach that a node developer chooses, upgrading to a version with a breaking change could cause all workflows using the node to break. Be careful when upgrading your nodes. If you find that an upgrade causes issues, you can [downgrade](#upgrade-or-downgrade-to-a-specific-version).
 ///
 ### Upgrade to the latest version
 


### PR DESCRIPTION
A nice enhancement from the MkDocs version upgrade is that the internal link checker is now spitting out broken internal links. These are the main ones.

The one I couldn't fix was this:

```
INFO    -  Doc file 'privacy-security/privacy.md' contains a link '#__consent', but there is
           no such anchor on this page.
```

This seems to be a special link to get the consent box to pop up again, giving users the chance to change their settings. I need to look into whether we can somehow mark this so the link checker ignores it.