### PR TITLE
docs: Remove tool name parameters from docs as they were removed

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcode.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcode.md
@@ -16,10 +16,6 @@ On this page, you'll find the node parameters for the Custom Code Tool node and 
 
 ## Node parameters
 
-### Name
-
-Give your custom code a name. It can't contain whitespace.
-
 ### Description
 
 Give your custom code a description. This tells the agent when to use this tool. For example:

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolvectorstore.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolvectorstore.md
@@ -19,17 +19,15 @@ For usage examples and templates to help you get started, refer to n8n's [Vector
 
 ## Node parameters
 
-### Data Name
-
-Enter the name of the data in the vector store.
-
 ### Description of Data
 
 Enter a description of the data in the vector store.
 
-n8n uses the **Data Name** and **Description of Data** parameters to populate the tool description for AI agents using the following format:
+n8n uses the **Node Name** and **Description of Data** parameters to populate the tool description for AI agents using the following format:
 
-> Useful for when you need to answer questions about [Data Name]. Whenever you need information about [Description of Data], you should ALWAYS use this. Input should be a fully formed question.
+> Useful for when you need to answer questions about [Node Name]. Whenever you need information about [Description of Data], you should ALWAYS use this. Input should be a fully formed question.
+
+Spaces in **Node Name** are converted to underscores on the tool description, and special characters are not allowed.
 
 ### Limit
 

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md
@@ -16,10 +16,6 @@ On this page, you'll find the node parameters for the Workflow Tool node, and li
 
 ## Node parameters
 
-### Name
-
-Enter a name for your custom code. It can't contain whitespace or special characters.
-
 ### Description
 
 Enter a custom code a description. This tells the agent when to use this tool. For example:


### PR DESCRIPTION
Separate name parameter was removed from nodes

- Workflow Tool (v2.2)
- Vector Stores Tool (v1.1)
- Code Tool (v1.2)

and the name of the node is now used instead, to align all tool nodes to work in a similar way.

When the node name is used on the tool's description when passing it to the agent whitespaces on the name are converted to underscores - this is similar to how other tools already worked so perhaps we don't need to highlight this too much? Feel free to suggest something else for the docs here too.

These changes [were merged today](https://github.com/n8n-io/n8n/pull/14604), new versions of these nodes starting next release will not have the name parameter.