### PR TITLE
add Straico documentation for chat model node

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmChatStraico.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmChatStraico.md
@@ -1,0 +1,56 @@
+# Straico Chat Model node
+
+Use the **Straico Chat Model** node to connect with Straico's powerful AI models for conversational tasks,. This node enables chat-based interactions for generating text, answering questions, summarizing content, and more — directly within your n8n workflows.
+
+On this page, you'll find details about the node's parameters, authentication, and configuration options.
+
+---
+
+## Credentials
+
+This node requires API credentials from Straico. You can generate and manage your API keys in your Straico account.
+
+> For help setting up credentials, see: [Straico Authentication Guide](https://documenter.getpostman.com/view/5900072/2s9YyzddrR).
+
+---
+
+## Parameter resolution in sub-nodes
+
+Sub-nodes behave differently from standard nodes when processing multiple input items using expressions.
+
+Most nodes process all input items independently. For example, if you use the expression `{{ $json.name }}` with five inputs, it resolves each name individually.
+
+However, sub-nodes always resolve expressions using the **first input item**. In the same example, `{{ $json.name }}` would return the first name for all five items.
+
+---
+
+## Node Parameters
+
+- **Model**: Select the Straico model to use for generating completions. Available models are dynamically fetched via the Straico API. Refer to the [Straico Model Reference](https://documenter.getpostman.com/view/5900072/2s9YyzddrR#7527bcfd-0c71-4ee9-b67f-3ce21b41e5f2) for more information.
+
+---
+
+## Node Options
+
+- **Frequency Penalty**: Reduces the likelihood of repeated phrases. Higher values increase penalty for repetition.
+- **Maximum Number of Tokens**: Sets the length of the response. Straico models support up to 32,000 tokens.
+- **Presence Penalty**: Encourages the model to talk about new topics by adjusting topic diversity.
+- **Sampling Temperature**: Controls creativity. Lower values are more deterministic; higher values are more diverse (but may hallucinate).
+- **Top P**: Sets nucleus sampling probability. Lower values reduce randomness.
+- **Timeout**: Set a time limit for each API request (in milliseconds).
+- **Max Retries**: Number of retry attempts in case of a failed request.
+
+---
+
+## Example Use Case
+
+💡 **Customer Support Assistant**  
+Use the Straico Chat Model node in a workflow with a webhook and a database to build an automated customer support assistant. Send user questions to Straico and receive high-quality, context-aware answers.
+
+---
+
+## Additional Resources
+
+- [Straico API Documentation](https://documenter.getpostman.com/view/5900072/2s9YyzddrR)
+- [Straico Website](https://straico.com)
+- [n8n Community Nodes Guide](https://docs.n8n.io/integrations/community-nodes/)

--- a/docs/integrations/builtin/credentials/Straico.md
+++ b/docs/integrations/builtin/credentials/Straico.md
@@ -1,0 +1,32 @@
+---
+title: Straico credentials
+description: Documentation for Straico credentials. Use these credentials to authenticate Straico in n8n, a workflow automation platform.
+contentType: [integration, reference]
+priority: critical
+---
+
+# Straico credentials
+
+You can use these credentials to authenticate the following nodes:
+
+- [Straico Chat Model](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmChatStraico.md)
+
+## Prerequisites
+
+Create a [Straico](https://straico.com) account.
+
+## Supported authentication methods
+
+- API key
+
+## Related resources
+
+Refer to the [Straico API documentation](https://documenter.getpostman.com/view/5900072/2s9YyzddrR) for full technical details and usage examples.
+
+## Using API key
+
+To configure this credential, you'll need:
+
+- An **API Key**: You can generate an API key by logging into your Straico account and navigating to the [API Key management section](https://straico.com/api/).
+
+Your API key is used to authenticate all requests made to the Straico Chat Model API. When entering the API key in n8n, ensure you store it securely using the **Straico API** credential type.

--- a/nav.yml
+++ b/nav.yml
@@ -734,6 +734,7 @@ nav:
             - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai/common-issues.md
           - OpenRouter Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenrouter.md
           - xAI Grok Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatxaigrok.md
+          - Straico Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmChatStraico.md
           - Cohere Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmcohere.md
           - Ollama Model:
             - Ollama Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmollama/index.md
@@ -1075,6 +1076,7 @@ nav:
         - integrations/builtin/credentials/wufoo.md
         - integrations/builtin/credentials/twitter.md
         - integrations/builtin/credentials/xai.md
+        - integrations/builtin/credentials/Straico.md
         - integrations/builtin/credentials/xata.md
         - integrations/builtin/credentials/xero.md
         - integrations/builtin/credentials/yourls.md


### PR DESCRIPTION
This adds the initial documentation for the Straico Chat Model node. The doc includes credential setup, parameter explanation, node options, and example use cases to help users integrate Straico's AI capabilities into their n8n workflows.