### PR TITLE
Update outdated LangChain documentation URL

### DIFF
--- a/_snippets/integrations/builtin/cluster-nodes/tools-link.md
+++ b/_snippets/integrations/builtin/cluster-nodes/tools-link.md
@@ -1,1 +1,1 @@
-Refer to [LangChain's documentation on tools](https://js.langchain.com/docs/modules/agents/tools/){:target=_blank .external-link} for more information about tools in LangChain.
+Refer to [LangChain's documentation on tools](https://langchain-ai.github.io/langgraphjs/how-tos/tool-calling/){:target=_blank .external-link} for more information about tools in LangChain.


### PR DESCRIPTION
Update outdated link to Langchain documentation

Old link result:
![image](https://github.com/user-attachments/assets/73011b76-a882-4011-a3a8-2fd98096cfe6)

New link result:
![image](https://github.com/user-attachments/assets/fa41aba8-3e2e-4ab9-88bd-d2a329ce27fd)

