### PR TITLE
fix: Update external secrets to clarify value types

### DIFF
--- a/docs/external-secrets.md
+++ b/docs/external-secrets.md
@@ -20,7 +20,7 @@ n8n stores all credentials encrypted in its database, and restricts access to th
 ## Connect n8n to your secrets store
 
 /// note | Secret names
-Your secret names can't contain spaces, hyphens, or other special characters. n8n supports secret names containing alphanumeric characters (`a-z`, `A-Z`, and `0-9`), and underscores.
+Your secret names can't contain spaces, hyphens, or other special characters. n8n supports secret names containing alphanumeric characters (`a-z`, `A-Z`, and `0-9`), and underscores. We curently only support plaintext values for secrets and not JSON objects or key-value pairs.
 ///
 1. In n8n, go to **Settings** > **External Secrets**.
 1. Select **Set Up** for your store provider.


### PR DESCRIPTION
Clarify the requirement for only allowing plaintext secrets and not supporting JSON objects (also know as key/value pairs in AWS secrets manager).

Fixes: DOC-1470
See also: PAY-2869