### PR TITLE
Small verification guidelines improvement

### DIFF
--- a/_snippets/integrations/submit-community-node.md
+++ b/_snippets/integrations/submit-community-node.md
@@ -31,4 +31,4 @@ Before submitting your node for review by n8n, you must:
 * Make sure that the node has appropriate documentation in the form of a README in the [npm package](https://docs.npmjs.com/about-package-readme-files) or a related public repository.
 * Submit your node to npm as n8n will fetch it from there for final vetting.
 
-If your node meets all the above requirements, [click here to submit your node for verification](https://internal.users.n8n.cloud/form/f0ff9304-f34a-420e-99da-6103a2f8ac5b).
+If your node meets all the above requirements, [click here to submit your node for verification](https://internal.users.n8n.cloud/form/f0ff9304-f34a-420e-99da-6103a2f8ac5b). Note that n8n reserves the right to reject nodes that compete with any of n8n's paid features, especially enterprise functionality.

--- a/docs/integrations/creating-nodes/build/reference/verification-guidelines.md
+++ b/docs/integrations/creating-nodes/build/reference/verification-guidelines.md
@@ -6,7 +6,7 @@ contentType: reference
 # Community node verification guidelines
 
 /// note | Do you want n8n to verify your node?
-Consider following these guidelines while building your node if you want to submit it for verification by n8n. Any user with verified community nodes enabled can discover and install verified nodes from n8n's nodes panel.
+Consider following these guidelines while building your node if you want to submit it for verification by n8n. Any user with verified community nodes enabled can discover and install verified nodes from n8n's nodes panel across all deployment types (self-hosted and n8n Cloud).
 ///
 
 ## Package source verification


### PR DESCRIPTION
This PR adds two small refinements:
- clarification that verified community nodes are available on all deployment types, to make it clear they are also on cloud
- n8n reserves right to reject nodes that compete with paid features