### PR TITLE
Add action for checking links in PRs

### DIFF
--- a/.github/workflows/lychee-pr-check.yml
+++ b/.github/workflows/lychee-pr-check.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           args: --config lychee.toml ${{ steps.changed-files.outputs.all_changed_files }}
       - name: Comment Broken Links
+        permissions:
+          contents: read
+          pull-requests: write
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           path: lychee/out.md

--- a/.github/workflows/lychee-pr-check.yml
+++ b/.github/workflows/lychee-pr-check.yml
@@ -3,7 +3,8 @@ on:
   pull_request:
     branches:
       - main
-permissions:
+permissions:  
+  contents: read 
   pull-requests: write
 jobs:
   link-check:

--- a/.github/workflows/lychee-pr-check.yml
+++ b/.github/workflows/lychee-pr-check.yml
@@ -20,13 +20,10 @@ jobs:
         uses: lycheeverse/lychee-action@v1
         with:
           args: --config lychee.toml ${{ steps.changed-files.outputs.all_changed_files }}
-      - name: Comment Broken Links
-        permissions:
-          contents: read
-          pull-requests: write
-        uses: marocchino/sticky-pull-request-comment@v2
+      - name: PR comment with file
+        uses: thollander/actions-comment-pull-request@v3
         with:
-          path: lychee/out.md
+          file-path: lychee/out.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/lychee-pr-check.yml
+++ b/.github/workflows/lychee-pr-check.yml
@@ -17,6 +17,10 @@ jobs:
         uses: lycheeverse/lychee-action@v1
         with:
           args: --config lychee.toml ${{ steps.changed-files.outputs.all_changed_files }}
+      - name: Comment Broken Links
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: lychee/out.md
 
       - name: Report Status
         if: failure()

--- a/.github/workflows/lychee-pr-check.yml
+++ b/.github/workflows/lychee-pr-check.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches:
       - main
+permissions:
+  pull-requests: write
 jobs:
   link-check:
     runs-on: ubuntu-latest
@@ -21,6 +23,8 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           path: lychee/out.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Report Status
         if: failure()


### PR DESCRIPTION
- Adds a new action which runs on PRs
-  checks all changes files for broken external links
- adds a comment to the PR with report if there is a failure

There WILL be false positives on this for a while until the main config excludes all the external sites which block robots.