### PR TITLE
Update course level 2 to use pokeapi instead of quotable

### DIFF
--- a/docs/courses/level-two/chapter-1.md
+++ b/docs/courses/level-two/chapter-1.md
@@ -206,17 +206,17 @@ return items[0].json.workEmail.map(item => {
 
 ### Exercise
 
-1. Use the **HTTP Request node** to make a GET request to the Quotable API `https://api.quotable.io/quotes`. (This API requires no authentication).
+1. Use the **HTTP Request node** to make a GET request to the PokéAPI `https://pokeapi.co/api/v2/pokemon`. (This API requires no authentication).
 2. Transform the data in the `results` field with the **Split Out node**.
 3. Transform the data in the `results` field with the **Code node**.
 
 
 ??? note "Show me the solution"
 
-	1. To get the quotes from the Quotable API, execute the **HTTP Request node** with the following parameters:
+	1. To get the pokemon from the PokéAPI, execute the **HTTP Request node** with the following parameters:
 		- **Authentication**: None
 		- **Request Method**: GET
-		- **URL**: https://api.quotable.io/quotes
+		- **URL**: https://pokeapi.co/api/v2/pokemon
 	2. To transform the data with the **Split Out node**, connect this node to the **HTTP Request node** and set the following parameters:
 		- **Field To Split Out**: results
 		- **Include**: No Other Fields

--- a/docs/courses/level-two/chapter-2.md
+++ b/docs/courses/level-two/chapter-2.md
@@ -57,17 +57,17 @@ Use the **XML node** to convert XML to JSON and JSON to XML. This operation is u
 
 ### XML Exercise
 
-In the [final exercise of Chapter 1](/courses/level-two/chapter-1.md#exercise_2), you used an **HTTP Request node** to make a request to the Quotable API. In this exercise, we'll return to that same API but we'll convert the output to XML:
+In the [final exercise of Chapter 1](/courses/level-two/chapter-1.md#exercise_2), you used an **HTTP Request node** to make a request to the PokéAPI. In this exercise, we'll return to that same API but we'll convert the output to XML:
 
-1. Add an **HTTP Request node** that makes the same request to the Quotable API at `https://api.quotable.io/quotes`.
+1. Add an **HTTP Request node** that makes the same request to the PokéAPI at `https://pokeapi.co/api/v2/pokemon`.
 2. Use the XML node to convert the JSON output to XML.
 
 ??? note "Show me the solution"
 
-	1. To get the quotes from the Quotable API, execute the **HTTP Request node** with the following parameters:
+	1. To get the pokemon from the PokéAPI, execute the **HTTP Request node** with the following parameters:
 		- **Authentication**: None
 		- **Request Method**: GET
-		- **URL**: https://api.quotable.io/quotes
+		- **URL**: https://pokeapi.co/api/v2/pokemon
 	2. Connect an **XML node** to it with the following parameters:
 		- **Mode**: JSON to XML
 		- **Property name**: data


### PR DESCRIPTION
quotable.io is no longer online it seems, this PR replaces it with PokeAPI in our level 2 course