### PR TITLE
docs: compose.yaml and --api flag redundancy

### DIFF
--- a/docs/hosting/installation/server-setups/docker-compose.md
+++ b/docs/hosting/installation/server-setups/docker-compose.md
@@ -120,15 +120,14 @@ The Docker Compose file below can automatically create this directory, but doing
 
 ## 6. Create Docker Compose file
 
-Create a `docker-compose.yml` file. Paste the following in the file:
+Create a `compose.yaml` file. Paste the following in the file:
 
-```yaml title="docker-compose.yml file"
+```yaml title="compose.yaml file"
 services:
   traefik:
     image: "traefik"
     restart: always
     command:
-      - "--api=true"
       - "--api.insecure=true"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"


### PR DESCRIPTION
This PR makes two tiny changes:
1. Removes the `--api` flag, as `--api.insecure=true` implies it.
2. Changes the `docker-compose.yml` file definition to `compose.yaml` [ref](https://docs.docker.com/compose/intro/compose-application-model/#the-compose-file) is preferred since August 2020, v.1.27.0