### PR TITLE
feat(ado-3519)- docs for changes in document loader

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentdefaultdataloader.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentdefaultdataloader.md
@@ -12,28 +12,32 @@ Use the Default Data Loader node to load binary data files or JSON data for [vec
 
 On this page, you'll find a list of parameters the Default Data Loader node supports, and links to more resources.
 
---8<-- "_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
+--8<-- "\_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
 
 ## Node parameters
 
-* **Type of Data**: Select **Binary** or **JSON**.
-* **Data Format**: Displays when you set **Type of Data** to **Binary**. Select the file MIME type for your binary data. Set to **Automatically Detect by MIME Type** if you want n8n to set the data format for you. If you set a specific data format and the incoming file MIME type doesn't match it, the node errors. If you use **Automatically Detect by MIME Type**, the node falls back to text format if it can't match the file MIME type to a supported data format.
-* **Mode**: Choose from:
-	* **Load All Input Data**: Use all the node's input data.
-	* **Load Specific Data**: Use [expressions](/code/expressions.md) to define the data you want to load. You can add text as well as expressions. This means you can create a custom document from a mix of text and expressions.
+-   **Text Splitting**: Choose from:
+    -   **Simple**: Uses the [**Recursive Character Text Splitter**](n8n-nodes-langchain.textsplitterrecursivecharactertextsplitter.md) with a chunk size of **1000** and an overlap of **200**
+    -   **Custom**: Allows you to connect a Text Splitter of your choice
+-   **Type of Data**: Select **Binary** or **JSON**.
+-   **Data Format**: Displays when you set **Type of Data** to **Binary**. Select the file MIME type for your binary data. Set to **Automatically Detect by MIME Type** if you want n8n to set the data format for you. If you set a specific data format and the incoming file MIME type doesn't match it, the node errors. If you use **Automatically Detect by MIME Type**, the node falls back to text format if it can't match the file MIME type to a supported data format.
+-   **Mode**: Choose from:
+    -   **Load All Input Data**: Use all the node's input data.
+    -   **Load Specific Data**: Use [expressions](/code/expressions.md) to define the data you want to load. You can add text as well as expressions. This means you can create a custom document from a mix of text and expressions.
 
 ## Node options
 
-* **Metadata**: Set the metadata that should accompany the document in the vector store. This is what you match to using the **Metadata Filter** option when retrieving data using the vector store nodes.
+-   **Metadata**: Set the metadata that should accompany the document in the vector store. This is what you match to using the **Metadata Filter** option when retrieving data using the vector store nodes.
 
 ## Templates and examples
 
 <!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->
-[[ templatesWidget(page.title, 'default-data-loader') ]]
+
+[[templatesWidget(page.title, 'default-data-loader')]]
 
 ## Related resources
 
---8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-doc-loaders-link.md"
+--8<-- "\_snippets/integrations/builtin/cluster-nodes/langchain-doc-loaders-link.md"
 
---8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
---8<-- "_glossary/ai-glossary.md"
+--8<-- "\_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
+--8<-- "\_glossary/ai-glossary.md"

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentdefaultdataloader.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentdefaultdataloader.md
@@ -12,32 +12,31 @@ Use the Default Data Loader node to load binary data files or JSON data for [vec
 
 On this page, you'll find a list of parameters the Default Data Loader node supports, and links to more resources.
 
---8<-- "\_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
+--8<-- "_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
 
 ## Node parameters
 
--   **Text Splitting**: Choose from:
-    -   **Simple**: Uses the [**Recursive Character Text Splitter**](n8n-nodes-langchain.textsplitterrecursivecharactertextsplitter.md) with a chunk size of **1000** and an overlap of **200**
-    -   **Custom**: Allows you to connect a Text Splitter of your choice
--   **Type of Data**: Select **Binary** or **JSON**.
--   **Data Format**: Displays when you set **Type of Data** to **Binary**. Select the file MIME type for your binary data. Set to **Automatically Detect by MIME Type** if you want n8n to set the data format for you. If you set a specific data format and the incoming file MIME type doesn't match it, the node errors. If you use **Automatically Detect by MIME Type**, the node falls back to text format if it can't match the file MIME type to a supported data format.
--   **Mode**: Choose from:
-    -   **Load All Input Data**: Use all the node's input data.
-    -   **Load Specific Data**: Use [expressions](/code/expressions.md) to define the data you want to load. You can add text as well as expressions. This means you can create a custom document from a mix of text and expressions.
+* **Text Splitting**: Choose from:
+	* **Simple**: Uses the [Recursive Character Text Splitter](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.textsplitterrecursivecharactertextsplitter.md) with a chunk size of 1000 and an overlap of 200.
+	* **Custom**: Allows you to connect a text splitter of your choice.
+* **Type of Data**: Select **Binary** or **JSON**.
+* **Mode**: Choose from:
+    * **Load All Input Data**: Use all the node's input data.
+    * **Load Specific Data**: Use [expressions](/code/expressions.md) to define the data you want to load. You can add text as well as expressions. This means you can create a custom document from a mix of text and expressions.
+* **Data Format**: Displays when you set **Type of Data** to **Binary**. Select the file MIME type for your binary data. Set to **Automatically Detect by MIME Type** if you want n8n to set the data format for you. If you set a specific data format and the incoming file MIME type doesn't match it, the node errors. If you use **Automatically Detect by MIME Type**, the node falls back to text format if it can't match the file MIME type to a supported data format.
 
 ## Node options
 
--   **Metadata**: Set the metadata that should accompany the document in the vector store. This is what you match to using the **Metadata Filter** option when retrieving data using the vector store nodes.
+* **Metadata**: Set the metadata that should accompany the document in the vector store. This is what you match to using the **Metadata Filter** option when retrieving data using the vector store nodes.
 
 ## Templates and examples
 
 <!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->
-
-[[templatesWidget(page.title, 'default-data-loader')]]
+[[ templatesWidget(page.title, 'default-data-loader') ]]
 
 ## Related resources
 
---8<-- "\_snippets/integrations/builtin/cluster-nodes/langchain-doc-loaders-link.md"
+--8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-doc-loaders-link.md"
 
---8<-- "\_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
---8<-- "\_glossary/ai-glossary.md"
+--8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
+--8<-- "_glossary/ai-glossary.md"

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentdefaultdataloader.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentdefaultdataloader.md
@@ -21,8 +21,8 @@ On this page, you'll find a list of parameters the Default Data Loader node supp
 	* **Custom**: Allows you to connect a text splitter of your choice.
 * **Type of Data**: Select **Binary** or **JSON**.
 * **Mode**: Choose from:
-    * **Load All Input Data**: Use all the node's input data.
-    * **Load Specific Data**: Use [expressions](/code/expressions.md) to define the data you want to load. You can add text as well as expressions. This means you can create a custom document from a mix of text and expressions.
+	* **Load All Input Data**: Use all the node's input data.
+	* **Load Specific Data**: Use [expressions](/code/expressions.md) to define the data you want to load. You can add text as well as expressions. This means you can create a custom document from a mix of text and expressions.
 * **Data Format**: Displays when you set **Type of Data** to **Binary**. Select the file MIME type for your binary data. Set to **Automatically Detect by MIME Type** if you want n8n to set the data format for you. If you set a specific data format and the incoming file MIME type doesn't match it, the node errors. If you use **Automatically Detect by MIME Type**, the node falls back to text format if it can't match the file MIME type to a supported data format.
 
 ## Node options

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentgithubloader.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentgithubloader.md
@@ -15,26 +15,31 @@ On this page, you'll find the node parameters for the GitHub Document Loader nod
 You can find authentication information for this node [here](/integrations/builtin/credentials/github.md). This node doesn't support OAuth for authentication.
 ///
 
---8<-- "_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
+--8<-- "\_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
 
 ## Node parameters
 
-* **Repository Link**: Enter the URL of your GitHub repository.
-* **Branch**: Enter the branch name to use.
+-   **Text Splitting**: Choose from:
+    -   **Simple**: Uses the [**Recursive Character Text Splitter**](n8n-nodes-langchain.textsplitterrecursivecharactertextsplitter.md) with a chunk size of **1000** and an overlap of **200**
+    -   **Custom**: Allows you to connect a Text Splitter of your choice
+
+*   **Repository Link**: Enter the URL of your GitHub repository.
+*   **Branch**: Enter the branch name to use.
 
 ## Node options
 
-* **Recursive**: Select whether to include sub-folders and files (turned on) or not (turned off).
-* **Ignore Paths**: Enter directories to ignore.
+-   **Recursive**: Select whether to include sub-folders and files (turned on) or not (turned off).
+-   **Ignore Paths**: Enter directories to ignore.
 
 ## Templates and examples
 
 <!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->
-[[ templatesWidget(page.title, 'github-document-loader') ]]
+
+[[templatesWidget(page.title, 'github-document-loader')]]
 
 ## Related resources
 
---8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-doc-loaders-link.md"
+--8<-- "\_snippets/integrations/builtin/cluster-nodes/langchain-doc-loaders-link.md"
 
---8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
---8<-- "_glossary/ai-glossary.md"
+--8<-- "\_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
+--8<-- "\_glossary/ai-glossary.md"

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentgithubloader.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentgithubloader.md
@@ -15,31 +15,29 @@ On this page, you'll find the node parameters for the GitHub Document Loader nod
 You can find authentication information for this node [here](/integrations/builtin/credentials/github.md). This node doesn't support OAuth for authentication.
 ///
 
---8<-- "\_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
+--8<-- "_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
 
 ## Node parameters
 
--   **Text Splitting**: Choose from:
-    -   **Simple**: Uses the [**Recursive Character Text Splitter**](n8n-nodes-langchain.textsplitterrecursivecharactertextsplitter.md) with a chunk size of **1000** and an overlap of **200**
-    -   **Custom**: Allows you to connect a Text Splitter of your choice
-
-*   **Repository Link**: Enter the URL of your GitHub repository.
-*   **Branch**: Enter the branch name to use.
+* **Text Splitting**: Choose from:
+	* **Simple**: Uses the [Recursive Character Text Splitter](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.textsplitterrecursivecharactertextsplitter.md) with a chunk size of 1000 and an overlap of 200.
+    * **Custom**: Allows you to connect a text splitter of your choice.
+* **Repository Link**: Enter the URL of your GitHub repository.
+* **Branch**: Enter the branch name to use.
 
 ## Node options
 
--   **Recursive**: Select whether to include sub-folders and files (turned on) or not (turned off).
--   **Ignore Paths**: Enter directories to ignore.
+* **Recursive**: Select whether to include sub-folders and files (turned on) or not (turned off).
+* **Ignore Paths**: Enter directories to ignore.
 
 ## Templates and examples
 
 <!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->
-
-[[templatesWidget(page.title, 'github-document-loader')]]
+[[ templatesWidget(page.title, 'github-document-loader') ]]
 
 ## Related resources
 
---8<-- "\_snippets/integrations/builtin/cluster-nodes/langchain-doc-loaders-link.md"
+--8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-doc-loaders-link.md"
 
---8<-- "\_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
---8<-- "\_glossary/ai-glossary.md"
+--8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
+--8<-- "_glossary/ai-glossary.md"


### PR DESCRIPTION
We are making a change the Data loader node with this task https://linear.app/n8n/issue/ADO-3519/default-text-splitting-in-the-data-loaders 
Currently, the user had to use a text splitter input node. We are making this easy by adding a new property in the data loader node. If the user chooses `simple`, we use a Recursive Character Text Splitter` under the hood. The user also has an option to pick the `custom` option and chose a text splitter of their choice. 
This affects two nodes 
- Default Data Loader
- GitHub Document Loader