### PR TITLE
Fixed link at the end of the page

### DIFF
--- a/docs/advanced-ai/evaluations/overview.md
+++ b/docs/advanced-ai/evaluations/overview.md
@@ -64,4 +64,4 @@ Since there are too many test cases to check individually, evaluations measure t
 
 * [Light evaluations](/advanced-ai/evaluations/light-evaluations.md): Perfect for evaluating your AI workflows against hand-selected test cases during development.
 * [Metric-based evaluations](/advanced-ai/evaluations/metric-based-evaluations.md): Advanced evaluations to maintain performance and correctness in production by using scoring and metrics with large datasets.
-* [Tips and common issues](/advanced-ai/evaluations/metric-based-evaluations.md): Learn how to set up specific evaluation use cases and work around common issues.
+* [Tips and common issues](/advanced-ai/evaluations/tips-and-common-issues.md): Learn how to set up specific evaluation use cases and work around common issues.


### PR DESCRIPTION
Hyperlink should be pointing to Tips and Common issues. Instead it was pointing to Metric-base Evaluations.