### PR TITLE
Update sub-workflow input details

### DIFF
--- a/_snippets/flow-logic/subworkflow-usage.md
+++ b/_snippets/flow-logic/subworkflow-usage.md
@@ -12,7 +12,7 @@
 	1. Change the **This workflow can be called by** setting.	Refer to [Workflow settings](/workflows/settings.md) for more information on configuring your workflows.
 1. Add the **Execute Sub-workflow** trigger node (if you are searching under trigger nodes, this is also titled **When Executed by Another Workflow**).
 1. Set the **Input data mode** to choose how you will define the sub-workflow's input data:
-	* **Define using fields below**: Choose this mode to define individual input names and data types that the calling workflow needs to provide.
+	* **Define using fields below**: Choose this mode to define individual input names and data types that the calling workflow needs to provide. The [Execute Sub-workflow node](/integrations/builtin/core-nodes/n8n-nodes-base.executeworkflow.md) or [Call n8n Workflow Tool node](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md) in the calling workflow will automatically pull in the fields defined here.
 	* **Define using JSON example**: Choose this mode to provide an example JSON object that demonstrates the expected input items and their types.
 	* **Accept all data**: Choose this mode to accept all data unconditionally. The sub-workflow won't define any required input items. This sub-workflow must handle any input inconsistencies or missing values.
 1. Add other nodes as needed to build your sub-workflow functionality.

--- a/docs/advanced-ai/examples/api-workflow-tool.md
+++ b/docs/advanced-ai/examples/api-workflow-tool.md
@@ -7,7 +7,7 @@ description: Use the n8n workflow tool to load data from an API using the HTTP R
 
 # Call an API to fetch data
 
