### PR TITLE
Mention that Simple Vector Store data is accessible to all users

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreinmemory.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreinmemory.md
@@ -36,7 +36,7 @@ This node stores data in memory only. All data is lost when n8n restarts and may
 
 Memory keys for the Simple Vector Store node are global, not scoped to individual workflows.
 
-This means that all user of the instance can access vector store data by adding a Simple Vector Store node and selecting the memory key, regardless of the access controls set for the original workflow. Take care not to expose sensitive information when ingesting data with the Simple Vector Store node.
+This means that all users of the instance can access vector store data by adding a Simple Vector Store node and selecting the memory key, regardless of the access controls set for the original workflow. Take care not to expose sensitive information when ingesting data with the Simple Vector Store node.
 
 ## Node usage patterns
 


### PR DESCRIPTION
Hey! We're changing Simple Vector Stores at PR https://github.com/n8n-io/n8n/pull/15421, changing the `Memory Key` picker to a resource locator that lists all currently existing vector stores in memory. This is introduced on a new version of the In-Memory vector store node, version 1.2, to be shipped at next n8n beta version once that PR gets merged.

Another substantial change at that PR is that we're removing the workflow prefixing done by n8n at the backend from these nodes on version 1.2. This removes the workflow level isolation and enables the Simple Vector Stores to be used across workflows, but this also means that any instance users can now access data stored on the in memory vector stores regardless of their access to workflows. We've adjusted the warning on the UI to mention this, but docs should also change here.

This docs page also mentions the workflow isolation bunch of times. I didn't touch those, but that is changing with the new version of the node. Old nodes still respect the workflow level isolation, but the new version can also select stores created by the older versions of the node by picking the workflow prefixed items from the list. Some adjustments to the texts here should be made.