### PR TITLE
Add: Support for llms.txt

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -204,4 +204,13 @@ plugins:
       links_attr_map:
         target: _blank
         rel: external
+  # https://github.com/pawamoy/mkdocs-llmstxt
+  - llmstxt:
+      markdown_description: |
+        Documentation for n8n, a workflow automation platform. This file helps LLMs understand and use the documentation more effectively.
+      full_output: llms-full.txt
+      # Include all Markdown files in the docs directory and subdirectories
+      sections:
+        All documentation:
+          - "**/*.md"
 INHERIT: ./nav.yml

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mkdocs==1.6.1
 mkdocs-exclude==1.0.2
 mkdocs-glightbox
 mkdocs-macros-plugin==1.0.4
+mkdocs-llmstxt==0.2.0


### PR DESCRIPTION
This PR would add support for the /llms.txt file for our docs. Information can be found here : https://llmstxt.org/

This is a proposed standard that would give LLMS an easy to index version of our docs without the need for scraping. This will help with SEO as well as ensuring that LLMs knowledge about n8n is up-to-date. 

When the build process is rung, the llms.txt and llms-full.txt is added to the site root directly. 