### PR TITLE
fix: Refactor Milvus Vector Store node docs to use Milvus-specific workflow templates

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremilvus.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremilvus.md
@@ -26,26 +26,31 @@ You can use the Milvus Vector Store node in the following patterns.
 
 You can use the Milvus Vector Store as a regular node to insert, or get documents. This pattern places the Milvus Vector Store in the regular connection flow without using an agent.
 
-You can see an example of this in scenario 1 of [this template](https://n8n.io/workflows/2165-chat-with-pdf-docs-using-ai-quoting-sources/), by replacing the Pinecone Vector store node with the Milvus Vector Store node.
+See this [example template](https://n8n.io/workflows/3573-create-a-rag-system-with-paul-essays-milvus-and-openai-for-cited-answers/) for how to build a system that stores documents in Milvus and retrieves them to support cited, chat-based answers.
+
 
 ### Connect directly to an AI agent as a tool
 
 You can connect the Milvus Vector Store node directly to the tool connector of an [AI agent](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/index.md) to use a vector store as a resource when answering queries.
 
-Here, the connection would be: AI agent (tools connector) -> Milvus Vector Store node.
+Here, the connection would be: AI agent (tools connector) -> Milvus Vector Store node. See this [example template](https://n8n.io/workflows/3576-paul-graham-essay-search-and-chat-with-milvus-vector-database/) where data is embedded and indexed in Milvus, and the AI Agent uses the vector store as a knowledge tool for question-answering.
+
 
 ### Use a retriever to fetch documents
 
 You can use the [Vector Store Retriever](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrievervectorstore.md) node with the Milvus Vector Store node to fetch documents from the Milvus Vector Store node. This is often used with the [Question and Answer Chain](/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainretrievalqa/index.md) node to fetch documents from the vector store that match the given chat input.
 
-An [example of the connection flow](https://n8n.io/workflows/1960-ask-questions-about-a-pdf-using-ai/) would be: Question and Answer Chain (Retriever connector) -> Vector Store Retriever (Vector Store connector) -> Milvus Vector Store. In this example, the Pinecone Vector Store node should be replaced with the Milvus Vector Store node.
+A typical node connection flow looks like this: Question and Answer Chain (Retriever connector) -> Vector Store Retriever (Vector Store connector) -> Milvus Vector Store.
+
+Check out this [workflow example](https://n8n.io/workflows/3574-create-a-paul-graham-essay-qanda-system-with-openai-and-milvus-vector-database/) to see how to ingest external data into Milvus and build a chat-based semantic Q&A system.
+
 
 ### Use the Vector Store Question Answer Tool to answer questions
 
 Another pattern uses the [Vector Store Question Answer Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolvectorstore.md) to summarize results and answer questions from the Milvus Vector Store node. Rather than connecting the Milvus Vector Store directly as a tool, this pattern uses a tool specifically designed to summarizes data in the vector store.
 
-The [connections flow](https://n8n.io/workflows/2705-chat-with-github-api-documentation-rag-powered-chatbot-with-pinecone-and-openai/) in this case would look like this: AI agent (tools connector) -> Vector Store Question Answer Tool (Vector Store connector) -> Milvus Vector store. In this example, the Pinecone Vector Store node should be replaced with the Milvus Vector Store node.
-	
+The connections flow would look like this: AI agent (tools connector) -> Vector Store Question Answer Tool (Vector Store connector) -> Milvus Vector store.
+
 ## Node parameters
 
 --8<-- "_snippets/integrations/builtin/cluster-nodes/vector-store-mode.md"


### PR DESCRIPTION
This PR updates the documentation for the Milvus Vector Store node by replacing the existing Pinecone-based template references with **dedicated Milvus-specific workflow templates**.

### Changes:

* Replaced all mentions of example workflows using Pinecone with Milvus-specific templates hosted on n8n.io.
* Updated the descriptions to reflect Milvus usage patterns more clearly and accurately across:

  * Regular node usage (insert/retrieve)
  * Retriever-based Q\&A workflows
  * AI Agent tool integration
  
These updates ensure that users following the Milvus docs can reference working, Milvus-native examples without needing to adapt templates from other vector stores.
