### PR TITLE
document `N8N_LOG_FORMAT`

### DIFF
--- a/docs/hosting/configuration/environment-variables/logs.md
+++ b/docs/hosting/configuration/environment-variables/logs.md
@@ -23,7 +23,7 @@ This page lists environment variables to set up logging for debugging. Refer to 
 | :------- | :---- | :------- | :---------- |
 | `N8N_LOG_LEVEL` | Enum string: `info`, `warn`, `error`, `debug` | `info` | Log output level. Refer to [Log levels](/hosting/logging-monitoring/logging.md#log-levels) for details. |
 | `N8N_LOG_OUTPUT` | Enum string: `console`, `file` | `console` | Where to output logs. Provide multiple values as a comma-separated list. |
-| `N8N_LOG_FORMAT` | Enum string: `text`, `json` | `text` | What format the logs should have. `text` is only printing the human readable messages. `json` is printing one JSON object per line containing the message, level, timestamp and all the metadata. This is very useful for production monitoring as well as debugging. |
+| `N8N_LOG_FORMAT` | Enum string: `text`, `json` | `text` | The log format to use. `text` prints human readable messages. `json` prints one JSON object per line containing the message, level, timestamp, and all metadata. This is useful for production monitoring as well as debugging. |
 | `N8N_LOG_FILE_COUNT_MAX` | Number | `100` | Max number of log files to keep. |
 | `N8N_LOG_FILE_SIZE_MAX` | Number | `16` | Max size of each log file in MB. |
 | `N8N_LOG_FILE_LOCATION` | String | `<n8n-directory-path>/logs/n8n.log` | Log file location. Requires N8N_LOG_OUTPUT set to `file`. |

--- a/docs/hosting/configuration/environment-variables/logs.md
+++ b/docs/hosting/configuration/environment-variables/logs.md
@@ -23,6 +23,7 @@ This page lists environment variables to set up logging for debugging. Refer to 
 | :------- | :---- | :------- | :---------- |
 | `N8N_LOG_LEVEL` | Enum string: `info`, `warn`, `error`, `debug` | `info` | Log output level. Refer to [Log levels](/hosting/logging-monitoring/logging.md#log-levels) for details. |
 | `N8N_LOG_OUTPUT` | Enum string: `console`, `file` | `console` | Where to output logs. Provide multiple values as a comma-separated list. |
+| `N8N_LOG_FORMAT` | Enum string: `text`, `json` | `text` | What format the logs should have. `text` is only printing the human readable messages. `json` is printing one JSON object per line containing the message, level, timestamp and all the metadata. This is very useful for production monitoring as well as debugging. |
 | `N8N_LOG_FILE_COUNT_MAX` | Number | `100` | Max number of log files to keep. |
 | `N8N_LOG_FILE_SIZE_MAX` | Number | `16` | Max size of each log file in MB. |
 | `N8N_LOG_FILE_LOCATION` | String | `<n8n-directory-path>/logs/n8n.log` | Log file location. Requires N8N_LOG_OUTPUT set to `file`. |


### PR DESCRIPTION
Add docs for a new environment variable `N8N_LOG_FORMAT`. This allows logging JSON to stdout.


Feature: https://github.com/n8n-io/n8n/pull/15766