### PR TITLE
Update templates to link to markdown files directly instead of relative URL links

### DIFF
--- a/document-templates/app-nodes.md
+++ b/document-templates/app-nodes.md
@@ -37,7 +37,7 @@ Use the _Name_ node to automate work in _Name_ and integrate _Name_ with other a
 On this page, you'll find a list of operations the _Name_ node supports, and links to more resources.
 
 ///  note  | Credentials
-You can find authentication information for this node [here](/integrations/builtin/credentials/_Name_/).
+You can find authentication information for this node [here](/integrations/builtin/credentials/_Name_.md).
 ///
 
 
@@ -54,11 +54,11 @@ You can find authentication information for this node [here](/integrations/built
 ## Related resources
 
 <!-- provide a link to the trigger node docs, if there is a trigger node for this service -->
-n8n provides a trigger node for _Name_. You can find the trigger node docs [here](/integrations/builtin/trigger-nodes/n8n-nodes-base._Name_trigger/).
+n8n provides a trigger node for _Name_. You can find the trigger node docs [here](/integrations/builtin/trigger-nodes/n8n-nodes-base._Name_trigger.md).
 
 
 <!-- add a link to the service's documentation. This should usually go direct to the API docs -->
-Refer to [_Name_'s documentation](){:target=_blank .external-link} for more information about the service.
+Refer to [_Name_'s documentation]() for more information about the service.
 
 <!-- IF THE NODE SUPPORTS PREDEFINED CREDS
 let users know they can use the HTTP node if their operation isn't supported 
@@ -74,6 +74,6 @@ Here are some common errors and issues with the _Name_ node and steps to resolve
 <!-- 
 If the node is large enough to warrant subpages, create a separate Common issues page using the common-issues.md template and link to it here using this text:
 
-For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/_relativepath_).
+For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/_filepath_.md).
 
 -->

--- a/document-templates/cluster-nodes.md
+++ b/document-templates/cluster-nodes.md
@@ -19,7 +19,7 @@ Use the _Name_ node to automate work in _Name_ and integrate _Name_ with other a
 On this page, you'll find a list of operations the _Name_ node supports, and links to more resources.
 
 ///  note  | Credentials
-You can find authentication information for this node [here](/integrations/builtin/credentials/_Name_/).
+You can find authentication information for this node [here](/integrations/builtin/credentials/_Name_.md).
 ///
 
 ## Node parameters
@@ -48,7 +48,7 @@ _Description of node option_
 
 ## Related resources
 
-Refer to [_Name_'s documentation](){:target=_blank .external-link} for more information about the service.
+Refer to [_Name_'s documentation]() for more information about the service.
 
 --8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
 --8<-- "_glossary/ai-glossary.md"
@@ -62,6 +62,6 @@ Here are some common errors and issues with the _Name_ node and steps to resolve
 <!-- 
 If the node is large enough to warrant subpages, create a separate Common issues page using the common-issues.md template and link to it here using this text:
 
-For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/_relativepath_).
+For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/_filepath_.md).
 
 -->

--- a/document-templates/common-issues.md
+++ b/document-templates/common-issues.md
@@ -27,7 +27,7 @@ priority: _priority-from-main-node_
 
 # _Name_ node common issues
 
-Here are some common errors and issues with the [_Name_ node](/integrations/builtin/_relativepathtonode_) and steps to resolve or troubleshoot them.
+Here are some common errors and issues with the [_Name_ node](/integrations/builtin/_filepathtonode_.md) and steps to resolve or troubleshoot them.
 
 <!--
 Create a subheading for each error code, issue, or tip.

--- a/document-templates/core-nodes.md
+++ b/document-templates/core-nodes.md
@@ -31,7 +31,7 @@ When you add this node to mkdocs.yml in the navigation, prepend it with the `_Na
 _Briefly summarize the functionality._
 
 /// note | Credentials
-You can find authentication information for this node [here](/integrations/builtin/credentials/_Name_/).
+You can find authentication information for this node [here](/integrations/builtin/credentials/_Name_.md).
 ///
 
 
@@ -64,6 +64,6 @@ Here are some common errors and issues with the _Name_ node and steps to resolve
 <!-- 
 If the node is large enough to warrant subpages, create a separate Common issues page using the common-issues.md template and link to it here using this text:
 
-For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/_relativepath_).
+For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/_filepath_.md).
 
 -->

--- a/document-templates/credentials.md
+++ b/document-templates/credentials.md
@@ -50,11 +50,11 @@ _Include info on services they need to sign up for or required account settings/
 ## Related resources
 
 <!-- add a link to the service's documentation. This should usually go directly to the API credential docs. Amend the link text if necessary. -->
-Refer to [_Name_'s API documentation](){:target=_blank .external-link} for more information about the service.
+Refer to [_Name_'s API documentation]() for more information about the service.
 
 
 <!-- If this is a credential-only node, add a link to the node page on n8n's website. For example: https://n8n.io/integrations/gmail/ 
-This is a credential-only node. Refer to [Custom API operations](/integrations/custom-operations/) to learn more. View [example workflows and related content](https://n8n.io/integrations/_Name_/){:target=_blank .external-link} on n8n's website. -->
+This is a credential-only node. Refer to [Custom API operations](/integrations/custom-operations.md) to learn more. View [example workflows and related content](https://n8n.io/integrations/_Name_/) on n8n's website. -->
 
 
 ## Using _Auth method_
@@ -70,21 +70,21 @@ _Add an intro statement that makes sense. For example: To generate an access tok
 
 <!-- For all credentials, include a link to the service's documentation on this type of authentication. This usually goes directly to API credentials, OAuth, etc.
 Amend the link/sentence text as necessary. -->
-Refer to [_Name_'s API documentation](){:target=_blank .external-link} for more information about authenticating to the service.
+Refer to [_Name_'s API documentation]() for more information about authenticating to the service.
 
 <!-- IF OAUTH FOR CLOUD-HOSTED DOESN'T REQUIRE ANY SETUP, use the section below. Otherwise omit -->
 --8<-- "_snippets/integrations/builtin/credentials/cloud-oauth-button.md"
 
 <!-- If OAuth method, self-hosted usually needs to configure OAuth from scratch. -->
 <!-- For low or unprioritized credentials, use this statement and delete the next one -->
-If you're [self-hosting](/hosting/) n8n, you'll need to _create an app_ to configure OAuth2. Refer to [_Name_'s OAuth documentation](){:target=_blank .external-link} for more information about setting up OAuth2.
+If you're [self-hosting](/hosting/index.md) n8n, you'll need to _create an app_ to configure OAuth2. Refer to [_Name_'s OAuth documentation]() for more information about setting up OAuth2.
 
 <!-- For Medium, High, or Critical credentials, use this section: -->
-If you're [self-hosting](/hosting/) n8n, you'll need to _create an app_ to configure OAuth2. To do so:
+If you're [self-hosting](/hosting/index.md) n8n, you'll need to _create an app_ to configure OAuth2. To do so:
 
 1. _Detailed numbered instructions to create app for OAuth2 and configure credential. Add links to specific docs here if there are any that are relevant._
 
-Refer to [_Name_'s OAuth documentation](){:target=_blank .external-link} for more information about setting up OAuth2.
+Refer to [_Name_'s OAuth documentation]() for more information about setting up OAuth2.
 
 ## Common issues
 
@@ -95,6 +95,6 @@ Here are some common errors and issues with the _Name_ node and steps to resolve
 <!-- 
 If the node is large enough to warrant subpages, create a separate Common issues page using the common-issues.md template and link to it here using this text:
 
-For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/_relativepath_).
+For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/_filepath_.md).
 
 -->

--- a/document-templates/release-notes.md
+++ b/document-templates/release-notes.md
@@ -15,24 +15,24 @@ You can find more info on working with the docs project in the README: https://g
 
 ## n8n@<version-number>
 
-View the [commits](<url for GitHub's 'Comparing changes' view, comparing this release to the previous one>){:target=_blank .external-link} for this version.<br />
+View the [commits](<url for GitHub's 'Comparing changes' view, comparing this release to the previous one>) for this version.<br />
 **Release date:** <yyyy-MM-dd>
 
 _One or two sentence summary of release._
 
-For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases){:target=_blank .external-link} on GitHub.
+For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
 
 <!-- if this release contains breaking changes, include the breaking changes warning 
 
 /// warning | Breaking changes
-Please note that this version contains a breaking change. The minimum Node.js version is now v16. You can read more about it [here](https://github.com/n8n-io/n8n/blob/master/packages/cli/BREAKING-CHANGES.md#02230){:target=_blank .external-link}.
+Please note that this version contains a breaking change. The minimum Node.js version is now v16. You can read more about it [here](https://github.com/n8n-io/n8n/blob/master/packages/cli/BREAKING-CHANGES.md#02230).
 ///
 -->
 
 <!--  Explain the different versions. This note should go on both the latest and next versions, and be updated as the version status updates. For the next version, add: "Use the next version to try n8n's newest features, and to help test 
 
 ///  note  | <Latest/Next> version
-This is the <Latest/Next> version. n8n recommends using the latest version. The next version may be unstable. To report issues, use the [forum](https://community.n8n.io/c/questions/12){:target=_blank .external-link}.
+This is the <Latest/Next> version. n8n recommends using the latest version. The next version may be unstable. To report issues, use the [forum](https://community.n8n.io/c/questions/12).
 ///
 -->
 	

--- a/document-templates/trigger-nodes.md
+++ b/document-templates/trigger-nodes.md
@@ -31,13 +31,13 @@ Match the brand name exactly. For example, GitHub NOT Github.
 
 <!-- Briefly summarize the node. For example:_
 
-Use the _Name_ Trigger node to respond to events in [_Name_](_service-url.com_){:target=_blank .external-link} and integrate _Name_ with other applications. n8n has built-in support for a wide range of _Name_ events, including . . .
+Use the _Name_ Trigger node to respond to events in [_Name_](_service-url.com_) and integrate _Name_ with other applications. n8n has built-in support for a wide range of _Name_ events, including . . .
 -->
 
 On this page, you'll find a list of events the _Name_ Trigger node can respond to and links to more resources.
 
 ///  note  | Credentials
-You can find authentication information for this node [here](/integrations/builtin/credentials/_Name_/).
+You can find authentication information for this node [here](/integrations/builtin/credentials/_Name_.md).
 ///
 
 ## Events
@@ -48,13 +48,13 @@ You can find authentication information for this node [here](/integrations/built
 ## Related resources
 
 <!-- provide a link to the app node docs, if there is an app node for this service -->
-n8n provides an app node for _Name_. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base._Name_/).
+n8n provides an app node for _Name_. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base._Name_.md).
 
 <!-- add a link to the node page on n8n's website. For example: https://n8n.io/integrations/356-gmail/ -->
-View [example workflows and related content](https://n8n.io/integrations/_Name_/){:target=_blank .external-link} on n8n's website.
+View [example workflows and related content](https://n8n.io/integrations/_Name_/) on n8n's website.
 
 <!-- add a link to the service's documentation. This should usually go direct to the API docs -->
-Refer to [_Name_'s documentation](){:target=_blank .external-link} for details about their API.
+Refer to [_Name_'s documentation]() for details about their API.
 
 ## Common issues
 
@@ -65,7 +65,7 @@ Here are some common errors and issues with the _Name_ node and steps to resolve
 <!-- 
 If the node is large enough to warrant subpages, create a separate Common issues page using the common-issues.md template and link to it here using this text:
 
-For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/_relativepath_).
+For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/_filepath_.md).
 
 -->
 


### PR DESCRIPTION
This is a follow up task after changing our repo from relative URL links (like `[link](/path/to/page)`) to absolute file links from the docs directory (like `[link](/path/to/file.md)`).

