### PR TITLE
Improve first two pages identified by feedback widget

### DIFF
--- a/docs/_workflows/integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches/rss-feed-example.json
+++ b/docs/_workflows/integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches/rss-feed-example.json
@@ -1,0 +1,106 @@
+{
+  "nodes": [
+    {
+      "parameters": {},
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ],
+      "id": "e6e1cfe6-eff1-48bd-b21c-6ba83d4244d9",
+      "name": "When clicking ‘Test workflow’"
+    },
+    {
+      "parameters": {
+        "jsCode": "return [\n\t{\n\t\tjson: {\n\t\t\turl: 'https://medium.com/feed/n8n-io',\n\t\t}\n\t},\n\t{\n\t\tjson: {\n\t\t\turl: 'https://dev.to/feed/n8n',\n\t\t}\n\t}\n];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        220,
+        0
+      ],
+      "id": "137f1128-45b6-4bc4-a9fb-8660baa652a9",
+      "name": "Code"
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "type": "n8n-nodes-base.splitInBatches",
+      "typeVersion": 3,
+      "position": [
+        440,
+        0
+      ],
+      "id": "3449a953-49c2-4a36-ba3d-cbc0573f3f6c",
+      "name": "Loop Over Items"
+    },
+    {
+      "parameters": {
+        "url": "={{ $json.url }}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.rssFeedRead",
+      "typeVersion": 1.1,
+      "position": [
+        660,
+        100
+      ],
+      "id": "cc2e59d7-0a9b-4640-8052-d8f7f8d8c9fe",
+      "name": "RSS Read"
+    }
+  ],
+  "connections": {
+    "When clicking ‘Test workflow’": {
+      "main": [
+        [
+          {
+            "node": "Code",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Code": {
+      "main": [
+        [
+          {
+            "node": "Loop Over Items",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Loop Over Items": {
+      "main": [
+        [],
+        [
+          {
+            "node": "RSS Read",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "RSS Read": {
+      "main": [
+        [
+          {
+            "node": "Loop Over Items",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {},
+  "meta": {
+    "instanceId": "cb484ba7b742928a2048bf8829668bed5b5ad9787579adea888f05980292a4a7"
+  }
+}

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches.md
@@ -12,7 +12,7 @@ The Loop Over Items node helps you loop through data.
 
 The node saves the original incoming data, and with each iteration, returns a predefined amount of data through the **loop** output.
 
-When the node execution completes, it combines all the data and returns it through the **done** output.
+When the node execution completes, it combines all of the processed data and returns it through the **done** output.
 
 ## When to use the Loop Over Items node
 
@@ -34,6 +34,12 @@ Enter the number of items to return with each call.
 ### Reset
 
 If turned on, the node will reset with the current input-data newly initialized with each loop. Use this when you want the Loop Over Items node to treat incoming data as a new set of data instead of a continuation of previous items.
+
+For example, you can use the Loop Over Items node with the reset option and an [If node](/integrations/builtin/core-nodes/n8n-nodes-base.if.md) to query a paginated service when you don't know how many pages you need in advance. The loop queries pages one at a time, performs any processing, and increments the page number. The loop reset ensures the loop recognizes each iteration as a new set of data. The If node evaluates an exit condition to decide whether to perform another iteration or not.
+
+/// warning | Include a valid termination condition
+For workflows like the example described above, it's critical to include a valid termination condition for the loop. If your termination condition never matches, your workflow execution will get stuck in an infinite loop.
+///
 
 When enabled, you can adjust the reset conditions by switching the parameter representation from **Fixed** to **Expression**. The results of your expression evaluation determine when the node will reset item processing.
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches.md
@@ -14,6 +14,15 @@ The node saves the original incoming data, and with each iteration, returns a pr
 
 When the node execution completes, it combines all the data and returns it through the **done** output.
 
+## When to use the Loop Over Items node
+
+n8n automatically processes incoming items. Depending on what you're trying to achieve, you often don't need the Loop Over Items node in your workflow. You can learn more about how n8n processes multiple items on the [looping in n8n](/flow-logic/looping.md) page.
+
+In particular, these two sections are of particular interest to the Loop Over Items node:
+
+* [Loop until all items are processed](/flow-logic/looping.md#loop-until-all-items-are-processed): describes how the Loop Over Items node differs from normal item processing and when you might want to incorporate this node.
+* [Node exceptions](/flow-logic/looping.md#node-exceptions): outlines specific cases and nodes where you may need to use the Loop Over Items node to manually build looping logic.
+
 ## Node parameters
 
 ### Batch Size
@@ -24,11 +33,9 @@ Enter the number of items to return with each call.
 
 ### Reset
 
-If turned on, the node will reset with the current input-data newly initialized with each loop.
+If turned on, the node will reset with the current input-data newly initialized with each loop. Use this when you want the Loop Over Items node to treat incoming data as a new set of data instead of a continuation of previous items.
 
-/// note | Check if you need this node
-n8n automatically processes incoming items. You may not need the Loop Over Items node in your workflow. To learn more about how n8n handles multiple items, refer to the documentation on [Looping in n8n](/flow-logic/looping.md).
-///
+When enabled, you can adjust the reset conditions by switching the parameter representation from **Fixed** to **Expression**. The results of your expression evaluation determine when the node will reset item processing.
 
 ## Templates and examples
 
@@ -43,7 +50,9 @@ The example walks through building the workflow, but assumes you are already fam
 
 The final workflow looks like this:
 
-![A workflow with the Loop Over Items node](/_images/integrations/builtin/core-nodes/splitinbatches/workflow.png)
+[[ workflowDemo("file:///integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches/rss-feed-example.json") ]]
+
+Copy the workflow file above and paste into your instance, or manually build it by following these steps:
 
 1. Add the manual trigger.
 2. Add the Code node.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.airtabletrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.airtabletrigger.md
@@ -10,11 +10,66 @@ priority: medium
 
 [Airtable](https://airtable.com/){:target=_blank .external-link} is a spreadsheet-database hybrid, with the features of a database but applied to a spreadsheet. The fields in an Airtable table are similar to cells in a spreadsheet, but have types such as 'checkbox', 'phone number', and 'drop-down list', and can reference file attachments like images.
 
+On this page, you'll find a list of events the Airtable Trigger node can respond to and links to more resources.
+
 /// note | Credentials
 You can find authentication information for this node [here](/integrations/builtin/credentials/airtable.md).
 ///
 
-///  note  | Examples and templates
-For usage examples and templates to help you get started, refer to n8n's [Airtable Trigger integrations](https://n8n.io/integrations/airtable-trigger/){:target=_blank .external-link} page.
-///
+## Events
 
+* **New Airtable event**
+
+## Related resources
+
+n8n provides an app node for Airtable. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.airtable/index.md).
+
+View [example workflows and related content](https://n8n.io/integrations/airtable-trigger/) on n8n's website.
+
+Refer to [Airtable's documentation](https://airtable.com/developers/web/api/introduction) for details about their API.
+
+## Node parameters
+
+Use these parameters to configure your node.
+
+### Poll Times
+
+n8n's Airtable node uses polling for check for updates on configured Airtable resources. The **Poll Times** parameter configures the querying frequency:
+
+* Every Minute
+* Every Hour
+* Every Day
+* Every Week
+* Every Month
+* Every X: Check for updates every given number of minutes or hours.
+* Custom: Customize the polling interval by providing a [cron expression](https://en.wikipedia.org/wiki/Cron).
+
+Use the **Add Poll Time** button to add more polling intervals.
+
+### Base
+
+The [Airtable base](https://support.airtable.com/docs/airtable-bases-overview) you want to check for updates on. You can provide your base's URL or [base ID](https://support.airtable.com/docs/finding-airtable-ids#finding-base-table-and-view-ids-from-urls).
+
+### Table
+
+The [Airtable table](https://support.airtable.com/docs/tables-overview) within the Airtable base that you want to check for updates on. You can provide the table's URL or [table ID](https://support.airtable.com/docs/finding-airtable-ids#finding-base-table-and-view-ids-from-urls).
+
+### Trigger Field
+
+A created or last modified field in your table. The Airtable Trigger node uses this to determine what updates occurred since the previous check.
+
+### Download Attachments
+
+Whether to download attachments from the table. When enabled, the **Download Fields** parameter defines the attachment fields.
+
+### Download Fields
+
+When you enable the **Download Attachments** toggle, this field defines which table fields to download. Field names are case sensitive. Use a comma to separate multiple field names.
+
+### Additional Fields
+
+Use the **Add Field** button to add the following parameters:
+
+* **Fields**: A comma-separated list of fields to include in the output. If you don't specify anything here, the output will contain only the **Trigger Field**.
+* **Formula**: An [Airtable formula](https://support.airtable.com/docs/formula-field-reference) to further filter the results. You can use this to add further constraints to the events that trigger the workflow. Note that formula values aren't taken into account for manual executions, only for production polling.
+* **View ID**: The name or ID of a table view. When defined, only returns records available in the given view.


### PR DESCRIPTION
Includes changes to the following pages:

* Airtable Trigger node: builds out some of the information more in line with our current templates.
* Loop Over Items node: explains some of the caveats and options just a bit more clearly. Replace an image with an embedded workflow.

It looks like Johannes' recent commit also reverted the update to the insiders submodule, so this one also resets that to the commit we recently updated to.