### PR TITLE
Update n8n-nodes-langchain.mcptrigger.md (change tab to space)

### DIFF
--- a/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger.md
@@ -83,9 +83,9 @@ To do so, add the following to your Claude Desktop configuration:
         "--header",
         "Authorization: Bearer ${AUTH_TOKEN}"
       ],
-	  "env": {
-	    "AUTH_TOKEN": "<MCP_BEARER_TOKEN>"
-	  }
+      "env": {
+        "AUTH_TOKEN": "<MCP_BEARER_TOKEN>"
+      }
     }
   }
 }


### PR DESCRIPTION
# Description
The place set to "tab" was displayed differently depending on the rendering environment, so it was changed to "space".

# Capture
https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger/#integrating-with-claude-desktop
![image](https://github.com/user-attachments/assets/03e457db-12d9-42b9-ba38-84a297adaef5)

https://github.com/n8n-io/n8n-docs/blob/main/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger.md
![image](https://github.com/user-attachments/assets/f04bbec7-db45-4cbe-93f1-e16a03bacdf4)

https://github.com/n8n-io/n8n-docs/edit/main/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger.md
![image](https://github.com/user-attachments/assets/9e71baca-f03e-4fae-907f-1054281e3194)
