### PR TITLE
feat(documentation): favors Scalar for api reference

### DIFF
--- a/_overrides/api.html
+++ b/_overrides/api.html
@@ -4,13 +4,24 @@
 <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
 
 <!--
-Redoc doesn't change outer page styles
+Scalar doesn't change outer page styles
 -->
 <style>
-
+  /* Mkdocs style reset */
   body {
     margin: 0;
     padding: 0;
+  }
+
+  .md-content__button {
+    position: absolute;
+    right: 4px;
+    top: 88px;
+    z-index: 1;
+  }
+
+  .md-typeset svg {
+    border: none;
   }
 
   .md-main__inner  {
@@ -18,13 +29,15 @@ Redoc doesn't change outer page styles
       margin-top: 0;
   }
 
-  .md-grid {
-      max-width: 100%;
+  .md-typeset .grid {
+    grid-gap: 0;
+    margin: 0;
   }
 
   .md-content__inner {
-    padding: 0;
     margin: 0;
+    padding: 0;
+    position: relative;
   }
 
   .md-content__inner > p {
@@ -39,14 +52,37 @@ Redoc doesn't change outer page styles
     margin-bottom: invalid;
   }
 
-  [dir=ltr] .md-typeset ol li, [dir=ltr] .md-typeset ul li {
-    margin-left: 0;
+  [dir=ltr] .md-typeset ol li, [dir=ltr] .md-typeset ul li,
+  [dir=ltr] .md-typeset ol, [dir=ltr] .md-typeset ul,
+  [dir=ltr] .md-typeset ul li ul {
+    margin: 0;
   }
 
-  [dir=ltr] .md-typeset ol, [dir=ltr] .md-typeset ul {
-    margin-left: 0;
-  }
+  /* Scalar API Reference style reset */
+  .scalar-api-reference {
+    --scalar-custom-header-height: 48px;
 
+    h1,
+    h2,
+    h3,
+    table,
+    li,
+    kbd {
+      all: unset;
+    }
+
+    .sidebar-search {
+      border-style: solid;
+    }
+
+    .section-container {
+      padding-right: 4px!important;
+    }
+
+    .section-container:has(.show-more) {
+      background-color: transparent!important;
+    }
+  }
 </style>
 
 {% endblock %}

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -8,23 +8,18 @@ description: API reference for n8n's public REST API.
 contentType: reference
 ---
 
+<script
+  id="api-reference"
+  data-url="/api/v1/openapi.yml"></script>
 
-<redoc
-  spec-url="/api/v1/openapi.yml"
-  disable-search
-  hide-hostname
-  theme='{
-    "typography": {
-      "fontSize": "14px",
-      "lineHeight": "1.2em",
-      "fontFamily": "\"Open sans\", Helvetica, sans-serif",
-      "headings": {
-        "fontFamily": "\"Open sans\", Helvetica, sans-serif"
-      }
-    },
-    "sidebar": {
-      "backgroundColor": "#eaeaea",
-      "width": "280px"
-    }
-  }' />
-<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>
+<script>
+  var configuration = {
+    forceDarkModeState: 'light',
+    hideDarkModeToggle: true,
+  }
+
+  document.getElementById('api-reference').dataset.configuration =
+    JSON.stringify(configuration)
+</script>
+
+<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>


### PR DESCRIPTION
**description**
this first pr is a proposal to favor the open source project [scalar](https://github.com/scalar/scalar) for the api reference documentation which include an interactive playground.


**how to test**
Describe the steps to verify that the changes are working as expected.
1. run `mkdocs serve`
2. visit `/api/api-reference`


**what changed**
| before | after |
| -------|------|
| <img width="1470" alt="image" src="https://github.com/user-attachments/assets/988841bb-3ca2-4630-8397-6f1493de9762" /> | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/d9db4b08-e322-43e6-a11f-be7af1f44111" /> |