-Use n8n to bring data from any [API](/glossary.md#api) to your AI. This workflow uses the [Chat Trigger](/integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/index.md) to provide the chat interface, and the [Custom n8n Workflow Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md) to call a second workflow that calls the API. The second workflow uses AI functionality to refine the API request based on the user's query.
+Use n8n to bring data from any [API](/glossary.md#api) to your AI. This workflow uses the [Chat Trigger](/integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/index.md) to provide the chat interface, and the [Call n8n Workflow Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md) to call a second workflow that calls the API. The second workflow uses AI functionality to refine the API request based on the user's query.
 
 [[ workflowDemo("file:///advanced-ai/examples/let_your_ai_call_an_api.json") ]]
 
@@ -17,7 +17,7 @@ This workflow uses:
 
 * [Chat Trigger](/integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/index.md): start your workflow and respond to user chat interactions. The node provides a customizable chat interface.
 * [Agent](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/index.md): the key piece of the AI workflow. The Agent interacts with other components of the workflow and makes decisions about what tools to use.
-* [Custom n8n Workflow Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md): plug in n8n workflows as custom tools. In AI, a tool is an interface the AI can use to interact with the world (in this case, the data provided by your workflow). The AI model uses the tool to access information beyond its built-in dataset.
+* [Call n8n Workflow Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md): plug in n8n workflows as custom tools. In AI, a tool is an interface the AI can use to interact with the world (in this case, the data provided by your workflow). The AI model uses the tool to access information beyond its built-in dataset.
 * A [Basic LLM Chain](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainllm.md) with an [Auto-fixing Output Parser](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparserautofixing.md) and [Structured Output Parser](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparserstructured/index.md) to read the user's query and set parameters for the API call based on the user input.
 
 ## Using the example

--- a/docs/advanced-ai/examples/data-google-sheets.md
+++ b/docs/advanced-ai/examples/data-google-sheets.md
@@ -7,7 +7,7 @@ description: Use the n8n workflow tool to load data from Google Sheets into your
 
 # Chat with a Google Sheet using AI
 
-Use n8n to bring your own data to AI. This workflow uses the [Chat Trigger](/integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/index.md) to provide the chat interface, and the [Custom n8n Workflow Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md) to call a second workflow that queries Google Sheets.
+Use n8n to bring your own data to AI. This workflow uses the [Chat Trigger](/integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/index.md) to provide the chat interface, and the [Call n8n Workflow Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md) to call a second workflow that queries Google Sheets.
 
 [[ workflowDemo("file:///advanced-ai/examples/chat_with_google_sheets_docs_version.json") ]]
 
@@ -17,7 +17,7 @@ This workflow uses:
 
 * [Chat Trigger](/integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/index.md): start your workflow and respond to user chat interactions. The node provides a customizable chat interface.
 * [Agent](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/index.md): the key piece of the AI workflow. The Agent interacts with other components of the workflow and makes decisions about what tools to use.
-* [Custom n8n Workflow Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md): plug in n8n workflows as custom tools. In AI, a tool is an interface the AI can use to interact with the world (in this case, the data provided by your workflow). The AI model uses the tool to access information beyond its built-in dataset.
+* [Call n8n Workflow Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md): plug in n8n workflows as custom tools. In AI, a tool is an interface the AI can use to interact with the world (in this case, the data provided by your workflow). The AI model uses the tool to access information beyond its built-in dataset.
 
 
 ## Using the example

--- a/docs/advanced-ai/examples/human-fallback.md
+++ b/docs/advanced-ai/examples/human-fallback.md
@@ -9,7 +9,7 @@ description: Have a workflow that triggers a human answer when the AI can't help
 
 This is a workflow that tries to answer user queries using the standard GPT-4 model. If it can't answer, it sends a message to Slack to ask for human help. It prompts the user to supply an email address.
 
-This workflow uses the [Chat Trigger](/integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/index.md) to provide the chat interface, and the [Custom n8n Workflow Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md) to call a second workflow that handles checking for email addresses and sending the Slack message. 
+This workflow uses the [Chat Trigger](/integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/index.md) to provide the chat interface, and the [Call n8n Workflow Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md) to call a second workflow that handles checking for email addresses and sending the Slack message. 
 
 [[ workflowDemo("file:///advanced-ai/examples/ask_a_human.json") ]]
 
@@ -19,7 +19,7 @@ This workflow uses:
 
 * [Chat Trigger](/integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/index.md): start your workflow and respond to user chat interactions. The node provides a customizable chat interface.
 * [Agent](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/index.md): the key piece of the AI workflow. The Agent interacts with other components of the workflow and makes decisions about what tools to use.
-* [Custom n8n Workflow Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md): plug in n8n workflows as custom tools. In AI, a tool is an interface the AI can use to interact with the world (in this case, the data provided by your workflow). It allows the AI model to access information beyond its built-in dataset.
+* [Call n8n Workflow Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md): plug in n8n workflows as custom tools. In AI, a tool is an interface the AI can use to interact with the world (in this case, the data provided by your workflow). It allows the AI model to access information beyond its built-in dataset.
 
 ## Using the example
 

--- a/docs/advanced-ai/examples/introduction.md
+++ b/docs/advanced-ai/examples/introduction.md
@@ -21,7 +21,7 @@ This section provides explanations of important AI concepts, and workflow templa
     [:octicons-arrow-right-24: What's an agent in AI?](/advanced-ai/examples/understand-agents.md)  
 	[:octicons-arrow-right-24: Demonstration of key differences between agents and chains](/advanced-ai/examples/agent-chain-comparison.md) 
 
--   __Custom n8n Workflow Tool__
+-   __Call n8n Workflow Tool__
 
     Learn about [tools](/glossary.md#ai-tool) in AI, then explore examples that use n8n workflows as custom tools to give your AI workflow access to more data.
 

--- a/docs/advanced-ai/examples/understand-tools.md
+++ b/docs/advanced-ai/examples/understand-tools.md
@@ -21,11 +21,11 @@ Here are a couple of other ways of expressing it:
 
 n8n provides tool [sub-nodes](/glossary.md#sub-node-n8n) that you can connect to your [AI agent](/glossary.md#ai-agent). As well as providing some popular tools, such as [Wikipedia](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolwikipedia.md) and [SerpAPI](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolserpapi.md), n8n provides three especially powerful tools:
 
-* [Custom n8n Workflow Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md): use this to load any n8n workflow as a tool.
+* [Call n8n Workflow Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md): use this to load any n8n workflow as a tool.
 * [Custom Code Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcode.md): write code that your agent can run.
 * [HTTP Request Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolhttprequest.md): make calls to fetch a website or data from an API.
 
-The next three examples highlight the Custom n8n Workflow Tool:
+The next three examples highlight the Call n8n Workflow Tool:
 
 - [Chat with Google Sheets](/advanced-ai/examples/data-google-sheets.md)
 - [Call an API to fetch data](/advanced-ai/examples/api-workflow-tool.md)

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md
@@ -1,16 +1,16 @@
 ---
 #https://www.notion.so/n8n/Frontmatter-432c2b8dff1f43d4b1c8d20075510fe4
-title: Custom n8n Workflow Tool node documentation
-description: Learn how to use the Custom n8n Workflow Tool node in n8n. Follow technical documentation to integrate Custom n8n Workflow Tool node into your workflows.
+title: Call n8n Workflow Tool node documentation
+description: Learn how to use the Call n8n Workflow Tool node in n8n. Follow technical documentation to integrate Call n8n Workflow Tool node into your workflows.
 contentType: [integration, reference]
 priority: high
 ---
 
-# Custom n8n Workflow Tool node
+# Call n8n Workflow Tool node
 
-The Workflow Tool node is a [tool](/glossary.md#ai-tool) that allows an [agent](/glossary.md#ai-agent) to run another n8n workflow and fetch its output data. 
+The Call n8n Workflow Tool node is a [tool](/glossary.md#ai-tool) that allows an [agent](/glossary.md#ai-agent) to run another n8n workflow and fetch its output data. 
 
-On this page, you'll find the node parameters for the Workflow Tool node, and links to more resources.
+On this page, you'll find the node parameters for the Call n8n Workflow Tool node, and links to more resources.
 
 --8<-- "_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
 
@@ -30,24 +30,25 @@ Enter a custom code a description. This tells the agent when to use this tool. F
 
 Tell n8n which workflow to call. You can choose either:
 
-* **Database** and enter a workflow ID.
-* **Parameter** and copy in a complete [workflow JSON](/workflows/export-import.md).
+* **Database** to select the workflow from a list or enter a workflow ID.
+* **Define Below** and copy in a complete [workflow JSON](/workflows/export-import.md).
 
-### Workflow Values
+### Workflow Inputs
 
---8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-sub-nodes/workflow-values.md"
+When using **Database** as workflow source, once you choose a sub-workflow (and define the **Workflow Input Schema** in the sub-workflow), you can define the **Workflow Inputs**.
 
-### Specify input schema
+Select the **Refresh** button to pull in the input fields from the sub-workflow.
 
-/// note | Agent support
-The structured input schema requires with a Tools Agent or OpenAI Functions Agent.
-///
+You can define the workflow input values using any combination of the following options:
 
-Enable this option to define the input schema for the workflow you're calling. This is useful when you want to make sure the input data the LLM provides is in the correct format.
+* providing fixed values
+* using expressions to reference data from the current workflow
+* [letting the AI model specify the parameter](/advanced-ai/examples/using-the-fromai-function.md) by selecting the button AI button on the right side of the field
+* using the [`$fromAI()` function](/advanced-ai/examples/using-the-fromai-function.md#use-the-fromai-function) in expressions to control the way the model fills in data and to mix AI generated input with other custom input
 
-**Schema Type**: Define the input structure and validation. You have two options to provide the schema:
+To reference data from the current workflow, drag fields from the input panel to the field with the Expressions mode selected.
 
---8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-sub-nodes/schema-type-structuring.md"
+To get started with the `$fromAI()` function, select the "Let the model define this parameter" button on the right side of the field and then use the **X** on the box to revert to user-defined values. The field will change to an expression field pre-populated with the `$fromAI()` expression. From here, you can customize the expression to add other static or dynamic content, or tweak the `$fromAI()` function parameters.
 
 ## Templates and examples
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger.md
@@ -17,7 +17,7 @@ n8n allows you to call workflows from other workflows. This is useful if you wan
 
 ## Usage
 
-This node runs in response to a call from the [Execute Workflow](/integrations/builtin/core-nodes/n8n-nodes-base.executeworkflow.md) node.
+This node runs in response to a call from the [Execute Sub-workflow](/integrations/builtin/core-nodes/n8n-nodes-base.executeworkflow.md) or [Call n8n Workflow Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md) nodes.
 
 --8<-- "_snippets/flow-logic/subworkflow-usage.md"
 

--- a/nav.yml
+++ b/nav.yml
@@ -755,7 +755,7 @@ nav:
           - Vector Store Question Answer Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolvectorstore.md
           - Wikipedia: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolwikipedia.md
           - Wolfram|Alpha: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolwolframalpha.md
-          - Custom n8n Workflow Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md
+          - Call n8n Workflow Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md
       - Credentials:
         - integrations/builtin/credentials/index.md
         - integrations/builtin/credentials/actionnetwork.md


### PR DESCRIPTION
Updates some of the existing info on sub-workflow inputs including:

* Removing outdated options
* Using `$fromAI()` to populate values
* Letting the model fill in values automatically

Additionally, this PR changes the name of the tool node to match the product name ("Custom n8n Workflow Tool" -> "Call n8n Workflow Tool").