### PR TITLE
docs: add HTTP Request note for PostBin content visibility

### DIFF
--- a/docs/try-it-out/tutorial-first-workflow.md
+++ b/docs/try-it-out/tutorial-first-workflow.md
@@ -135,6 +135,16 @@ The last step of the workflow is to send the two reports about solar flares. For
     1. Hover over the Postbin node, then select **Node context menu** <span class="inline-image">![Node context menu icon](/_images/common-icons/node-context-menu.png){.off-glb}</span> > **Duplicate node** to duplicate the first Postbin node.
     1. Drag the **false** connector from the If node to the left side of the new Postbin node.
 
+    /// note | PostBin content visibility
+    Using the built‑in **PostBin** node only displays the request headers. To send and view your custom body content on PostBin website, use an **HTTP Request** node with **Method** `POST`, **URL** `https://www.postb.in/<YOUR_BIN_ID>`, then enable **Send Body**, set **Body Content Type** to **JSON**, choose **Using JSON** under Specify Body, then paste the following JSON into the editor:
+    ```js
+    {
+    "message":"There was a solar flare of class {{$json["classType"]}}"
+    }
+    ```
+    ///
+
+
 ## Step six: Test the workflow
 
 1. You can now test the entire workflow. Select **Test Workflow**. n8n runs the workflow, showing each stage in progress.


### PR DESCRIPTION
## Description

This PR enhances the **Step five: Output data from your workflow** section of the First Workflow tutorial by adding an informational note to help users actually see their custom body content on PostBin. Because the built‑in PostBin node only displays request headers, the new note shows how to use an **HTTP Request** node (**Method** `POST`, **Send Body** enabled, **Body Content Type** JSON) with the correct expression so that the message appears in the PostBin UI—all without removing any of the original tutorial steps.

## Background

Addresses issue [#11836](https://github.com/n8n-io/n8n/issues/11836): the PostBin node’s **Send a request** operation issues a GET request and omits the body, preventing users from seeing their message.

Multiple users have reported being unable to complete the Quick Start “longer introduction” tutorial because of this behavior.

## Changes

- Inserted a `note | PostBin content visibility` block immediately after the numbered steps in **Step five**, explaining:
  - How to add an **HTTP Request** node on a branch.
  - Which parameters to set (**Method** `POST`, **URL** `https://www.postb.in/<YOUR_BIN_ID>`, enable **Send Body**, set **Body Content Type** to JSON, choose **Using JSON** under Specify Body).
  - The exact JSON snippet to paste into the editor:
    ```markdown
    {
      "message": "There was a solar flare of class {{$json["classType"]}}"
    }
    ```
- Kept all existing PostBin instructions intact—this simply supplements them with a working alternative.
