### PR TITLE
Add Events and Related Resources to some trigger nodes

### DIFF
--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.activecampaigntrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.activecampaigntrigger.md
@@ -17,3 +17,13 @@ You can find authentication information for this node [here](/integrations/built
 ///  note  | Examples and templates
 For usage examples and templates to help you get started, refer to n8n's [ActiveCampaign Trigger integrations](https://n8n.io/integrations/activecampaign-trigger/){:target=_blank .external-link} page.
 ///
+
+## Events
+
+* New ActiveCampaign event
+
+## Related resources
+
+n8n provides an app node for ActiveCampaign. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.activecampaign.md).
+
+View [example workflows and related content](https://n8n.io/integrations/activecampaign-trigger/) on n8n's website.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.activecampaigntrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.activecampaigntrigger.md
@@ -27,3 +27,5 @@ For usage examples and templates to help you get started, refer to n8n's [Active
 n8n provides an app node for ActiveCampaign. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.activecampaign.md).
 
 View [example workflows and related content](https://n8n.io/integrations/activecampaign-trigger/) on n8n's website.
+
+Refer to [ActiveCampaign's documentation](https://developers.activecampaign.com/reference/overview) for details about their API.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.acuityschedulingtrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.acuityschedulingtrigger.md
@@ -16,3 +16,11 @@ You can find authentication information for this node [here](/integrations/built
 ///  note  | Examples and templates
 For usage examples and templates to help you get started, refer to n8n's [Acuity Scheduling Trigger integrations](https://n8n.io/integrations/acuity-scheduling-trigger/){:target=_blank .external-link} page.
 ///
+
+## Events
+
+* Appointment canceled
+* Appointment changed
+* Appointment rescheduled
+* Appointment scheduled
+* Order completed

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.affinitytrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.affinitytrigger.md
@@ -59,3 +59,5 @@ For usage examples and templates to help you get started, refer to n8n's [Affini
 n8n provides an app node for Affinity. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.affinity.md).
 
 View [example workflows and related content](https://n8n.io/integrations/affinity-trigger/) on n8n's website.
+
+Refer to [Affinity's documentation](https://api-docs.affinity.co/) for details about their API.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.affinitytrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.affinitytrigger.md
@@ -16,3 +16,46 @@ You can find authentication information for this node [here](/integrations/built
 ///  note  | Examples and templates
 For usage examples and templates to help you get started, refer to n8n's [Affinity Trigger integrations](https://n8n.io/integrations/affinity-trigger/){:target=_blank .external-link} page.
 ///
+
+## Events
+
+* Field value
+  * Created
+  * Deleted
+  * Updated
+* Field
+  * Created
+  * Deleted
+  * Updated
+* File
+  * Created
+  * Deleted
+* List entry
+  * Created
+  * Deleted
+* List
+  * Created
+  * Deleted
+  * Updated
+* Note
+  * Created
+  * Deleted
+  * Updated
+* Opportunity
+  * Created
+  * Deleted
+  * Updated
+* Organization
+  * Created
+  * Deleted
+  * Updated
+* Person
+  * Created
+  * Deleted
+  * Updated
+
+## Related resources
+
+n8n provides an app node for Affinity. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.affinity.md).
+
+View [example workflows and related content](https://n8n.io/integrations/affinity-trigger/) on n8n's website.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.asanatrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.asanatrigger.md
@@ -16,3 +16,13 @@ You can find authentication information for this node [here](/integrations/built
 ///  note  | Examples and templates
 For usage examples and templates to help you get started, refer to n8n's [Asana Trigger integrations](https://n8n.io/integrations/asana-trigger/){:target=_blank .external-link} page.
 ///
+
+## Events
+
+* New Asana event
+
+## Related resources
+
+n8n provides an app node for Asana. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.asana.md).
+
+View [example workflows and related content](https://n8n.io/integrations/asana-trigger/) on n8n's website.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.asanatrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.asanatrigger.md
@@ -26,3 +26,5 @@ For usage examples and templates to help you get started, refer to n8n's [Asana 
 n8n provides an app node for Asana. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.asana.md).
 
 View [example workflows and related content](https://n8n.io/integrations/asana-trigger/) on n8n's website.
+
+Refer to [Asana's documentation](https://developers.asana.com/reference/rest-api-reference) for details about their API.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.awssnstrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.awssnstrigger.md
@@ -26,3 +26,5 @@ For usage examples and templates to help you get started, refer to n8n's [AWS SN
 n8n provides an app node for AWS SNS. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.awssns.md).
 
 View [example workflows and related content](https://n8n.io/integrations/aws-sns-trigger/) on n8n's website.
+
+Refer to [AWS SNS's documentation](https://docs.aws.amazon.com/sns/latest/api/welcome.html) for details about their API.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.awssnstrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.awssnstrigger.md
@@ -16,3 +16,13 @@ You can find authentication information for this node [here](/integrations/built
 ///  note  | Examples and templates
 For usage examples and templates to help you get started, refer to n8n's [AWS SNS Trigger integrations](https://n8n.io/integrations/aws-sns-trigger/){:target=_blank .external-link} page.
 ///
+
+## Events
+
+* New AWS SNS event
+
+## Related resources
+
+n8n provides an app node for AWS SNS. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.awssns.md).
+
+View [example workflows and related content](https://n8n.io/integrations/aws-sns-trigger/) on n8n's website.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.brevotrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.brevotrigger.md
@@ -37,3 +37,5 @@ For usage examples and templates to help you get started, refer to n8n's [Brevo 
 n8n provides an app node for Brevo. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.brevo.md).
 
 View [example workflows and related content](https://n8n.io/integrations/brevo-trigger/) on n8n's website.
+
+Refer to [Brevo's documentation](https://developers.brevo.com/) for details about their API.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.brevotrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.brevotrigger.md
@@ -17,3 +17,23 @@ You can find authentication information for this node [here](/integrations/built
 For usage examples and templates to help you get started, refer to n8n's [Brevo Trigger integrations](https://n8n.io/integrations/brevo-trigger/){:target=_blank .external-link} page.
 ///
 
+## Events
+
+* Email blocked
+* Email clicked
+* Email deferred
+* Email delivered
+* Email hard bounce
+* Email invalid
+* Email marked spam
+* Email opened
+* Email sent
+* Email soft bounce
+* Email unique open
+* Email unsubscribed
+
+## Related resources
+
+n8n provides an app node for Brevo. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.brevo.md).
+
+View [example workflows and related content](https://n8n.io/integrations/brevo-trigger/) on n8n's website.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.calendlytrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.calendlytrigger.md
@@ -17,3 +17,8 @@ You can find authentication information for this node [here](/integrations/built
 ///  note  | Examples and templates
 For usage examples and templates to help you get started, refer to n8n's [Calendly Trigger integrations](https://n8n.io/integrations/calendly-trigger/){:target=_blank .external-link} page.
 ///
+
+## Events
+
+* Event created
+* Event canceled

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.caltrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.caltrigger.md
@@ -17,4 +17,9 @@ You can find authentication information for this node [here](/integrations/built
 For usage examples and templates to help you get started, refer to n8n's [Cal Trigger integrations](https://n8n.io/integrations/cal-trigger/){:target=_blank .external-link} page.
 ///
 
+## Events
 
+* Booking cancelled
+* Booking created
+* Booking rescheduled
+* Meeting ended

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.clickuptrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.clickuptrigger.md
@@ -17,3 +17,38 @@ You can find authentication information for this node [here](/integrations/built
 ///  note  | Examples and templates
 For usage examples and templates to help you get started, refer to n8n's [ClickUp Trigger integrations](https://n8n.io/integrations/clickup-trigger/){:target=_blank .external-link} page.
 ///
+
+## Events
+
+* Key result
+  * Created
+  * Deleted
+  * Updated
+* List
+  * Created
+  * Deleted
+  * Updated
+* Space
+  * Created
+  * Deleted
+  * Updated
+* Task
+  * Assignee updated
+  * Comment
+    * Posted
+    * Updated
+  * Created
+  * Deleted
+  * Due date updated
+  * Moved
+  * Status updated
+  * Tag updated
+  * Time estimate updated
+  * Time tracked updated
+  * Updated
+
+## Related resources
+
+n8n provides an app node for ClickUp. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.clickup.md).
+
+View [example workflows and related content](https://n8n.io/integrations/clickup-trigger/) on n8n's website.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.clickuptrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.clickuptrigger.md
@@ -52,3 +52,5 @@ For usage examples and templates to help you get started, refer to n8n's [ClickU
 n8n provides an app node for ClickUp. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.clickup.md).
 
 View [example workflows and related content](https://n8n.io/integrations/clickup-trigger/) on n8n's website.
+
+Refer to [ClickUp's documentation](https://developer.clickup.com/docs/index) for details about their API.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.convertkittrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.convertkittrigger.md
@@ -36,3 +36,5 @@ For usage examples and templates to help you get started, refer to n8n's [Conver
 n8n provides an app node for ConvertKit. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.convertkit.md).
 
 View [example workflows and related content](https://n8n.io/integrations/convertkit-trigger/) on n8n's website.
+
+Refer to [ConvertKit's documentation](https://developers.kit.com/v4#introduction) for details about their API.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.convertkittrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.convertkittrigger.md
@@ -16,3 +16,23 @@ You can find authentication information for this node [here](/integrations/built
 ///  note  | Examples and templates
 For usage examples and templates to help you get started, refer to n8n's [ConvertKit Trigger integrations](https://n8n.io/integrations/convertkit-trigger/){:target=_blank .external-link} page.
 ///
+
+## Events
+
+* Form subscribe
+* Link click
+* Product purchase
+* Purchase created
+* Purchase complete
+* Sequence complete
+* Sequence subscribe
+* Subscriber activated
+* Subscriber unsubscribe
+* Tag add
+* Tag Remove
+
+## Related resources
+
+n8n provides an app node for ConvertKit. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.convertkit.md).
+
+View [example workflows and related content](https://n8n.io/integrations/convertkit-trigger/) on n8n's website.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.coppertrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.coppertrigger.md
@@ -16,3 +16,17 @@ You can find authentication information for this node [here](/integrations/built
 ///  note  | Examples and templates
 For usage examples and templates to help you get started, refer to n8n's [Copper Trigger integrations](https://n8n.io/integrations/copper-trigger/){:target=_blank .external-link} page.
 ///
+
+## Events
+
+* Delete
+* New
+* Update
+
+## Related resources
+
+n8n provides an app node for Copper. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.copper.md).
+
+View [example workflows and related content](https://n8n.io/integrations/copper-trigger/) on n8n's website.
+
+Refer to [Copper's documentation](https://developer.copper.com/) for details about their API.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.customeriotrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.customeriotrigger.md
@@ -16,3 +16,50 @@ You can find authentication information for this node [here](/integrations/built
 ///  note  | Examples and templates
 For usage examples and templates to help you get started, refer to n8n's [Customer.io Trigger integrations](https://n8n.io/integrations/customerio-trigger/){:target=_blank .external-link} page.
 ///
+
+## Events
+
+* Customer
+  * Subscribed
+  * Unsubscribe
+* Email
+  * Bounced
+  * Clicked
+  * Converted
+  * Delivered
+  * Drafted
+  * Failed
+  * Opened
+  * Sent
+  * Spammed
+* Push
+  * Attempted
+  * Bounced
+  * Clicked
+  * Delivered
+  * Drafted
+  * Failed
+  * Opened
+  * Sent
+* Slack
+  * Attempted
+  * Clicked
+  * Drafted
+  * Failed
+  * Sent
+* Sms
+  * Attempted
+  * Bounced
+  * Clicked
+  * Delivered
+  * Drafted
+  * Failed
+  * Sent
+
+## Related resources
+
+n8n provides an app node for Customer.io. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.customerio.md).
+
+View [example workflows and related content](https://n8n.io/integrations/customerio-trigger/) on n8n's website.
+
+Refer to [Customer.io's documentation](https://docs.customer.io/api/) for details about their API.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.flowtrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.flowtrigger.md
@@ -16,3 +16,15 @@ You can find authentication information for this node [here](/integrations/built
 ///  note  | Examples and templates
 For usage examples and templates to help you get started, refer to n8n's [Flow Trigger integrations](https://n8n.io/integrations/flow-trigger/){:target=_blank .external-link} page.
 ///
+
+## Events
+
+* New Flow event
+
+## Related resources
+
+n8n provides an app node for Flow. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.flow.md).
+
+View [example workflows and related content](https://n8n.io/integrations/flow-trigger/) on n8n's website.
+
+Refer to [Flow's documentation](https://developer.getflow.com/api/) for details about their API.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.githubtrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.githubtrigger.md
@@ -17,3 +17,55 @@ You can find authentication information for this node [here](/integrations/built
 ///  note  | Examples and templates
 For usage examples and templates to help you get started, refer to n8n's [GitHub Trigger integrations](https://n8n.io/integrations/github-trigger/){:target=_blank .external-link} page.
 ///
+
+## Events
+
+* Check run
+* Check suite
+* Commit comment
+* Create
+* Delete
+* Deploy key
+* Deployment
+* Deployment status
+* Fork
+* GitHub app authorization
+* Gollum
+* Installation
+* Installation repositories
+* Issue comment
+* Label
+* Marketplace purchase
+* Member
+* Membership
+* Meta
+* Milestone
+* Org block
+* Organization
+* Page build
+* Project
+* Project card
+* Project column
+* Public
+* Pull request
+* Pull request review
+* Pull request review comment
+* Push
+* Release
+* Repository
+* Repository import
+* Repository vulnerability alert
+* Security advisory
+* Star
+* Status
+* Team
+* Team add
+* Watch
+
+## Related resources
+
+n8n provides an app node for GitHub. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.github.md).
+
+View [example workflows and related content](https://n8n.io/integrations/github-trigger/) on n8n's website.
+
+Refer to [GitHub's documentation](https://docs.github.com/en/rest) for details about their API.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.gitlabtrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.gitlabtrigger.md
@@ -14,6 +14,23 @@ priority: medium
 You can find authentication information for this node [here](/integrations/builtin/credentials/gitlab.md).
 ///
 
-///  note  | Examples and templates
+## Events
+
+* Comment
+* Confidential issues
+* Confidential comments
+* Deployments
+* Issue
+* Job
+* Merge request
+* Pipeline
+* Push
+* Release
+* Tag
+* Wiki page
+
+## Related resources
+
+n8n provides an app node for GitLab. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.gitlab.md).
+
 For usage examples and templates to help you get started, refer to n8n's [GitLab Trigger integrations](https://n8n.io/integrations/gitlab-trigger/){:target=_blank .external-link} page.
-///

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.gitlabtrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.gitlabtrigger.md
@@ -14,6 +14,10 @@ priority: medium
 You can find authentication information for this node [here](/integrations/builtin/credentials/gitlab.md).
 ///
 
+///  note  | Examples and templates
+For usage examples and templates to help you get started, refer to n8n's [GitLab Trigger integrations](https://n8n.io/integrations/gitlab-trigger/){:target=_blank .external-link} page.
+///
+
 ## Events
 
 * Comment
@@ -33,4 +37,6 @@ You can find authentication information for this node [here](/integrations/built
 
 n8n provides an app node for GitLab. You can find the node docs [here](/integrations/builtin/app-nodes/n8n-nodes-base.gitlab.md).
 
-For usage examples and templates to help you get started, refer to n8n's [GitLab Trigger integrations](https://n8n.io/integrations/gitlab-trigger/){:target=_blank .external-link} page.
+View [example workflows and related content](https://n8n.io/integrations/gitlab-trigger/) on n8n's website.
+
+Refer to [GitLab's documentation](https://docs.gitlab.com/api/rest/) for details about their API.


### PR DESCRIPTION
Add Events and Related Resources to some trigger nodes.

Updated trigger nodes:
- ActiveCampaign
- Acuity scheduling
- Affinity
- Asana
- AWS SNS
- Brevo
- Calendly
- Cal.com
- ClickUp
- ConvertKit
- Copper
- Customer.io
- Flow
- GitHub
- GitLab