### PR TITLE
docs: clarify docker compose directory requirement

### DIFF
--- a/_snippets/self-hosting/installation/docker-compose-updating.md
+++ b/_snippets/self-hosting/installation/docker-compose-updating.md
@@ -1,6 +1,9 @@
 If you run n8n using a Docker Compose file, follow these steps to update n8n:
 
 ```sh
+# Navigate to the directory containing your docker compose file
+cd </path/to/your/compose/directory>
+
 # Pull latest version
 docker compose pull
 


### PR DESCRIPTION
Previously, the need to run commands from the compose file directory was only implied, which could confuse non-technical users. This change:

1. Clearly states users must first navigate to their compose file directory

2. Explicitly requires running update commands from that location