### PR TITLE
Add docs for hyperbrowser

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.hyperbrowser.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.hyperbrowser.md
@@ -1,0 +1,47 @@
+---
+#https://www.notion.so/n8n/Frontmatter-432c2b8dff1f43d4b1c8d20075510fe4
+title: Hyperbrowser node documentation
+description: Learn how to use the Hyperbrowser node in n8n. Hyperbrowser is a platform for running browser agents and headless browsers.
+contentType: [integration, reference]
+---
+
+# Asana node
+
+Use the Hyperbrowser node to automate all your browser agents and web scraping needs. n8n has built-in support for the most important Hyperbrowser features, including - 
+- Browser Agents
+  - Claude Computer Use Agent
+  - OpenAI CUA Agent
+  - Browser Use Agent
+- Scrape a website
+- Crawl a website
+- Structured extraction 
+
+
+
+Use the Asana node to automate work in Asana, and integrate Asana with other applications. n8n has built-in support for a wide range of Asana features, including creating, updating, deleting, and getting users, tasks, projects, and subtasks.
+
+On this page, you'll find a list of operations the Asana node supports and links to more resources.
+
+/// note | Credentials
+Refer to [Hyperbrowser credentials](/integrations/builtin/credentials/hyperbrowser.md) for guidance on setting up authentication.
+///
+
+--8<-- "_snippets/integrations/builtin/app-nodes/ai-tools.md"
+
+## Operations
+
+* Web Scraping Tools
+    * scrape a single page
+    * Crawl a website
+    * Get structured output from a site
+* Browser Agent tool
+    * Run a task using Claude Computer-Use agent
+    * Run a task using OpenAI CUA agent
+    * Run a task using Browser-Use agent
+
+## Templates and examples
+
+<!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->
+[[ templatesWidget(page.title, 'hyperbrowser') ]]
+
+--8<-- "_snippets/integrations/builtin/app-nodes/operation-not-supported.md"

--- a/docs/integrations/builtin/credentials/hyperbrowser.md
+++ b/docs/integrations/builtin/credentials/hyperbrowser.md
@@ -1,0 +1,30 @@
+---
+title: Hyeprbrowser credentials
+description: Documentation for Hyperbrowser credentials. Use these credentials to authenticate Hyperbrowser in n8n.
+contentType: [integration, reference]
+---
+
+# Hyperbrowser credentials
+
+You can use these credentials to authenticate the following nodes:
+
+- [Hyperbrowser](/integrations/builtin/app-nodes/n8n-nodes-base.hyperbrowser.md)
+
+## Prerequisites
+
+Create a [Hyperbrowser](https://app.hyperbrowser.ai/){:target=_blank .external-link} account.
+
+## Supported authentication methods
+
+- API key
+
+## Related resources
+
+Refer to [Hyperbrowser's API documentation](https://docs.hyperbrowser.ai/){:target=_blank .external-link} for more information about the service.
+
+## Using API key
+
+To configure this credential, you'll need:
+
+- An **API Key**: Generate an API key from your profile in the [settings](https://app.hyperbrowser.ai/settings){:target=_blank .external-link}. Refer to the [Hyperbrowser API docs](https://docs.hyperbrowser.ai/get-started/quickstart){:target=_blank .external-link} for more information.
+


### PR DESCRIPTION
This PR adds docs for adding Hyperbrowser as a built in node for n8n. The PR for this is present in the primary repo. 

Primary PR is available here: https://github.com/n8n-io/n8n/pull/14368