### PR TITLE
Update npm.md to remove Windows note

### DIFF
--- a/docs/hosting/installation/npm.md
+++ b/docs/hosting/installation/npm.md
@@ -49,9 +49,7 @@ n8n
 n8n start
 ```
 
-/// note | Keep in mind
-Windows users remember to change into the `.n8n` directory of your Home folder (`~/.n8n`) before running `n8n start`.
-///
+
 ### Next steps
 
 Try out n8n using the [Quickstarts](/try-it-out/index.md).


### PR DESCRIPTION
Remove note to Windows users - n8n will start without them navigating into that directory, and n8n should autodetect home folder.