### PR TITLE
chore: Rename Test workflow to Execute workflow

### DIFF
--- a/_snippets/integrations/openai-api-issues.md
+++ b/_snippets/integrations/openai-api-issues.md
@@ -11,7 +11,7 @@ There are two ways to work around this issue:
         {
             "parameters": {},
             "id": "35d05920-ad75-402a-be3c-3277bff7cc67",
-            "name": "When clicking ‘Test workflow’",
+            "name": "When clicking ‘Execute workflow’",
             "type": "n8n-nodes-base.manualTrigger",
             "typeVersion": 1,
             "position": [
@@ -64,7 +64,7 @@ There are two ways to work around this issue:
         }
         ],
         "connections": {
-        "When clicking ‘Test workflow’": {
+        "When clicking ‘Execute workflow’": {
             "main": [
             [
                 {

--- a/docs/_workflows/advanced-ai/examples/populate_a_pinecone_vector_database_from_a_website.json
+++ b/docs/_workflows/advanced-ai/examples/populate_a_pinecone_vector_database_from_a_website.json
@@ -292,7 +292,7 @@
     },
     {
       "parameters": {
-        "content": "## Try it out \n\n1. Set credentials and choose your Pinecone vector database. See the notes on individual nodes for details.\n2. Select **Test workflow** to run the main workflow and load data into Pinecone.\n3. Select **Chat** and try asking:\n\n_What is the purpose of the n8n demo website?_",
+        "content": "## Try it out \n\n1. Set credentials and choose your Pinecone vector database. See the notes on individual nodes for details.\n2. Select **Execute workflow** to run the main workflow and load data into Pinecone.\n3. Select **Chat** and try asking:\n\n_What is the purpose of the n8n demo website?_",
         "height": 326.49681260818465,
         "color": 4
       },
@@ -453,7 +453,7 @@
     {
       "parameters": {},
       "id": "b43ddbd1-adfd-4bba-bee5-4b81229e88dd",
-      "name": "Start the workflow by clicking \"Test workflow\"",
+      "name": "Start the workflow by clicking \"Execute workflow\"",
       "type": "n8n-nodes-base.manualTrigger",
       "typeVersion": 1,
       "position": [
@@ -692,7 +692,7 @@
         ]
       ]
     },
-    "Start the workflow by clicking \"Test workflow\"": {
+    "Start the workflow by clicking \"Execute workflow\"": {
       "main": [
         [
           {

--- a/docs/_workflows/courses/level-one/chapter-2.json
+++ b/docs/_workflows/courses/level-one/chapter-2.json
@@ -9,7 +9,7 @@
         0
       ],
       "id": "5738d1d8-ae7d-4e04-bca4-885c59e1d9e8",
-      "name": "When clicking ‘Test workflow’"
+      "name": "When clicking ‘Execute workflow’"
     },
     {
       "parameters": {
@@ -32,7 +32,7 @@
     }
   ],
   "connections": {
-    "When clicking ‘Test workflow’": {
+    "When clicking ‘Execute workflow’": {
       "main": [
         [
           {

--- a/docs/_workflows/courses/level-one/chapter-5/chapter-5.1.json
+++ b/docs/_workflows/courses/level-one/chapter-5/chapter-5.1.json
@@ -40,7 +40,7 @@
         -680
       ],
       "id": "ffa1a8ce-1a1e-48c4-8a0d-6af28c0447a5",
-      "name": "When clicking ‘Test workflow’"
+      "name": "When clicking ‘Execute workflow’"
     }
   ],
   "connections": {
@@ -49,7 +49,7 @@
         []
       ]
     },
-    "When clicking ‘Test workflow’": {
+    "When clicking ‘Execute workflow’": {
       "main": [
         [
           {

--- a/docs/_workflows/courses/level-one/chapter-5/chapter-5.2.json
+++ b/docs/_workflows/courses/level-one/chapter-5/chapter-5.2.json
@@ -136,7 +136,7 @@
         -680
       ],
       "id": "ffa1a8ce-1a1e-48c4-8a0d-6af28c0447a5",
-      "name": "When clicking ‘Test workflow’"
+      "name": "When clicking ‘Execute workflow’"
     }
   ],
   "connections": {
@@ -151,7 +151,7 @@
         ]
       ]
     },
-    "When clicking ‘Test workflow’": {
+    "When clicking ‘Execute workflow’": {
       "main": [
         [
           {

--- a/docs/_workflows/courses/level-one/chapter-5/chapter-5.3.json
+++ b/docs/_workflows/courses/level-one/chapter-5/chapter-5.3.json
@@ -169,7 +169,7 @@
         -680
       ],
       "id": "ffa1a8ce-1a1e-48c4-8a0d-6af28c0447a5",
-      "name": "When clicking ‘Test workflow’"
+      "name": "When clicking ‘Execute workflow’"
     }
   ],
   "connections": {
@@ -196,7 +196,7 @@
         []
       ]
     },
-    "When clicking ‘Test workflow’": {
+    "When clicking ‘Execute workflow’": {
       "main": [
         [
           {

--- a/docs/_workflows/courses/level-one/chapter-5/chapter-5.4.json
+++ b/docs/_workflows/courses/level-one/chapter-5/chapter-5.4.json
@@ -165,7 +165,7 @@
         -520
       ],
       "id": "ffa1a8ce-1a1e-48c4-8a0d-6af28c0447a5",
-      "name": "When clicking ‘Test workflow’"
+      "name": "When clicking ‘Execute workflow’"
     }
   ],
   "connections": {
@@ -203,7 +203,7 @@
         ]
       ]
     },
-    "When clicking ‘Test workflow’": {
+    "When clicking ‘Execute workflow’": {
       "main": [
         [
           {

--- a/docs/_workflows/courses/level-one/chapter-5/chapter-5.5.json
+++ b/docs/_workflows/courses/level-one/chapter-5/chapter-5.5.json
@@ -178,7 +178,7 @@
         -520
       ],
       "id": "ffa1a8ce-1a1e-48c4-8a0d-6af28c0447a5",
-      "name": "When clicking ‘Test workflow’"
+      "name": "When clicking ‘Execute workflow’"
     }
   ],
   "connections": {
@@ -227,7 +227,7 @@
         []
       ]
     },
-    "When clicking ‘Test workflow’": {
+    "When clicking ‘Execute workflow’": {
       "main": [
         [
           {

--- a/docs/_workflows/courses/level-one/chapter-5/chapter-5.6.json
+++ b/docs/_workflows/courses/level-one/chapter-5/chapter-5.6.json
@@ -200,7 +200,7 @@
         -520
       ],
       "id": "ffa1a8ce-1a1e-48c4-8a0d-6af28c0447a5",
-      "name": "When clicking ‘Test workflow’"
+      "name": "When clicking ‘Execute workflow’"
     }
   ],
   "connections": {
@@ -255,7 +255,7 @@
         ]
       ]
     },
-    "When clicking ‘Test workflow’": {
+    "When clicking ‘Execute workflow’": {
       "main": [
         [
           {

--- a/docs/_workflows/credentials/dynamic_credentials_using_expressions.json
+++ b/docs/_workflows/credentials/dynamic_credentials_using_expressions.json
@@ -62,7 +62,7 @@
     },
     {
       "parameters": {
-        "content": "This workflow shows how to set credentials dynamically using expressions.\n\n\nFirst, set up your NASA credential: \n\n1. Create a new NASA credential.\n1. Hover over **API Key**.\n1. Toggle **Expression** on.\n1. In the **API Key** field, enter `{{ $json[\"Enter your NASA API key\"] }}`.\n\n\nThen, test the workflow:\n\n1. Get an [API key from NASA](https://api.nasa.gov/)\n2. Select **Test workflow**\n3. Enter your key using the form.\n4. The workflow runs and sends you to the NASA picture of the day.\n\n\nFor more information on expressions, refer to [n8n documentation | Expressions](https://docs.n8n.io/code/expressions/).",
+        "content": "This workflow shows how to set credentials dynamically using expressions.\n\n\nFirst, set up your NASA credential: \n\n1. Create a new NASA credential.\n1. Hover over **API Key**.\n1. Toggle **Expression** on.\n1. In the **API Key** field, enter `{{ $json[\"Enter your NASA API key\"] }}`.\n\n\nThen, test the workflow:\n\n1. Get an [API key from NASA](https://api.nasa.gov/)\n2. Select **Execute workflow**\n3. Enter your key using the form.\n4. The workflow runs and sends you to the NASA picture of the day.\n\n\nFor more information on expressions, refer to [n8n documentation | Expressions](https://docs.n8n.io/code/expressions/).",
         "height": 564,
         "width": 322,
         "color": 4

--- a/docs/_workflows/integrations/builtin/app-nodes/n8n-nodes-base.googledrive/get-most-recent-file.json
+++ b/docs/_workflows/integrations/builtin/app-nodes/n8n-nodes-base.googledrive/get-most-recent-file.json
@@ -25,7 +25,7 @@
     {
       "parameters": {},
       "id": "ba223e7c-4fed-41dd-8c80-2e8fd742629f",
-      "name": "When clicking ‘Test workflow’",
+      "name": "When clicking ‘Execute workflow’",
       "type": "n8n-nodes-base.manualTrigger",
       "typeVersion": 1,
       "position": [
@@ -90,7 +90,7 @@
     }
   ],
   "connections": {
-    "When clicking ‘Test workflow’": {
+    "When clicking ‘Execute workflow’": {
       "main": [
         [
           {

--- a/docs/_workflows/integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches/rss-feed-example.json
+++ b/docs/_workflows/integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches/rss-feed-example.json
@@ -9,7 +9,7 @@
         0
       ],
       "id": "e6e1cfe6-eff1-48bd-b21c-6ba83d4244d9",
-      "name": "When clicking ‘Test workflow’"
+      "name": "When clicking ‘Execute workflow’"
     },
     {
       "parameters": {
@@ -53,7 +53,7 @@
     }
   ],
   "connections": {
-    "When clicking ‘Test workflow’": {
+    "When clicking ‘Execute workflow’": {
       "main": [
         [
           {

--- a/docs/courses/level-one/chapter-1.md
+++ b/docs/courses/level-one/chapter-1.md
@@ -71,7 +71,7 @@ The top bar of the **Editor UI** contains the following information:
 The **canvas** is the gray dotted grid background in the Editor UI. It displays several icons and a node with different functionalities:
 
 - Buttons to zoom the canvas to fit the screen, zoom in or out of the canvas, and tidy up the nodes on screen.
-- A button to **Test workflow** once you add your first node. When you click on it, n8n executes all nodes on the canvas in sequence.
+- A button to **Execute workflow** once you add your first node. When you click on it, n8n executes all nodes on the canvas in sequence.
 - A button with a **+** sign inside. This button opens the nodes panel.
 - A button with a note icon inside. This button adds a [sticky note](/workflows/components/sticky-notes.md) to the canvas (visible when hovering on the top right + icon).
 - A dotted square with the text "Add first step." This is where you add your first node.

--- a/docs/courses/level-one/chapter-2.md
+++ b/docs/courses/level-one/chapter-2.md
@@ -28,7 +28,7 @@ Then:
 1. Search for the **Manual Trigger** node.
 2. Select it when it appears in the search.
 
-This will add the [Manual Trigger](/integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger.md) node to your canvas, which allows you to run the workflow at any time by selecting the **Test workflow** button.
+This will add the [Manual Trigger](/integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger.md) node to your canvas, which allows you to run the workflow at any time by selecting the **Execute workflow** button.
 
 /// note | Manual triggers
 For faster workflow creation, you can skip this step in the future. Adding any other node without a trigger will add the Manual Trigger node to the workflow.
@@ -114,9 +114,9 @@ To find the original node name (the type of node), open the node window and sele
 
 ## 4. Execute the node
 
-Select the **Test step** button in the node details window. You should see 10 results in the Output **Table** view.
+Select the **Execute step** button in the node details window. You should see 10 results in the Output **Table** view.
 
-<!--This screenshot needs updating now that the button says "Test step" rather than "Execute node"-->
+<!--This screenshot needs updating now that the button says "Execute step" rather than "Test node"-->
 <figure><img src="/_images/courses/level-one/chapter-two/l1-c2-results-in-table-view-for-the-hacker-news-node.png" alt="Results in Table view for the Hacker News node" style="width:100%"><figcaption align = "center"><i>Results in Table view for the Hacker News node</i></figcaption></figure>
 
 ### Node executions

--- a/docs/courses/level-one/chapter-5/chapter-5.1.md
+++ b/docs/courses/level-one/chapter-5/chapter-5.1.md
@@ -71,7 +71,7 @@ Once you save, exit out of the Credentials window to return to the HTTP Request 
 
 ## Get the data
 
-Select the **Test step** button in the HTTP Request node window. The table view of the HTTP request results should look like this:
+Select the **Execute step** button in the HTTP Request node window. The table view of the HTTP request results should look like this:
 
 <figure><img src="/_images/courses/level-one/chapter-five/l1-c5-5-1-http-request-node-window.png" alt="HTTP Request node output" style="width:100%"><figcaption align = "center"><i>HTTP Request node output</i></figcaption></figure>
 

--- a/docs/courses/level-one/chapter-5/chapter-5.2.md
+++ b/docs/courses/level-one/chapter-5/chapter-5.2.md
@@ -78,7 +78,7 @@ In the Airtable node window, configure the following parameters:
 
 ## Test the Airtable node
 
-Once you've finished configuring the Airtable node, execute it by selecting **Test step**. This might take a moment to process, but you can follow the progress by viewing the base in Airtable.
+Once you've finished configuring the Airtable node, execute it by selecting **Execute step**. This might take a moment to process, but you can follow the progress by viewing the base in Airtable.
 
 Your results should look like this:
 

--- a/docs/courses/level-one/chapter-5/chapter-5.3.md
+++ b/docs/courses/level-one/chapter-5/chapter-5.3.md
@@ -59,7 +59,7 @@ In the If node window, configure the parameters:
 Make sure to select the correct data type (boolean, date & time, number, or string) when you select the **Operation**.
 ///
 
-Select **Test step** to test the If node.
+Select **Execute step** to test the If node.
 
 Your results should look like this:
 
@@ -79,7 +79,7 @@ Since Nathan only needs the `processing` orders in the table, we'll connect the 
 
 In this case, since the Airtable node is already on our canvas, select the **If node** `true` connector and drag it to the Airtable node.
 
-It's a good idea at this point to retest the Airtable node. Before you do, open your table in Airtable and delete all existing rows. Then open the Airtable node window in n8n and select **Test step**.
+It's a good idea at this point to retest the Airtable node. Before you do, open your table in Airtable and delete all existing rows. Then open the Airtable node window in n8n and select **Execute step**.
 
 Review your data in Airtable to be sure your workflow only added the correct orders (those with `orderStatus` of `processing`). There should be 14 records now instead of 30.
 

--- a/docs/courses/level-one/chapter-5/chapter-5.4.md
+++ b/docs/courses/level-one/chapter-5/chapter-5.4.md
@@ -35,7 +35,7 @@ With the Edit Fields node window open, configure these parameters:
     - Drag **If** > **employeeName** as the second field.
 - Ensure that **Include Other Input Fields** is set to false.
 
-Select **Test step**. You should see the following results:
+Select **Execute step**. You should see the following results:
 
 <figure><img src="/_images/courses/level-one/chapter-five/l1-c5-4-set-node.png" alt="Edit Fields (Set) node" style="width:100%"><figcaption align = "center"><i>Edit Fields (Set) node</i></figcaption></figure>
 

--- a/docs/courses/level-one/chapter-5/chapter-5.5.md
+++ b/docs/courses/level-one/chapter-5/chapter-5.5.md
@@ -102,7 +102,7 @@ return [{ json: {totalBooked, bookedSum} }]
 If you don't use the correct data structure, you will get an error message: `Error: Always an Array of items has to be returned!`
 ///
 
-Now select **Test step** and you should see the following results:
+Now select **Execute step** and you should see the following results:
 
 <figure><img src="/_images/courses/level-one/chapter-five/l1-c5-5-5-code-node.png" alt="Code node output" style="width:100%"><figcaption align = "center"><i>Code node output</i></figcaption></figure>
 

--- a/docs/courses/level-one/chapter-5/chapter-5.6.md
+++ b/docs/courses/level-one/chapter-5/chapter-5.6.md
@@ -37,7 +37,7 @@ In the Discord node window, configure these parameters:
 		This week we've {{$json["totalBooked"]}} booked orders with a total value of {{$json["bookedSum"]}}. My Unique ID: {{ $('HTTP Request').params["headerParameters"]["parameters"][0]["value"] }}
 		```
 
-Now select **Test step** in the Discord node. If all works well, you should see this output in n8n:
+Now select **Execute step** in the Discord node. If all works well, you should see this output in n8n:
 
 <figure><img src="/_images/courses/level-one/chapter-five/l1-c5-5-6-discord-output.png" alt="Discord node output" style="width:100%"><figcaption align = "center"><i>Discord node output</i></figcaption></figure>
 

--- a/docs/courses/level-one/chapter-5/chapter-5.7.md
+++ b/docs/courses/level-one/chapter-5/chapter-5.7.md
@@ -55,7 +55,7 @@ Your full workflow should look like this:
 
 ## What's next?
 
-**You 👩‍🔧**: That was it for the workflow! I've added and configured all necessary nodes. Now every time you click on **Test workflow**, n8n will execute all the nodes: getting, filtering, calculating, and transferring the sales data.
+**You 👩‍🔧**: That was it for the workflow! I've added and configured all necessary nodes. Now every time you click on **Execute workflow**, n8n will execute all the nodes: getting, filtering, calculating, and transferring the sales data.
 
 **Nathan 🙋**: This is just what I needed! My workflow will run automatically every Monday morning, correct?
 

--- a/docs/courses/level-two/chapter-2.md
+++ b/docs/courses/level-two/chapter-2.md
@@ -158,7 +158,7 @@ To begin:
 		{
 		"parameters": {},
 		"id": "6bf64d5c-4b00-43cf-8439-3cbf5e5f203b",
-		"name": "When clicking \"Test workflow\"",
+		"name": "When clicking \"Execute workflow\"",
 		"type": "n8n-nodes-base.manualTrigger",
 		"typeVersion": 1,
 		"position": [
@@ -293,7 +293,7 @@ To begin:
 	],
 	"pinData": {},
 	"connections": {
-		"When clicking \"Test workflow\"": {
+		"When clicking \"Execute workflow\"": {
 		"main": [
 			[
 			{

--- a/docs/courses/level-two/chapter-3.md
+++ b/docs/courses/level-two/chapter-3.md
@@ -102,7 +102,7 @@ Build a workflow that merges data from the Customer Datastore node and Code node
 		{
 		"parameters": {},
 		"id": "71aa5aad-afdf-4f8a-bca0-34450eee8acc",
-		"name": "When clicking \"Test workflow\"",
+		"name": "When clicking \"Execute workflow\"",
 		"type": "n8n-nodes-base.manualTrigger",
 		"typeVersion": 1,
 		"position": [
@@ -138,7 +138,7 @@ Build a workflow that merges data from the Customer Datastore node and Code node
 		}
 	],
 	"connections": {
-		"When clicking \"Test workflow\"": {
+		"When clicking \"Execute workflow\"": {
 		"main": [
 			[
 			{
@@ -253,7 +253,7 @@ Build a workflow that reads the RSS feed from Medium and dev.to. The workflow sh
 		{
 		"parameters": {},
 		"id": "ed8dc090-ae8c-4db6-a93b-0fa873015c25",
-		"name": "When clicking \"Test workflow\"",
+		"name": "When clicking \"Execute workflow\"",
 		"type": "n8n-nodes-base.manualTrigger",
 		"typeVersion": 1,
 		"position": [
@@ -303,7 +303,7 @@ Build a workflow that reads the RSS feed from Medium and dev.to. The workflow sh
 		}
 	],
 	"connections": {
-		"When clicking \"Test workflow\"": {
+		"When clicking \"Execute workflow\"": {
 		"main": [
 			[
 			{

--- a/docs/courses/level-two/chapter-5/chapter-5.2.md
+++ b/docs/courses/level-two/chapter-5/chapter-5.2.md
@@ -122,7 +122,7 @@ The third part of the workflow consists of five nodes:
         {
         "parameters": {},
         "id": "c0236456-40be-4f8f-a730-e56cb62b7b5c",
-        "name": "When clicking \"Test workflow\"",
+        "name": "When clicking \"Execute workflow\"",
         "type": "n8n-nodes-base.manualTrigger",
         "typeVersion": 1,
         "position": [
@@ -430,7 +430,7 @@ The third part of the workflow consists of five nodes:
             ]
         ]
         },
-        "When clicking \"Test workflow\"": {
+        "When clicking \"Execute workflow\"": {
         "main": [
             [
             {

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/index.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/index.md
@@ -47,13 +47,13 @@ This example uses the Customer Datastore node to provide sample data to load int
 	![The spreadsheet set up for testing](/_images/integrations/builtin/app-nodes/googlesheets/test-sheet-before.png)  
 	2. Create the workflow: use the manual trigger, Customer Datastore, and Google Sheets nodes.  
 	![The spreadsheet set up for testing](/_images/integrations/builtin/app-nodes/googlesheets/workflow.png)  
-	3. Open the Customer Datastore node, enable **Return All**, then select **Test step**.
+	3. Open the Customer Datastore node, enable **Return All**, then select **Execute step**.
 	4. In the Google Sheets node, go through the steps above, using these settings:
 		* Select **Update Row** as the **Operation**.
 		* In **Column to Match On**, select `test1`.
 		* For the first field of **Values to Update**, drag in the **name** from the input view.
 		* For the second field of **Values to Update**, drag in the **email** from the input view.
-	5. Select **Test step**.
+	5. Select **Execute step**.
 	6. View your spreadsheet. **test2** should now contain the email addresses that match to the names in the input data.  
 	![The spreadsheet set up for testing](/_images/integrations/builtin/app-nodes/googlesheets/test-sheet-after.png)   -->
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftonedrive.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftonedrive.md
@@ -55,5 +55,5 @@ To perform operations on folders, you need to supply the ID. You can find this:
 	1. Select **Resource** > **Folder**.
 	2. Select **Operation** > **Search**.
 	3. In **Query**, enter the folder name.
-	4. Select **Test step**. n8n runs the query and returns data about the folder, including an `id` field containing the folder ID.
+	4. Select **Execute step**. n8n runs the query and returns data about the folder, including an `id` field containing the folder ID.
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.merge.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.merge.md
@@ -186,7 +186,7 @@ Now try different options in **Mode** to see how it affects the output data.
 
 #### Append
 
-Select **Mode** > **Append**, then select **Test step**.
+Select **Mode** > **Append**, then select **Execute step**.
 
 Your output in table view should look like this:
 <!-- vale off -->
@@ -206,7 +206,7 @@ You can merge these two data inputs so that each person gets the correct greetin
 1. Select **Mode** > **Combine**.
 2. Select **Combine by** > **Matching Fields**.
 3. In both **Input 1 Field** and **Input 2 Field**, enter `language`. This tells n8n to combine the data by matching the values in the `language` field in each data set.
-4. Select **Test step**.
+4. Select **Execute step**.
 
 Your output in table view should look like this:
 <!-- vale off -->
@@ -220,7 +220,7 @@ Your output in table view should look like this:
 
 #### Combine by Position
 
-Select **Mode** > **Combine**, **Combine by** > **Position**, then select **Test step**.
+Select **Mode** > **Combine**, **Combine by** > **Position**, then select **Execute step**.
 
 Your output in table view should look like this:
 <!-- vale off -->
@@ -245,7 +245,7 @@ Your output in table view should look like this:
 
 #### Combine by All Possible Combinations 
 
-Select **Mode** > **Combine**, **Combine by** > **All Possible Combinations**, then select **Test step**.
+Select **Mode** > **Combine**, **Combine by** > **All Possible Combinations**, then select **Execute step**.
 
 Your output in table view should look like this:
 <!-- vale off -->

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.removeduplicates/templates-and-examples.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.removeduplicates/templates-and-examples.md
@@ -58,7 +58,7 @@ return {
 1. Add a Remove Duplicates node to the canvas and connect it to the Split Out node. Choose **Remove items repeated within current input** as the **Action** to start.
 2. Open the Remove Duplicates node and ensure that the **Operation** is set to **Remove Items Repeated Within Current Input**.
 3. Choose **All fields** in the **Compare** field.
-4. Select **Test step** to run the Remove Duplicates node, removing duplicated data in the current input.
+4. Select **Execute step** to run the Remove Duplicates node, removing duplicated data in the current input.
 
 n8n removes the items that have the same data across all fields. Your output in table view should look like this:
 
@@ -77,7 +77,7 @@ n8n removes the items that have the same data across all fields. Your output in 
 
 5. Open the Remove Duplicates node again and change the **Compare** parameter to **Selected Fields**.
 6. In the **Fields To Compare** field, enter `job`.
-7. Select **Test step** to run the Remove Duplicates node, removing duplicated data in the current input.
+7. Select **Execute step** to run the Remove Duplicates node, removing duplicated data in the current input.
 
 n8n removes the items in the current input that have the same `job` data. Your output in table view should look like this:
 
@@ -93,7 +93,7 @@ n8n removes the items in the current input that have the same `job` data. Your o
 1. Open the Remove Duplicates node and set the **Operation** to **Remove Items Processed in Previous Executions**.
 2. Set the **Keep Items Where** parameter to **Value Is New**.
 3. Set the **Value to Dedupe On** parameter to `{{ $json.name }}`.
-4. On the canvas, select **Test workflow** to run the workflow. Open the Remove Duplicates node to examine the results.
+4. On the canvas, select **Execute workflow** to run the workflow. Open the Remove Duplicates node to examine the results.
 
 n8n compares the current input data to the items stored from previous executions. Since this is the first time running the Remove Duplicates node with this operation, n8n processes all data items and places them into the **Kept** output tab. The order of the items may be different than the order in the input data:
 
@@ -118,7 +118,7 @@ The current input items are only compared against the stored items from previous
 ///
 
 5. Open the Code node and uncomment (remove the `//` from) the line for "Tom Hanks."
-6. On the canvas, select **Test workflow** again. Open the Remove Duplicates node again to examine the results.
+6. On the canvas, select **Execute workflow** again. Open the Remove Duplicates node again to examine the results.
 
 n8n compares the current input data to the items stored from previous executions. This time, the **Kept** tab contains the one new record from the Code node:
 
@@ -149,14 +149,14 @@ The **Discarded** tab contains the items processed by the previous execution:
 Before continuing, clear the duplication history to get ready for the next example:
 
 7. Open the Remove Duplicates node and set the **Operation** to **Clear Deduplication History**.
-8. Select **Test step** to clear the current duplication history.
+8. Select **Execute step** to clear the current duplication history.
 
 ## Keep items where the value is higher than any previous value
 
 1. Open the Remove Duplicates node and set the **Operation** to **Remove Items Processed in Previous Executions**.
 2. Set the **Keep Items Where** parameter to **Value Is Higher than Any Previous Value**.
 3. Set the **Value to Dedupe On** parameter to `{{ $json.id }}`.
-4. On the canvas, select **Test workflow** to run the workflow. Open the Remove Duplicates node to examine the results.
+4. On the canvas, select **Execute workflow** to run the workflow. Open the Remove Duplicates node to examine the results.
 
 n8n compares the current input data to the items stored from previous executions. Since this is the first time running the Remove Duplicates node after clearing the history, n8n processes all data items and places them into the **Kept** output tab. The order of the items may be different than the order in the input data:
 
@@ -178,7 +178,7 @@ n8n compares the current input data to the items stored from previous executions
 <!-- vale on -->
 
 5. Open the Code node and uncomment (remove the `//` from) the lines for "Madonna" and "Bob Dylan."
-6. On the canvas, select **Test workflow** again. Open the Remove Duplicates node again to examine the results.
+6. On the canvas, select **Execute workflow** again. Open the Remove Duplicates node again to examine the results.
 
 n8n compares the current input data to the items stored from previous executions. This time, the **Kept** tab contains a single entry for "Bob Dylan." n8n keeps this item because its `id` column value (15) is higher than any previous values (the previous maximum value was 9):
 
@@ -211,14 +211,14 @@ The **Discarded** tab contains the 13 items with an `id` column value equal to o
 Before continuing, clear the duplication history to get ready for the next example:
 
 7. Open the Remove Duplicates node and set the **Operation** to **Clear Deduplication History**.
-8. Select **Test step** to clear the current duplication history.
+8. Select **Execute step** to clear the current duplication history.
 
 ## Keep items where the value is a date later than any previous date
 
 1. Open the Remove Duplicates node and set the **Operation** to **Remove Items Processed in Previous Executions**.
 2. Set the **Keep Items Where** parameter to **Value Is a Date Later than Any Previous Date**.
 3. Set the **Value to Dedupe On** parameter to `{{ $json.last_updated }}`.
-4. On the canvas, select **Test workflow** to run the workflow. Open the Remove Duplicates node to examine the results.
+4. On the canvas, select **Execute workflow** to run the workflow. Open the Remove Duplicates node to examine the results.
 
 n8n compares the current input data to the items stored from previous executions. Since this is the first time running the Remove Duplicates node after clearing the history, n8n processes all data items and places them into the **Kept** output tab. The order of the items may be different than the order in the input data:
 
@@ -244,7 +244,7 @@ n8n compares the current input data to the items stored from previous executions
 <!-- vale off -->
 5. Open the Code node and uncomment (remove the `//` from) the lines for "Harry Nilsson" and "Kylie Minogue."
 <!-- vale on -->
-6. On the canvas, select **Test workflow** again. Open the Remove Duplicates node again to examine the results.
+6. On the canvas, select **Execute workflow** again. Open the Remove Duplicates node again to examine the results.
 
 <!-- vale off -->
 n8n compares the current input data to the items stored from previous executions. This time, the **Kept** tab contains a single entry for "Kylie Minogue." n8n keeps this item because its `last_updated` column value (`2024-10-24T08:03:16.493Z`) is later than any previous values (the previous latest date was `2024-10-17T17:11:38.493Z`):

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.webhook/index.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.webhook/index.md
@@ -39,7 +39,7 @@ Select **Test URL** or **Production URL** to toggle which URL n8n displays.
 <figcaption>Sample Webhook URLs in the Webhook node's Parameters tab</figcaption>
 </figure>
 
-* **Test**: n8n registers a test webhook when you select **Listen for Test Event** or **Test workflow**, if the workflow isn't active. When you call the webhook URL, n8n displays the data in the workflow.
+* **Test**: n8n registers a test webhook when you select **Listen for Test Event** or **Execute workflow**, if the workflow isn't active. When you call the webhook URL, n8n displays the data in the workflow.
 * **Production**: n8n registers a production webhook when you activate the workflow. When using the production URL, n8n doesn't display the data in the workflow. You can still view workflow data for a production execution: select the **Executions** tab in the workflow, then select the workflow execution you want to view.
 
 ### HTTP Method

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger.md
@@ -35,7 +35,7 @@ The MCP Server Trigger node has two **MCP URLs**: test and production. n8n displ
 
 Select **Test URL** or **Production URL** to toggle which URL n8n displays.
 
-* **Test**: n8n registers a test MCP URL when you select **Listen for Test Event** or **Test workflow**, if the workflow isn't active. When you call the MCP URL, n8n displays the data in the workflow.
+* **Test**: n8n registers a test MCP URL when you select **Listen for Test Event** or **Execute workflow**, if the workflow isn't active. When you call the MCP URL, n8n displays the data in the workflow.
 * **Production**: n8n registers a production MCP URL when you activate the workflow. When using the production URL, n8n doesn't display the data in the workflow. You can still view workflow data for a production execution: select the **Executions** tab in the workflow, then select the workflow execution you want to view.
 
 ### Authentication

--- a/docs/integrations/builtin/credentials/facebookapp.md
+++ b/docs/integrations/builtin/credentials/facebookapp.md
@@ -93,7 +93,7 @@ Now that you have a token, you can configure the Facebook Trigger node:
 1. In your Meta app, copy the **App ID** from the top navigation bar.
 1. In n8n, open your Facebook Trigger node.
 2. Paste the **App ID** into the **APP ID** field.
-3. Select **Test step** to shift the trigger into listening mode.
+3. Select **Execute step** to shift the trigger into listening mode.
 6. Return to the tab or window where your Meta app's **Webhooks** product configuration is open.
 7. **Subscribe** to the objects you want to receive Facebook Trigger notifications about. For each subscription:
     1. Copy the **Webhook URL** from n8n and enter it as the **Callback URL** in your Meta App.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.googlesheetstrigger/common-issues.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.googlesheetstrigger/common-issues.md
@@ -12,7 +12,7 @@ Here are some common errors and issues with the [Google Sheets Trigger node](/in
 
 ## Stuck waiting for trigger event
 
-When testing the Google Sheets Trigger node with the **Test step** or or **Test workflow** buttons, the execution may appear stuck and unable to stop listening for events. If this occurs, you may need to exit the workflow and open it again to reset the canvas.
+When testing the Google Sheets Trigger node with the **Execute step** or **Execute workflow** buttons, the execution may appear stuck and unable to stop listening for events. If this occurs, you may need to exit the workflow and open it again to reset the canvas.
 
 Stuck listening events often occur due to issues with your network configuration outside of n8n. Specifically, this behavior often occurs when you run n8n behind a reverse proxy without configuring websocket proxying.
 

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.pushcuttrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.pushcuttrigger.md
@@ -27,6 +27,6 @@ Follow these steps to configure your Pushcut Trigger node with your Pushcut app.
 4. Select the **Server** tab.
 5. Select the **Integration** tab.
 6. Select **Integration Trigger**.
-7. In n8n, enter a name for the action and select **Test step**.
+7. In n8n, enter a name for the action and select **Execute step**.
 8. Select this action under the **Select Integration Trigger** screen in your Pushcut app.
 9. Select **Done** in the top right to save the action.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.telegramtrigger/common-issues.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.telegramtrigger/common-issues.md
@@ -12,7 +12,7 @@ Here are some common errors and issues with the [Telegram Trigger node](/integra
 
 ## Stuck waiting for trigger event
 
-When testing the Telegram Trigger node with the **Test step** or or **Test workflow** buttons, the execution may appear stuck and unable to stop listening for events. If this occurs, you may need to exit the workflow and open it again to reset the canvas.
+When testing the Telegram Trigger node with the **Execute step** or **Execute workflow** buttons, the execution may appear stuck and unable to stop listening for events. If this occurs, you may need to exit the workflow and open it again to reset the canvas.
 
 Stuck listening events often occur due to issues with your network configuration outside of n8n. Specifically, this behavior often occurs when you run n8n behind a reverse proxy without configuring websocket proxying.
 

--- a/docs/try-it-out/tutorial-first-workflow.md
+++ b/docs/try-it-out/tutorial-first-workflow.md
@@ -79,7 +79,7 @@ The [NASA node](/integrations/builtin/app-nodes/n8n-nodes-base.nasa.md) interact
         n8n uses Luxon to work with date and time, and also provides two variables for convenience: `$now` and `$today`. For more information, refer to [Expressions > Luxon](/code/cookbook/luxon.md).
 
 1. Close the **Edit Expression** modal to return to the NASA node.
-1. You can now check that the node is working and returning the expected date: select **Test step** to run the node manually. n8n calls the NASA API and displays details of solar flares in the past seven days in the **OUTPUT** section.
+1. You can now check that the node is working and returning the expected date: select **Execute step** to run the node manually. n8n calls the NASA API and displays details of solar flares in the past seven days in the **OUTPUT** section.
 1. Close the NASA node to return to the workflow canvas.
 
 ## Step four: Add logic with the If node
@@ -100,7 +100,7 @@ Add the If node:
 
     1. Change the comparison operation to **String > Contains**.
     1. In **Value 2**, enter **X**. This is the highest classification of solar flare. In the next step, you will create two reports: one for X class solar flares, and one for all the smaller solar flares.
-1. You can now check that the node is working and returning the expected date: select **Test step** to run the node manually. n8n tests the data against the condition, and shows which results match true or false in the **OUTPUT** panel.
+1. You can now check that the node is working and returning the expected date: select **Execute step** to run the node manually. n8n tests the data against the condition, and shows which results match true or false in the **OUTPUT** panel.
 
     /// note | Weeks without large solar flares
     In this tutorial, you are working with live data. If you find there aren't any X class solar flares when you run the workflow, try replacing **X** in **Value 2** with either **A**, **B**, **C**, or **M**.

--- a/docs/workflows/components/nodes.md
+++ b/docs/workflows/components/nodes.md
@@ -44,12 +44,12 @@ Select the **Add node** <span class="inline-image">![Add node icon](/_images/try
 
 To view node controls, hover over the node on the canvas:
 
-* **Test step** <span class="inline-image">![Test step icon](/_images/common-icons/play-node.png){.off-glb}</span>: Run the node.
+* **Execute step** <span class="inline-image">![Execute step icon](/_images/common-icons/play-node.png){.off-glb}</span>: Run the node.
 * **Deactivate** <span class="inline-image">![Deactivate node icon](/_images/common-icons/power-off.png){.off-glb}</span>: Deactivate the node.
 * **Delete** <span class="inline-image">![Delete node icon](/_images/common-icons/delete-node.png){.off-glb}</span>: Delete the node.
 * **Node context menu** <span class="inline-image">![Node context menu icon](/_images/common-icons/node-context-menu.png){.off-glb}</span>: Select node actions. Available actions:
 	* Open node
-	* Test step
+	* Execute step
 	* Rename node
 	* Deactivate node
 	* Pin node

--- a/docs/workflows/executions/manual-partial-and-production-executions.md
+++ b/docs/workflows/executions/manual-partial-and-production-executions.md
@@ -11,7 +11,7 @@ There are some important differences in how n8n executes workflows manually (by 
 
 ## Manual executions
 
-Manual executions allow you to run workflows directly from the [canvas](/glossary.md#canvas-n8n) to test your workflow logic. These executions are "ad-hoc" — they run only when you manually select the **Execute workflow** button.
+Manual executions allow you to run workflows directly from the [canvas](/glossary.md#canvas-n8n) to test your workflow logic. These executions are "ad-hoc": they run only when you manually select the **Execute workflow** button.
 
 Manual executions make building workflows easier by allowing you to iteratively test as you go, following the flow logic and seeing data transformations. You can test conditional branching, data formatting changes, and loop behavior by providing different input items and modifying node options.
 

--- a/docs/workflows/executions/manual-partial-and-production-executions.md
+++ b/docs/workflows/executions/manual-partial-and-production-executions.md
@@ -11,7 +11,7 @@ There are some important differences in how n8n executes workflows manually (by 
 
 ## Manual executions
 
-Manual executions allow you to run workflows directly from the [canvas](/glossary.md#canvas-n8n) to test your workflow logic. These executions are "ad-hoc" — they run only when you manually select the **Test workflow** button.
+Manual executions allow you to run workflows directly from the [canvas](/glossary.md#canvas-n8n) to test your workflow logic. These executions are "ad-hoc" — they run only when you manually select the **Execute workflow** button.
 
 Manual executions make building workflows easier by allowing you to iteratively test as you go, following the flow logic and seeing data transformations. You can test conditional branching, data formatting changes, and loop behavior by providing different input items and modifying node options.
 
@@ -23,9 +23,9 @@ On future runs, instead of executing the pinned node, n8n will substitute the pi
 
 ## Partial executions
 
-Clicking the **Test workflow** button at the bottom of the workflow in the **Editor** tab manually runs the entire workflow. You can also perform partial executions to run specific steps in your workflow. Partial executions are manual executions that only run a subset of your workflow nodes.
+Clicking the **Execute workflow** button at the bottom of the workflow in the **Editor** tab manually runs the entire workflow. You can also perform partial executions to run specific steps in your workflow. Partial executions are manual executions that only run a subset of your workflow nodes.
 
-To perform a partial execution, select a node, open its detail view, and select **Test step**. This executes the specific node and any preceding nodes required to fill in its input data. You can also temporarily disable specific nodes in the workflow chain to avoid interacting with those services while building.
+To perform a partial execution, select a node, open its detail view, and select **Execute step**. This executes the specific node and any preceding nodes required to fill in its input data. You can also temporarily disable specific nodes in the workflow chain to avoid interacting with those services while building.
 
 In particular, partial executions are useful when updating the logic of a specific node since they allow you to re-execute the node with the same input data.
 


### PR DESCRIPTION
To avoid confusion with the evaluation feature, we renamed the 'Test Workflow' button in the editor to 'Execute Workflow'.
'Test step' in node detail view became 'Execute step'. This PR replaces all mentions of those buttons in the docs.

## Related links
- https://linear.app/n8n/issue/AI-572/rename-the-test-workflownode-execution-buttons
- https://github.com/n8n-io/n8n/pull/15112

(Edit from @imchairmanm: Closes DOC-1461)