### PR TITLE
YouTube video embeds on Sticky notes

### DIFF
--- a/docs/workflows/components/sticky-notes.md
+++ b/docs/workflows/components/sticky-notes.md
@@ -82,10 +82,12 @@ You can force images to be 100% width of the sticky note by appending `#full-wid
 
 ## Embed a YouTube video
 
-To display a YouTube video (as long as the creator allows embedding), use the `@[youtube]<video-id>` directive with the video’s ID:
+To display a YouTube video in a note, use the `@[youtube](<video-id>)` directive with the video's ID. For this to work, the video's creator must allow embedding.
+
+For example:
 
 ```markdown
 @[youtube](ZCuL2e4zC_4)
 ```
 
-Replace "ZCuL2e4zC_4" with the video ID—the string that follows v= in the YouTube URL.
+To embed your own video, copy the above syntax, replacing `ZCuL2e4zC_4` with your video ID. The YouTube video ID is the string that follows `v=` in the YouTube URL.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2db3feb8-2169-426f-a469-8f70db50d2e0)

YouTube video embeds are getting support on sticky notes! We probably should document this on the sticky note node's documentation page - I added some placeholder for this, feel free to edit this suggestion ☺️ 

This didn't get merged in time for 1.100.0, so it will ship with 1.101.0.