### PR TITLE
Add env variable to override project shared email template

### DIFF
--- a/docs/hosting/configuration/environment-variables/user-management-smtp-2fa.md
+++ b/docs/hosting/configuration/environment-variables/user-management-smtp-2fa.md
@@ -32,6 +32,7 @@ Refer to [User management](/hosting/configuration/user-management-self-hosted.md
 | `N8N_UM_EMAIL_TEMPLATES_PWRESET` | String | - | Full path to your HTML email template. This overrides the default template for password reset emails. |
 | `N8N_UM_EMAIL_TEMPLATES_WORKFLOW_SHARED` | String | - | Overrides the default HTML template for notifying users that a workflow was shared. Provide the full path to the template. |
 | `N8N_UM_EMAIL_TEMPLATES_CREDENTIALS_SHARED` | String | - | Overrides the default HTML template for notifying users that a credential was shared. Provide the full path to the template.  |
+| `N8N_UM_EMAIL_TEMPLATES_PROJECT_SHARED` | String | - | Overrides the default HTML template for notifying users that a project was shared. Provide the full path to the template.  |
 | `N8N_USER_MANAGEMENT_JWT_SECRET` | String | - | Set a specific JWT secret. By default, n8n generates one on start. |
 | `N8N_USER_MANAGEMENT_JWT_DURATION_HOURS` | Number | 168 | Set an expiration date for the JWTs in hours. |
 | `N8N_USER_MANAGEMENT_JWT_REFRESH_TIMEOUT_HOURS` | Number | 0 | How many hours before the JWT expires to automatically refresh it. 0 means 25% of `N8N_USER_MANAGEMENT_JWT_DURATION_HOURS`. -1 means it will never refresh, which forces users to log in again after the period defined in `N8N_USER_MANAGEMENT_JWT_DURATION_HOURS`. |

--- a/docs/hosting/configuration/user-management-self-hosted.md
+++ b/docs/hosting/configuration/user-management-self-hosted.md
@@ -62,6 +62,7 @@ To set up SMTP with n8n, configure the SMTP environment variables for your n8n i
 | `N8N_UM_EMAIL_TEMPLATES_PWRESET` | string | Full path to your HTML email template. This overrides the default template for password reset emails. | Optional |
 | `N8N_UM_EMAIL_TEMPLATES_WORKFLOW_SHARED` | String | Overrides the default HTML template for notifying users that a credential was shared. Provide the full path to the template. | Optional |
 | `N8N_UM_EMAIL_TEMPLATES_CREDENTIALS_SHARED` | String | Overrides the default HTML template for notifying users that a credential was shared. Provide the full path to the template. | Optional |
+| `N8N_UM_EMAIL_TEMPLATES_PROJECT_SHARED` | String | Overrides the default HTML template for notifying users that a project was shared. Provide the full path to the template. | Optional |
 
 <!-- vale on-->
 If your n8n instance is already running, you need to restart it to enable the new SMTP settings.


### PR DESCRIPTION
This PR adds the N8N_UM_EMAIL_TEMPLATES_PROJECT_SHARED env variable doc for the user to override the project shared template email path.
To merge after https://github.com/n8n-io/n8n/pull/16687 ✅ 