### PR TITLE
MongoDB Atlas Vector Store Documentation

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md
@@ -2,12 +2,13 @@
 #https://www.notion.so/n8n/Frontmatter-432c2b8dff1f43d4b1c8d20075510fe4
 title: MongoDB Atlas Vector Store node documentation
 description: Learn how to use the MongoDB Atlas Vector Store node in n8n. Follow technical documentation to integrate MongoDB Atlas Vector Store node into your workflows.
+contentType: [integration, reference]
 priority: medium
 ---
 
 # MongoDB Atlas Vector Store node
 
-MongoDB Atlas Vector Search is a feature of MongoDB Atlas that allows you to store and query vector embeddings. Use this node to interact with Vector Search indexes in your MongoDB Atlas collections. You can insert documents, retrieve documents, and use the vector store in chains or as a tool for agents.
+MongoDB Atlas Vector Search is a feature of MongoDB Atlas that enables users to store and query vector embeddings. Use this node to interact with Vector Search indexes in your MongoDB Atlas collections. You can insert documents, retrieve documents, and use the vector store in chains or as a tool for agents.
 
 On this page, you'll find the node parameters for the MongoDB Atlas Vector Store node, and links to more resources.
 
@@ -19,40 +20,40 @@ You can find authentication information for this node [here](/integrations/built
 
 ## Prerequisites
 
-Before using this node, you need to create a [Vector Search index](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/) in your MongoDB Atlas collection. Follow these steps to create one:
+Before using this node, create a [Vector Search index](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/) in your MongoDB Atlas collection. Follow these steps to create one:
 
 1. Log in to the [MongoDB Atlas dashboard](https://cloud.mongodb.com/).
-2. Select your organization and project.
-3. Find "Search & Vector Search" section.
-4. Select your cluster and click "Go to search"
+
+3. Select your organization and project.
+4. Find "Search & Vector Search" section.
+5. Select your cluster and click "Go to search".
 7. Click "Create Search Index".
-8. Choose "Vector Search" mode and use the visual or JSON editors. Example of a JSON
-
-```json
-{
-  "fields": [
-    {
-      "type": "vector",
-      "path": "<field-name>",
-      "numDimensions": 1536, // any other value
-      "similarity": "<similarity-function>"
-    }
-  ]
-}
-```
-
+8. Choose "Vector Search" mode and use the visual or JSON editors. For example:
+   ```json
+   {
+     "fields": [
+       {
+         "type": "vector",
+         "path": "<field-name>",
+         "numDimensions": 1536, // any other value
+         "similarity": "<similarity-function>"
+       }
+     ]
+   }
+   ```
 
 9. Adjust the "dimensions" value according to your embedding model (e.g., 1536 for default OpenAI's text-embedding-small-3).
 10. Name your index and create.
 
 Make sure to note the following values as you'll need them for the node configuration:
+
 - Collection name
 - Vector index name 
 - Field names for embeddings and metadata
 
 ## Node usage patterns
 
-You can use the MongoDB Atlas Vector Store node in the following patterns.
+You can use the MongoDB Atlas Vector Store node in the following patterns:
 
 ### Use as a regular node to insert and retrieve documents
 

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md
@@ -42,10 +42,10 @@ Before using this node, create a [Vector Search index](https://www.mongodb.com/d
    }
    ```
 
-9. Adjust the "dimensions" value according to your embedding model (e.g., 1536 for default OpenAI's text-embedding-small-3).
+9. Adjust the "dimensions" value according to your embedding model (For example, `1536` for OpenAI's `text-embedding-small-3`).
 10. Name your index and create.
 
-Make sure to note the following values which will be required when configuring the node:
+Make sure to note the following values which are required when configuring the node:
 
 - Collection name
 - Vector index name 

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md
@@ -45,7 +45,7 @@ Before using this node, create a [Vector Search index](https://www.mongodb.com/d
 9. Adjust the "dimensions" value according to your embedding model (e.g., 1536 for default OpenAI's text-embedding-small-3).
 10. Name your index and create.
 
-Make sure to note the following values as you'll need them for the node configuration:
+Make sure to note the following values which will be required when configuring the node:
 
 - Collection name
 - Vector index name 
@@ -63,7 +63,7 @@ You can see an example of this in scenario 1 of [this template](https://n8n.io/w
 
 ### Connect directly to an AI agent as a tool
 
-You can connect the MongoDB Atlas Vector Store node directly to the tool connector of an [AI agent](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/) to use vector store as a resource when answering queries.
+You can connect the MongoDB Atlas Vector Store node directly to the tool connector of an [AI agent](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/) to use the vector store as a resource when answering queries.
 
 Here, the connection would be: AI agent (tools connector) -> MongoDB Atlas Vector Store node.
 
@@ -75,7 +75,7 @@ An [example of the connection flow](https://n8n.io/workflows/1960-ask-questions-
 
 ### Use the Vector Store Question Answer Tool to answer questions
 
-Another pattern uses the [Vector Store Question Answer Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolvectorstore/) to summarize results and answer questions from the MongoDB Atlas Vector Store node. Rather than connecting the MongoDB Atlas Vector Store directly as a tool, this pattern uses a tool specifically designed to summarizes data in the vector store.
+Another pattern uses the [Vector Store Question Answer Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolvectorstore/) to summarize results and answer questions from the MongoDB Atlas Vector Store node. Rather than connecting the MongoDB Atlas Vector Store directly as a tool, this pattern uses a tool specifically designed to summarize data in the vector store.
 
 The [connections flow](https://n8n.io/workflows/2465-building-your-first-whatsapp-chatbot/) (the linked example uses the In-Memory Vector Store, but the pattern is the same) in this case would look like this: AI agent (tools connector) -> Vector Store Question Answer Tool (Vector Store connector) -> In-Memory Vector store.
 
@@ -87,38 +87,38 @@ The [connections flow](https://n8n.io/workflows/2465-building-your-first-whatsap
 ### Get Many parameters
 <!-- vale on -->
 
-* **Mongo Collection**: Enter the name of the MongoDB collection you want to use.
-* **Vector Index Name**: Enter the name of the Vector Search index in your MongoDB Atlas collection.
-* **Embedding Field**: Enter the field name in your documents that contains the vector embeddings.
-* **Metadata Field**: Enter the field name in your documents that contains the text metadata.
+- **Mongo Collection**: Enter the name of the MongoDB collection to use.
+- **Vector Index Name**: Enter the name of the Vector Search index in your MongoDB Atlas collection.
+- **Embedding Field**: Enter the field name in your documents that contains the vector embeddings.
+- **Metadata Field**: Enter the field name in your documents that contains the text metadata.
 
 ### Insert Documents parameters
 
-* **Mongo Collection**: Enter the name of the MongoDB collection you want to use.
-* **Vector Index Name**: Enter the name of the Vector Search index in your MongoDB Atlas collection.
-* **Embedding Field**: Enter the field name in your documents that contains the vector embeddings.
-* **Metadata Field**: Enter the field name in your documents that contains the text metadata.
+- **Mongo Collection**: Enter the name of the MongoDB collection to use.
+- **Vector Index Name**: Enter the name of the Vector Search index in your MongoDB Atlas collection.
+- **Embedding Field**: Enter the field name in your documents that contains the vector embeddings.
+- **Metadata Field**: Enter the field name in your documents that contains the text metadata.
 
 ### Retrieve Documents parameters (As Vector Store for Chain/Tool)
 
-* **Mongo Collection**: Enter the name of the MongoDB collection you want to use.
-* **Vector Index Name**: Enter the name of the Vector Search index in your MongoDB Atlas collection.
-* **Embedding Field**: Enter the field name in your documents that contains the vector embeddings.
-* **Metadata Field**: Enter the field name in your documents that contains the text metadata.
+- **Mongo Collection**: Enter the name of the MongoDB collection to use.
+- **Vector Index Name**: Enter the name of the Vector Search index in your MongoDB Atlas collection.
+- **Embedding Field**: Enter the field name in your documents that contains the vector embeddings.
+- **Metadata Field**: Enter the field name in your documents that contains the text metadata.
 
 ### Retrieve Documents (As Tool for AI Agent) parameters
 
-* **Name**: The name of the vector store.
-* **Description**: Explain to the LLM what this tool does. A good, specific description allows LLMs to produce expected results more often.
-* **Mongo Collection**: Enter the name of the MongoDB collection you want to use.
-* **Vector Index Name**: Enter the name of the Vector Search index in your MongoDB Atlas collection.
-* **Limit**: Enter how many results to retrieve from the vector store. For example, set this to `10` to get the ten best results.
+- **Name**: The name of the vector store.
+- **Description**: Explain to the LLM what this tool does. A good, specific description allows LLMs to produce expected results more often.
+- **Mongo Collection**: Enter the name of the MongoDB collection to use.
+- **Vector Index Name**: Enter the name of the Vector Search index in your MongoDB Atlas collection.
+- **Limit**: Enter how many results to retrieve from the vector store. For example, set this to `10` to get the ten best results.
 
 ## Node options
 
 ### Options
 
-* **Metadata Filter**: Filters results based on metadata.
+- **Metadata Filter**: Filters results based on metadata.
 
 ## Templates and examples
 
@@ -128,8 +128,9 @@ The [connections flow](https://n8n.io/workflows/2465-building-your-first-whatsap
 ## Related resources
 
 Refer to:
-* [LangChain's MongoDB Atlas Vector Search documentation](https://js.langchain.com/docs/integrations/vectorstores/mongodb_atlas){:target=_blank .external-link} for more information about the service.
-* [MongoDB Atlas Vector Search documentation](https://www.mongodb.com/docs/atlas/atlas-vector-search/){:target=_blank .external-link} for more information about MongoDB Atlas Vector Search.
+
+- [LangChain's MongoDB Atlas Vector Search documentation](https://js.langchain.com/docs/integrations/vectorstores/mongodb_atlas){:target=_blank .external-link} for more information about the service.
+- [MongoDB Atlas Vector Search documentation](https://www.mongodb.com/docs/atlas/atlas-vector-search/){:target=_blank .external-link} for more information about MongoDB Atlas Vector Search.
 
 --8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
 

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md
@@ -1,0 +1,102 @@
+---
+#https://www.notion.so/n8n/Frontmatter-432c2b8dff1f43d4b1c8d20075510fe4
+title: MongoDB Atlas Vector Store node documentation
+description: Learn how to use the MongoDB Atlas Vector Store node in n8n. Follow technical documentation to integrate MongoDB Atlas Vector Store node into your workflows.
+priority: medium
+---
+
+# MongoDB Atlas Vector Store node
+
+MongoDB Atlas Vector Search is a feature of MongoDB Atlas that allows you to store and query vector embeddings. Use this node to interact with Vector Search indexes in your MongoDB Atlas collections. You can insert documents, retrieve documents, and use the vector store in chains or as a tool for agents.
+
+On this page, you'll find the node parameters for the MongoDB Atlas Vector Store node, and links to more resources.
+
+/// note | Credentials
+You can find authentication information for this node [here](/integrations/builtin/credentials/mongoDb/).
+///
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
+
+## Node usage patterns
+
+You can use the MongoDB Atlas Vector Store node in the following patterns.
+
+### Use as a regular node to insert and retrieve documents
+
+You can use the MongoDB Atlas Vector Store as a regular node to insert or get documents. This pattern places the MongoDB Atlas Vector Store in the regular connection flow without using an agent.
+
+You can see an example of this in scenario 1 of [this template](https://n8n.io/workflows/2621-ai-agent-to-chat-with-files-in-supabase-storage/) (the template uses the Supabase Vector Store, but the pattern is the same).
+
+### Connect directly to an AI agent as a tool
+
+You can connect the MongoDB Atlas Vector Store node directly to the tool connector of an [AI agent](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/) to use vector store as a resource when answering queries.
+
+Here, the connection would be: AI agent (tools connector) -> MongoDB Atlas Vector Store node.
+
+### Use a retriever to fetch documents
+
+You can use the [Vector Store Retriever](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrievervectorstore/) node with the MongoDB Atlas Vector Store node to fetch documents from the MongoDB Atlas Vector Store node. This is often used with the [Question and Answer Chain](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainretrievalqa/) node to fetch documents from the vector store that match the given chat input.
+
+An [example of the connection flow](https://n8n.io/workflows/1960-ask-questions-about-a-pdf-using-ai/) (the linked example uses Pinecone, but the pattern is the same) would be: Question and Answer Chain (Retriever connector) -> Vector Store Retriever (Vector Store connector) -> MongoDB Atlas Vector Store.
+
+### Use the Vector Store Question Answer Tool to answer questions
+
+Another pattern uses the [Vector Store Question Answer Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolvectorstore/) to summarize results and answer questions from the MongoDB Atlas Vector Store node. Rather than connecting the MongoDB Atlas Vector Store directly as a tool, this pattern uses a tool specifically designed to summarizes data in the vector store.
+
+The [connections flow](https://n8n.io/workflows/2465-building-your-first-whatsapp-chatbot/) (the linked example uses the In-Memory Vector Store, but the pattern is the same) in this case would look like this: AI agent (tools connector) -> Vector Store Question Answer Tool (Vector Store connector) -> In-Memory Vector store.
+
+## Node parameters
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/vector-store-mode.md"
+
+<!-- vale off -->
+### Get Many parameters
+<!-- vale on -->
+
+* **Mongo Collection**: Enter the name of the MongoDB collection you want to use.
+* **Vector Index Name**: Enter the name of the Vector Search index in your MongoDB Atlas collection.
+* **Embedding Field**: Enter the field name in your documents that contains the vector embeddings.
+* **Metadata Field**: Enter the field name in your documents that contains the text metadata.
+
+### Insert Documents parameters
+
+* **Mongo Collection**: Enter the name of the MongoDB collection you want to use.
+* **Vector Index Name**: Enter the name of the Vector Search index in your MongoDB Atlas collection.
+* **Embedding Field**: Enter the field name in your documents that contains the vector embeddings.
+* **Metadata Field**: Enter the field name in your documents that contains the text metadata.
+
+### Retrieve Documents parameters (As Vector Store for Chain/Tool)
+
+* **Mongo Collection**: Enter the name of the MongoDB collection you want to use.
+* **Vector Index Name**: Enter the name of the Vector Search index in your MongoDB Atlas collection.
+* **Embedding Field**: Enter the field name in your documents that contains the vector embeddings.
+* **Metadata Field**: Enter the field name in your documents that contains the text metadata.
+
+### Retrieve Documents (As Tool for AI Agent) parameters
+
+* **Name**: The name of the vector store.
+* **Description**: Explain to the LLM what this tool does. A good, specific description allows LLMs to produce expected results more often.
+* **Mongo Collection**: Enter the name of the MongoDB collection you want to use.
+* **Vector Index Name**: Enter the name of the Vector Search index in your MongoDB Atlas collection.
+* **Limit**: Enter how many results to retrieve from the vector store. For example, set this to `10` to get the ten best results.
+
+## Node options
+
+### Options
+
+* **Metadata Filter**: Filters results based on metadata.
+
+## Templates and examples
+
+<!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->
+[[ templatesWidget(page.title, 'mongodb-atlas-vector-store') ]]
+
+## Related resources
+
+Refer to:
+* [LangChain's MongoDB Atlas Vector Search documentation](https://js.langchain.com/docs/integrations/vectorstores/mongodb_atlas){:target=_blank .external-link} for more information about the service.
+* [MongoDB Atlas Vector Search documentation](https://www.mongodb.com/docs/atlas/atlas-vector-search/){:target=_blank .external-link} for more information about MongoDB Atlas Vector Search.
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
+
+--8<-- "_snippets/self-hosting/starter-kits/self-hosted-ai-starter-kit.md"

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md
@@ -17,6 +17,39 @@ You can find authentication information for this node [here](/integrations/built
 
 --8<-- "_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
 
+## Prerequisites
+
+Before using this node, you need to create a [Vector Search index](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/) in your MongoDB Atlas collection. Follow these steps to create one:
+
+1. Log in to the [MongoDB Atlas dashboard](https://cloud.mongodb.com/).
+2. Select your organization and project.
+3. Find "Search & Vector Search" section.
+4. Select your cluster and click "Go to search"
+7. Click "Create Search Index".
+8. Choose "Vector Search" mode and use the visual or JSON editors. Example of a JSON
+
+```json
+{
+  "fields": [
+    {
+      "type": "vector",
+      "path": "<field-name>",
+      "numDimensions": 1536, // any other value
+      "similarity": "<similarity-function>"
+    }
+  ]
+}
+```
+
+
+9. Adjust the "dimensions" value according to your embedding model (e.g., 1536 for default OpenAI's text-embedding-small-3).
+10. Name your index and create.
+
+Make sure to note the following values as you'll need them for the node configuration:
+- Collection name
+- Vector index name 
+- Field names for embeddings and metadata
+
 ## Node usage patterns
 
 You can use the MongoDB Atlas Vector Store node in the following patterns.

--- a/docs/integrations/builtin/credentials/mongodb.md
+++ b/docs/integrations/builtin/credentials/mongodb.md
@@ -11,6 +11,7 @@ priority: medium
 You can use these credentials to authenticate the following nodes:
 
 - [MongoDB](/integrations/builtin/app-nodes/n8n-nodes-base.mongodb.md)
+- [MongoDB Atlas Vector Store](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md)
 
 ## Prerequisites
 


### PR DESCRIPTION
This pull request adds documentation for the MongoDB Atlas Vector Store node in n8n, including detailed usage patterns, node parameters, and related resources. Additionally, it updates the credentials documentation to include the new node.

Documentation additions:

* [`docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md`](diffhunk://#diff-56728f466af3deab9c00b68b64ec75a253fc49493ae96fb384c710e6565dd033R1-R102): Added comprehensive documentation for the MongoDB Atlas Vector Store node, including usage patterns, node parameters, and related resources.

Credentials update:

* [`docs/integrations/builtin/credentials/mongodb.md`](diffhunk://#diff-49c9d9acb9f503555afd261310d683c22048925c2fbd0143d40bdaceddfb8c43R14): Updated to include the MongoDB Atlas Vector Store node in the list of nodes that can use MongoDB credentials.

Related node PR:
https://github.com/n8n-io/n8n/pull/12924

