### PR TITLE
Update n8n-nodes-base.googleanalytics.md - possible typo

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.googleanalytics.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.googleanalytics.md
@@ -18,7 +18,7 @@ Refer to [Google Analytics credentials](/integrations/builtin/credentials/google
 ///
 
 --8<-- "_snippets/integrations/builtin/app-nodes/ai-tools.md"
-v
+
 ## Operations
 
 * Report


### PR DESCRIPTION
## Summary
- There seems to be a typo on line before `Operations`, this PR was supposed to remove it

## Reference
N/A