### PR TITLE
Adjust course button styles and remove cached Airtable bases

### DIFF
--- a/docs/_workflows/courses/level-one/chapter-5/chapter-5.2.json
+++ b/docs/_workflows/courses/level-one/chapter-5/chapter-5.2.json
@@ -38,15 +38,13 @@
           "__rl": true,
           "value": "app9nOVsRxdypoknP",
           "mode": "list",
-          "cachedResultName": "beginner course",
-          "cachedResultUrl": "https://airtable.com/app9nOVsRxdypoknP"
+          "cachedResultName": "beginner course"
         },
         "table": {
           "__rl": true,
           "value": "tblo2KuMyn5X4jU0s",
           "mode": "list",
-          "cachedResultName": "orders",
-          "cachedResultUrl": "https://airtable.com/app9nOVsRxdypoknP/tblo2KuMyn5X4jU0s"
+          "cachedResultName": "orders"
         },
         "columns": {
           "mappingMode": "autoMapInputData",

--- a/docs/_workflows/courses/level-one/chapter-5/chapter-5.3.json
+++ b/docs/_workflows/courses/level-one/chapter-5/chapter-5.3.json
@@ -38,15 +38,13 @@
           "__rl": true,
           "value": "app9nOVsRxdypoknP",
           "mode": "list",
-          "cachedResultName": "beginner course",
-          "cachedResultUrl": "https://airtable.com/app9nOVsRxdypoknP"
+          "cachedResultName": "beginner course"
         },
         "table": {
           "__rl": true,
           "value": "tblo2KuMyn5X4jU0s",
           "mode": "list",
-          "cachedResultName": "orders",
-          "cachedResultUrl": "https://airtable.com/app9nOVsRxdypoknP/tblo2KuMyn5X4jU0s"
+          "cachedResultName": "orders"
         },
         "columns": {
           "mappingMode": "autoMapInputData",

--- a/docs/_workflows/courses/level-one/chapter-5/chapter-5.4.json
+++ b/docs/_workflows/courses/level-one/chapter-5/chapter-5.4.json
@@ -38,15 +38,13 @@
           "__rl": true,
           "value": "app9nOVsRxdypoknP",
           "mode": "list",
-          "cachedResultName": "beginner course",
-          "cachedResultUrl": "https://airtable.com/app9nOVsRxdypoknP"
+          "cachedResultName": "beginner course"
         },
         "table": {
           "__rl": true,
           "value": "tblTIOsm4BLJD9Tql",
           "mode": "list",
-          "cachedResultName": "processingOrders",
-          "cachedResultUrl": "https://airtable.com/app9nOVsRxdypoknP/tblTIOsm4BLJD9Tql"
+          "cachedResultName": "processingOrders"
         },
         "columns": {
           "mappingMode": "autoMapInputData",

--- a/docs/_workflows/courses/level-one/chapter-5/chapter-5.5.json
+++ b/docs/_workflows/courses/level-one/chapter-5/chapter-5.5.json
@@ -38,15 +38,13 @@
           "__rl": true,
           "value": "app9nOVsRxdypoknP",
           "mode": "list",
-          "cachedResultName": "beginner course",
-          "cachedResultUrl": "https://airtable.com/app9nOVsRxdypoknP"
+          "cachedResultName": "beginner course"
         },
         "table": {
           "__rl": true,
           "value": "tblTIOsm4BLJD9Tql",
           "mode": "list",
-          "cachedResultName": "processingOrders",
-          "cachedResultUrl": "https://airtable.com/app9nOVsRxdypoknP/tblTIOsm4BLJD9Tql"
+          "cachedResultName": "processingOrders"
         },
         "columns": {
           "mappingMode": "autoMapInputData",

--- a/docs/_workflows/courses/level-one/chapter-5/chapter-5.6.json
+++ b/docs/_workflows/courses/level-one/chapter-5/chapter-5.6.json
@@ -38,15 +38,13 @@
           "__rl": true,
           "value": "app9nOVsRxdypoknP",
           "mode": "list",
-          "cachedResultName": "beginner course",
-          "cachedResultUrl": "https://airtable.com/app9nOVsRxdypoknP"
+          "cachedResultName": "beginner course"
         },
         "table": {
           "__rl": true,
           "value": "tblTIOsm4BLJD9Tql",
           "mode": "list",
-          "cachedResultName": "processingOrders",
-          "cachedResultUrl": "https://airtable.com/app9nOVsRxdypoknP/tblTIOsm4BLJD9Tql"
+          "cachedResultName": "processingOrders"
         },
         "columns": {
           "mappingMode": "autoMapInputData",

--- a/docs/_workflows/courses/level-one/finished.json
+++ b/docs/_workflows/courses/level-one/finished.json
@@ -38,15 +38,13 @@
           "__rl": true,
           "value": "app9nOVsRxdypoknP",
           "mode": "list",
-          "cachedResultName": "beginner course",
-          "cachedResultUrl": "https://airtable.com/app9nOVsRxdypoknP"
+          "cachedResultName": "beginner course"
         },
         "table": {
           "__rl": true,
           "value": "tblTIOsm4BLJD9Tql",
           "mode": "list",
-          "cachedResultName": "processingOrders",
-          "cachedResultUrl": "https://airtable.com/app9nOVsRxdypoknP/tblTIOsm4BLJD9Tql"
+          "cachedResultName": "processingOrders"
         },
         "columns": {
           "mappingMode": "autoMapInputData",

--- a/docs/courses/level-one/chapter-4.md
+++ b/docs/courses/level-one/chapter-4.md
@@ -40,6 +40,4 @@ You will build this workflow in eight steps:
 
 To build this workflow, you will need the credentials found in the email you received from n8n when you signed up for this course. If you haven't signed up already, you can do it [here](https://n8n-community.typeform.com/to/PDEMrevI?typeform-source=127.0.0.1){:target="_blank" .external-link}. If you haven't received a confirmation email after signing up, [contact us](mailto:help@n8n.io).
 
-<div style="text-align:center;">
-	<button style="font-weight: 600;padding: 20px 46px;border-radius: 30px;color: #fff;background-color: #ff6d5a;border-color: #ff6d5a;border: 1px solid #ff6d5a;font-size: 14px;"><a href="/courses/level-one/chapter-5/chapter-5.1/" style="color: #fff;">Start building!</a></button>
-</div>
+[Start building!](/courses/level-one/chapter-5/chapter-5.1.md){ .md-button }

--- a/docs/courses/level-one/chapter-7.md
+++ b/docs/courses/level-one/chapter-7.md
@@ -18,9 +18,7 @@ You can test your knowledge by taking a **quiz**, which consists of questions ab
 - There's no time limit on answering the quiz questions.
 
 <br/>
-<div style="text-align:center;">
-	<button style="font-weight: 600;padding: 20px 46px;border-radius: 30px;color: #fff;background-color: #ff6d5a;border-color: #ff6d5a;border: 1px solid #ff6d5a;font-size: 14px;"><a href="https://n8n-community.typeform.com/to/JMoBXeGA" target="_blank" style="color: #fff;">Take the quiz!</a></button>
-</div>
+[Take the quiz!](https://n8n-community.typeform.com/to/JMoBXeGA){ .md-button }
 
 
 ## What's next?

--- a/docs/courses/level-one/index.md
+++ b/docs/courses/level-one/index.md
@@ -63,6 +63,4 @@ You can always **check your progress** throughout the course by entering your un
 
 If you complete the milestones above, you will get [**a badge and an avatar**](https://community.n8n.io/badges/104/completed-n8n-course-level-1) in your forum profile. You can then share your profile and course verification ID to showcase your n8n skills to others.
 
-<div style="text-align:center;">
-	<button style="font-weight: 600;padding: 20px 46px;border-radius: 30px;color: #fff;background-color: #ff6d5a;border-color: #ff6d5a;border: 1px solid #ff6d5a;font-size: 14px;"><a href="/courses/level-one/chapter-1/" style="color: #fff;">Let's get started!</a></button>
-</div>
+[Let's get started!](/courses/level-one/chapter-1.md){ .md-button }

--- a/docs/courses/level-two/chapter-6.md
+++ b/docs/courses/level-two/chapter-6.md
@@ -15,9 +15,8 @@ You can test your knowledge by taking a **quiz**, which consists of questions ab
 - You can take the quiz as many times as you want.
 - There's no time limit on answering the quiz questions.
 
-<div style="text-align:center;">
-	<button style="font-weight: 600;padding: 20px 46px;border-radius: 30px;color: #fff;background-color: #ff6d5a;border-color: #ff6d5a;border: 1px solid #ff6d5a;font-size: 14px;"><a href="https://n8n-community.typeform.com/to/r9hDbytg" target="_blank" style="color: #fff;">Take the quiz!</a></button>
-</div>
+<br/>
+[Take the quiz!](https://n8n-community.typeform.com/to/r9hDbytg){ .md-button }
 
 ## What's next?
 

--- a/docs/courses/level-two/index.md
+++ b/docs/courses/level-two/index.md
@@ -51,6 +51,4 @@ You can always **check your progress** throughout the course by entering your un
 
 If you successfully complete the milestones above, you will get [**a badge and an avatar**](https://community.n8n.io/badges/105/completed-n8n-course-level-2){:target="_blank" .external} in your forum profile. You can then share your profile and course verification ID to showcase your n8n skills to others.
 
-<div style="text-align:center;">
-	<button style="font-weight: 600;padding: 20px 46px;border-radius: 30px;color: #fff;background-color: #ff6d5a;border-color: #ff6d5a;border: 1px solid #ff6d5a;font-size: 14px;"><a href="/courses/level-two/chapter-1/" style="color: #fff;">Let's get started!</a></button>
-</div>
+[Let's get started!](/courses/level-two/chapter-1.md){ .md-button }


### PR DESCRIPTION
Some small adjustments to tweak the button style used in the courses and remove some cached URLs to personal accounts from workflow files.

Making changes here instead of the reorg branch since that hasn't incorporated the level one course changes yet.