### PR TITLE
fix: Update MCP docs to remove variables mention in custom path description

### DIFF
--- a/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger.md
@@ -49,17 +49,7 @@ Refer to the [HTTP request credentials](/integrations/builtin/credentials/httpre
 
 ### Path
 
-By default, this field contains a randomly generated MCP URL path, to avoid conflicts with other MCP Server Trigger nodes. 
-
-You can manually specify a URL path, including adding route parameters. For example, you may need to do this if you use n8n to prototype an API and want consistent endpoint URLs.
-
-The **Path** field can take the following formats:
-
-- `/:variable`
-- `/path/:variable`
-- `/:variable/path`
-- `/:variable1/path/:variable2`
-- `/:variable1/:variable2`
+By default, each trigger comes with a randomly generated MCP URL path, to avoid conflicts with other MCP Server Trigger nodes. 
 
 ## Templates and examples
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger.md
@@ -49,7 +49,9 @@ Refer to the [HTTP request credentials](/integrations/builtin/credentials/httpre
 
 ### Path
 
-By default, each trigger comes with a randomly generated MCP URL path, to avoid conflicts with other MCP Server Trigger nodes. 
+By default, this field contains a randomly generated MCP URL path, to avoid conflicts with other MCP Server Trigger nodes. 
+
+You can manually specify a URL path, including adding route parameters. For example, you may need to do this if you use n8n to prototype an API and want consistent endpoint URLs.
 
 ## Templates and examples
 


### PR DESCRIPTION
Update documentation. MCP Trigger has no path parameter. 

https://github.com/n8n-io/n8n/issues/17171