### PR TITLE
Update broken blog URLs

### DIFF
--- a/docs/courses/level-one/index.md
+++ b/docs/courses/level-one/index.md
@@ -43,7 +43,7 @@ You will build two workflows:
 
 1. **n8n set up**: You can use [n8n Cloud](/manage-cloud/overview.md) (or the [self-hosted version](/hosting/installation/docker.md) if you have experience hosting services).
 2. **A course user ID**: [Sign up here](https://n8n-community.typeform.com/to/PDEMrevI) to get your unique ID and other credentials you will need in the course.
-3. Basic knowledge of JavaScript and [APIs](https://n8n.io/blog/what-are-apis-how-to-use-them-with-no-code/) would be helpful, but isn't necessary.
+3. Basic knowledge of JavaScript and [APIs](https://blog.n8n.io/what-are-apis-how-to-use-them-with-no-code/) would be helpful, but isn't necessary.
 4. An [account on the n8n community forum](https://community.n8n.io/) if you wish to receive a profile badge and avatar upon successful completion.
 
 ## How long does the course take?

--- a/docs/courses/level-two/chapter-3.md
+++ b/docs/courses/level-two/chapter-3.md
@@ -22,7 +22,7 @@ In a one-way sync, data is synchronized in one direction. One system serves as t
 
 In a two-way sync, data is synchronized in both directions (between both systems). When information changes in either of the two systems, it automatically changes in the other one as well.
 
-[This blog tutorial](https://n8n.io/blog/how-to-sync-data-between-two-systems/) explains how to sync data one-way and two-way between two CRMs.
+[This blog tutorial](https://blog.n8n.io/how-to-sync-data-between-two-systems/) explains how to sync data one-way and two-way between two CRMs.
 ///
 
 

--- a/docs/embed/index.md
+++ b/docs/embed/index.md
@@ -17,4 +17,4 @@ The [community forum](https://community.n8n.io/) can help with various issues. I
 
 ## Russia and Belarus
 
-n8n Embed isn't available in Russia and Belarus. Refer to n8n's blog post [Update on n8n cloud accounts in Russia and Belarus](https://n8n.io/blog/update-on-n8n-cloud-accounts-in-russia-and-belarus/){:target=_blank .external-link} for more information.
+n8n Embed isn't available in Russia and Belarus. Refer to n8n's blog post [Update on n8n cloud accounts in Russia and Belarus](https://blog.n8n.io/update-on-n8n-cloud-accounts-in-russia-and-belarus/){:target=_blank .external-link} for more information.

--- a/docs/manage-cloud/overview.md
+++ b/docs/manage-cloud/overview.md
@@ -17,7 +17,7 @@ n8n Cloud is n8n's hosted solution. It provides:
 [Sign up for n8n Cloud](https://www.n8n.io/){:target=_blank .external-link}
 
 /// note | Russia and Belarus
-n8n Cloud isn't available in Russia and Belarus. Refer to this blog post: [Update on n8n cloud accounts in Russia and Belarus](https://n8n.io/blog/update-on-n8n-cloud-accounts-in-russia-and-belarus/) for more information.
+n8n Cloud isn't available in Russia and Belarus. Refer to this blog post: [Update on n8n cloud accounts in Russia and Belarus](https://blog.n8n.io/update-on-n8n-cloud-accounts-in-russia-and-belarus/) for more information.
 ///
 
 


### PR DESCRIPTION
Updated references from https://n8n.io/blog/ → https://blog.n8n.io/, which previously returned 404 errors.