### PR TITLE
Docs for Utopian Labs node

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.utopianlabs.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.utopianlabs.md
@@ -1,0 +1,36 @@
+---
+#https://www.notion.so/n8n/Frontmatter-432c2b8dff1f43d4b1c8d20075510fe4
+title: Utopian Labs node documentation
+description: Learn how to use the Utopian Labs node in n8n. Follow technical documentation to integrate Utopian Labs node into your workflows.
+contentType: [integration, reference]
+priority: medium
+---
+
+# Utopian Labs node
+
+Use the Utopian Labs node to bring AI into your sales workflows. n8n has built-in support for all Utopian Labs agents, including Research, Qualification, Timing, Classification, and Copywriting.
+
+On this page, you'll find a list of operations the Utopian Labs node supports and links to more resources.
+
+/// note | Credentials
+Refer to [Utopian Labs credentials](/integrations/builtin/credentials/utopianlabs.md) for guidance on setting up authentication.
+///
+
+--8<-- "\_snippets/integrations/builtin/app-nodes/ai-tools.md"
+
+## Operations
+
+-   Research a Lead
+-   Qualify a Lead
+-   Trigger a Timing Run
+-   Categorize a Lead
+-   Write an Email
+-   Write an Email Sequence
+
+## Templates and examples
+
+<!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->
+
+[[templatesWidget(page.title, 'utopianlabs')]]
+
+--8<-- "\_snippets/integrations/builtin/app-nodes/operation-not-supported.md"

--- a/docs/integrations/builtin/credentials/utopianlabs.md
+++ b/docs/integrations/builtin/credentials/utopianlabs.md
@@ -1,0 +1,33 @@
+---
+#https://www.notion.so/n8n/Frontmatter-432c2b8dff1f43d4b1c8d20075510fe4
+title: Utopian Labs credentials
+description: Documentation for Utopian Labs credentials. Use these credentials to authenticate Utopian Labs in n8n, a workflow automation platform.
+contentType: [integration, reference]
+priority: medium
+---
+
+# Utopian Labs credentials
+
+You can use these credentials to authenticate the following nodes:
+
+-   [Utopian Labs](/integrations/builtin/app-nodes/n8n-nodes-base.utopianlabs.md)
+
+## Supported authentication methods
+
+-   API token
+
+## Related resources
+
+Refer to [Utopian Labs' developer documentation](https://docs.utopianlabs.ai/){:target=\_blank .external-link} for more information about the service.
+
+## Using API keys
+
+To configure this credential, you'll need a [Utopian Labs](https://utopianlabs.ai/){:target=\_blank .external-link} account and:
+
+-   An **API Key**
+
+To get your API key:
+
+1. Open the [**API Keys page**](https://portal.utopianlabs.ai/api-keys){:target=\_blank .external-link}.
+2. Copy the **API key** and enter it in your n8n credential.
+3. After the API Key is accepted, you can run any agent you want.


### PR DESCRIPTION
PR for the documentation pages for the [Utopian Labs](https://utopianlabs.ai) node. 

We'll open a separate PR for the Utopian Labs node itself in the n8n repo.