### PR TITLE
docs: Milvus vector store documentation

### DIFF
--- a/docs/advanced-ai/langchain/langchain-n8n.md
+++ b/docs/advanced-ai/langchain/langchain-n8n.md
@@ -61,6 +61,7 @@ Learn more about [Agents in LangChain](https://js.langchain.com/docs/concepts/ag
 * [Qdrant Vector Store](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreqdrant.md)
 * [Supabase Vector Store](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoresupabase.md)
 * [Zep Vector Store](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorezep.md)
+* [Milvus Vector Store](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremilvus.md)
 
 Learn more about [Vector stores in LangChain](https://js.langchain.com/docs/concepts/vectorstores/){:target=_blank .external-link}.
 

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremilvus.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremilvus.md
@@ -1,0 +1,49 @@
+---
+title: Milvus Vector Store
+description: Documentation for the Milvus node in n8n, a workflow automation platform. Includes details of operations and configuration, and links to examples and credentials information.
+---
+
+# MIlvus Vector Store
+
+Use the Milvus node to interact with your Milvus collection as a vector store. You can insert documents into a vector database, get documents from a vector database, and retrieve documents to provide them to a retriever connected to a chain.
+
+On this page, you'll find the node parameters for the Milvus node, and links to more resources.
+
+/// note | Credentials
+You can find authentication information for this node [here](/integrations/builtin/credentials/milvus/).
+///
+
+/// note | Examples and templates
+For usage examples and templates to help you get started, refer to n8n's [Milvus Vector Store integrations](https://n8n.io/integrations/milvus-vector-store/){:target=_blank .external-link} page.
+///
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
+
+## Node parameters
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/vector-store-mode.md"
+
+### Parameters for Get Many
+
+* Milvus collection name
+* Prompt: search query.
+* Limit: how many results to retrieve from the vector store. For example, set this to `10` to get the ten best results.
+
+### Parameters for Insert Documents
+
+* Milvus collection name
+* Milvus collection creation configuration - Optional
+
+### Parameters for Retrieve Documents (For Agent/Chain)
+
+* Milvus collection name
+
+### Metadata Filter
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-root-nodes/vector-store-metadata-filter.md"
+
+## Related resources
+
+Refer to [LangChain's Milvus documentation](https://js.langchain.com/docs/integrations/vectorstores/milvus/){:target=_blank .external-link} for more information about the service.
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"

--- a/docs/integrations/builtin/credentials/milvus.md
+++ b/docs/integrations/builtin/credentials/milvus.md
@@ -1,0 +1,23 @@
+---
+title: Milvus credentials
+description: Documentation for the Milvus credentials. Use these credentials to authenticate Milvus in n8n, a workflow automation platform.
+---
+
+# Milvus credentials
+
+You can use these credentials to authenticate the following nodes:
+
+* [Milvus Vector Store](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremilvus/)
+
+
+## Prerequisites
+
+You need an API key(token) and Milvus cluster URL to establish a connection.
+
+Refer to [Milvus's authentication docs](https://milvus.io/docs/authenticate.md){:target=_blank .external-link} for guidance on getting your token and URL.
+
+## Related resources
+
+Refer to [MIlvus's documentation](https://milvus.io/docs){:target=_blank .external-link}
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -897,6 +897,7 @@ nav:
           - Qdrant Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreqdrant.md
           - Supabase Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoresupabase.md
           - Zep Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorezep.md
+          - Milvus Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremilvus.md
         - Sub-nodes:
           - integrations/builtin/cluster-nodes/sub-nodes/index.md
           - Default Data Loader: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentdefaultdataloader.md
@@ -1120,6 +1121,7 @@ nav:
         - integrations/builtin/credentials/microsoftazuremonitor.md
         - integrations/builtin/credentials/microsoftentra.md
         - integrations/builtin/credentials/microsoftsql.md
+        - integrations/builtin/credentials/milvus.md
         - integrations/builtin/credentials/mindee.md
         - integrations/builtin/credentials/miro.md
         - integrations/builtin/credentials/misp.md

--- a/styles/config/vocabularies/default/accept.txt
+++ b/styles/config/vocabularies/default/accept.txt
@@ -137,6 +137,7 @@ Meraki
 Metabase
 [Mm]iddleware
 [Mm]illicore
+Milvus
 Mindee
 [Mm]inimum
 Mocean


### PR DESCRIPTION
This PR adds documentation for the new [Milvus](https://milvus.io/) vectorstore.

Implementation PR: https://github.com/n8n-io/n8n/pull/13575