### PR TITLE
Add action to redirect support  requests

### DIFF
--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -1,0 +1,30 @@
+name: 'Support Requests'
+
+on:
+  issues:
+    types: [labeled, unlabeled, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/support-requests@47d5ea12f6c9e4a081637de9626b7319b415a3bf
+        with:
+          github-token: ${{ github.token }}
+          support-label: 'support'
+          issue-comment: >
+            :wave: @{issue-author}. Sorry you are having a problem!
+            This repository is for the n8n documentation though. Having
+            looked at your issue we think you'd get quicker help with your
+            problem by [posting on the community forum](https://community.n8n.io/c/questions/12),
+            where experts from n8n and our community can provide answers
+            to your questions. 
+            If you think this issue is specifically to do with the documentation,
+            please re-open and explain what you would like to see in docs to resolve it.
+          close-issue: true
+          issue-close-reason: 'not planned'
+          lock-issue: false
+          issue-lock-reason: 'off-topic'


### PR DESCRIPTION
This action monitors the issue labels.
When an issue is labelled 'support' it will receive the automatic reply linking to the support forum and the issue will be closed.