### PR TITLE
Changed 'Test Workflow' to 'Execute Workflow' to reflect change in UI

### DIFF
--- a/docs/_workflows/try-it-out/quickstart/very-quick-quickstart-workflow.json
+++ b/docs/_workflows/try-it-out/quickstart/very-quick-quickstart-workflow.json
@@ -47,7 +47,7 @@
     {
       "parameters": {},
       "id": "5af4b83b-31b6-4c29-aa55-3449f3851e2a",
-      "name": "When clicking \"Test Workflow\"",
+      "name": "When clicking \"Execute Workflow\"",
       "type": "n8n-nodes-base.manualTrigger",
       "position": [
         300,
@@ -117,7 +117,7 @@
         ]
       ]
     },
-    "When clicking \"Test Workflow\"": {
+    "When clicking \"Execute Workflow\"": {
       "main": [
         [
           {

--- a/docs/courses/level-one/chapter-5/chapter-5.7.md
+++ b/docs/courses/level-one/chapter-5/chapter-5.7.md
@@ -11,7 +11,7 @@ In this step of the workflow, you will learn how to schedule your workflow so th
 
 [[ workflowDemo("file:////courses/level-one/finished.json") ]]
 
-The workflow you've built so far executes only when you click on **Test Workflow**. But Nathan needs it to run automatically every Monday morning. You can do this with the [Schedule Trigger](/integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/index.md), which allows you to schedule workflows to run periodically at fixed dates, times, or intervals.
+The workflow you've built so far executes only when you click on **Execute Workflow**. But Nathan needs it to run automatically every Monday morning. You can do this with the [Schedule Trigger](/integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/index.md), which allows you to schedule workflows to run periodically at fixed dates, times, or intervals.
 
 To achieve this, we'll remove the Manual Trigger node we started with and replace it with a Schedule Trigger node instead.
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.form.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.form.md
@@ -198,7 +198,7 @@ While building or testing a workflow, use the **Test URL** in the [n8n Form Trig
 There are two ways to test:
 
 - Select **Test Step**. n8n opens the form. When you submit the form, n8n runs the node and any previous nodes, but not the rest of the workflow.
-- Select **Test Workflow**. n8n opens the form. When you submit the form, n8n runs the workflow.
+- Select **Execute Workflow**. n8n opens the form. When you submit the form, n8n runs the workflow.
 
 ### Production workflows
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
@@ -19,7 +19,7 @@ While building or testing a workflow, use the **Test URL**. Using a test URL ens
 There are two ways to test:
 
 - Select **Test Step**. n8n opens the form. When you submit the form, n8n runs the node, but not the rest of the workflow.
-- Select **Test Workflow**. n8n opens the form. When you submit the form, n8n runs the workflow.
+- Select **Execute Workflow**. n8n opens the form. When you submit the form, n8n runs the workflow.
 
 ## Production workflows
 
@@ -76,7 +76,7 @@ The Form Trigger node has two URLs: **Test URL** and **Production URL**. n8n dis
 
 ![Screenshot of the form URLs](/_images/integrations/builtin/core-nodes/form-trigger/form-urls.png)
 
-- **Test URL**: n8n registers a test webhook when you select **Test Step** or **Test Workflow**, if the workflow isn't active. When you call the URL, n8n displays the data in the workflow.
+- **Test URL**: n8n registers a test webhook when you select **Test Step** or **Execute Workflow**, if the workflow isn't active. When you call the URL, n8n displays the data in the workflow.
 - **Production URL**: n8n registers a production webhook when you activate the workflow. When using the production URL, n8n doesn't display the data in the workflow. You can still view workflow data for a production execution. Select the **Executions** tab in the workflow, then select the workflow execution you want to view.
 
 ### Form Path

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger.md
@@ -8,7 +8,7 @@ priority: critical
 
 # Manual Trigger node
 
-Use this node if you want to start a workflow by selecting **Test Workflow** and don't want any option for the workflow to run automatically.
+Use this node if you want to start a workflow by selecting **Execute Workflow** and don't want any option for the workflow to run automatically.
 
 Workflows always need a trigger, or start point. Most workflows start with a trigger node firing in response to an external event or the [Schedule Trigger](/integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/index.md) firing on a set schedule.
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches.md
@@ -81,9 +81,9 @@ Copy the workflow file above and paste into your instance, or manually build it 
 4. Add the Loop Over Items node.
 5. Configure Loop Over Items: set the batch size to `1` in the **Batch Size** field.
 6. Add the RSS Feed Read node.
-7. Select **Test Workflow**. This runs the workflow to load data into the RSS Feed Read node.
+7. Select **Execute Workflow**. This runs the workflow to load data into the RSS Feed Read node.
 8. Configure RSS Feed Read: map `url` from the input to the **URL** field. You can do this by dragging and dropping from the **INPUT** panel, or using this expression: `{{ $json.url }}`.
-9. Select **Test Workflow** to run the workflow and see the resulting data.
+9. Select **Execute Workflow** to run the workflow and see the resulting data.
 
 ### Check that the node has processed all items
 

--- a/docs/release-notes/0-x.md
+++ b/docs/release-notes/0-x.md
@@ -1741,7 +1741,7 @@ Editor: Improve UX for brace completion in the inline expressions editor.
 
 ### Node enhancements
 
-Webhook node: when test the node by selecting **Listen For Test Event** then dispatching a call to the webhook, n8n now only runs the Webhook node. Previously, n8n ran the entire workflow. You can still test the full workflow by selecting **Test Workflow**, then dispatching a test call. 
+Webhook node: when test the node by selecting **Listen For Test Event** then dispatching a call to the webhook, n8n now only runs the Webhook node. Previously, n8n ran the entire workflow. You can still test the full workflow by selecting **Execute Workflow**, then dispatching a test call. 
 
 ## n8n@0.209.2
 
@@ -2317,7 +2317,7 @@ The Execute Workflow Trigger starts a workflow in response to another workflow. 
 
 #### Manual Trigger node
 
-The Manual Trigger allows you to start a workflow by clicking **Test Workflow**, without any option to run it automatically. You can find documentation for the new node [here](/integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger.md).
+The Manual Trigger allows you to start a workflow by clicking **Execute Workflow**, without any option to run it automatically. You can find documentation for the new node [here](/integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger.md).
 
 </div>
 

--- a/docs/try-it-out/quickstart.md
+++ b/docs/try-it-out/quickstart.md
@@ -35,7 +35,7 @@ The individual pieces in an n8n workflow are called [nodes](/glossary.md#node-n8
 
 ## Step three: Run the workflow
 
-Select **Test Workflow**. This runs the workflow, loading the data from the Customer Datastore node, then transforming it with Edit Fields. You need this data available in the workflow so that you can work with it in the next step.
+Select **Execute Workflow**. This runs the workflow, loading the data from the Customer Datastore node, then transforming it with Edit Fields. You need this data available in the workflow so that you can work with it in the next step.
 
 ## Step four: Add a node
 
@@ -53,7 +53,7 @@ Add a third node to message each customer and tell them their description. Use t
         Hi {{ $json.customer_name }}. Your description is: {{ $json.customer_description }}
         ```
 5. Close the expressions editor, then close the **Customer Messenger** node by clicking outside the node or selecting **Back to canvas**.
-6. Select **Test Workflow**. n8n runs the workflow.
+6. Select **Execute Workflow**. n8n runs the workflow.
 
 The complete workflow should look like this:
 

--- a/docs/try-it-out/tutorial-first-workflow.md
+++ b/docs/try-it-out/tutorial-first-workflow.md
@@ -31,7 +31,7 @@ When you open n8n, you'll see either:
 
 n8n provides two ways to start a workflow:
 
-* Manually, by selecting **Test Workflow**.
+* Manually, by selecting **Execute Workflow**.
 * Automatically, using a trigger node as the first node. The trigger node runs the workflow in response to an external event, or based on your settings.
 
 For this tutorial, we'll use the [Schedule trigger](/integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/index.md). This allows you to run the workflow on a schedule:
@@ -137,7 +137,7 @@ The last step of the workflow is to send the two reports about solar flares. For
 
 ## Step six: Test the workflow
 
-1. You can now test the entire workflow. Select **Test Workflow**. n8n runs the workflow, showing each stage in progress.
+1. You can now test the entire workflow. Select **Execute Workflow**. n8n runs the workflow, showing each stage in progress.
 1. Go back to your Postbin bin. Refresh the page to see the output.
 1. If you want to use this workflow (in other words, if you want it to run once a week automatically), you need to activate it by selecting the **Active** toggle.
 

--- a/docs/workflows/create.md
+++ b/docs/workflows/create.md
@@ -26,7 +26,7 @@ If it's your first time building a workflow, you may want to use the [quickstart
 
 You may need to run your workflow manually when building and testing, or if your workflow doesn't have a trigger node. 
 
-To run manually, select **Test Workflow**.
+To run manually, select **Execute Workflow**.
 
 ## Run workflows automatically
 

--- a/docs/workflows/executions/index.md
+++ b/docs/workflows/executions/index.md
@@ -12,7 +12,7 @@ An execution is a single run of a workflow.
 
 There are two execution modes:
 
-* Manual: run workflows manually when testing. Select **Test Workflow** to start a manual execution. You can do manual executions of active workflows, but n8n recommends keeping your workflow set to **Inactive** while developing and testing.
+* Manual: run workflows manually when testing. Select **Execute Workflow** to start a manual execution. You can do manual executions of active workflows, but n8n recommends keeping your workflow set to **Inactive** while developing and testing.
 * Production: a production workflow is one that runs automatically. To enable this, set the workflow to **Active**.
 
 

--- a/docs/workflows/executions/manual-partial-and-production-executions.md
+++ b/docs/workflows/executions/manual-partial-and-production-executions.md
@@ -7,7 +7,7 @@ contentType: explanation
 
 # Manual, partial, and production executions
 
-There are some important differences in how n8n executes workflows manually (by clicking the **Test Workflow** button) and automatically (when the workflow is **Active** and triggered by an event or schedule).
+There are some important differences in how n8n executes workflows manually (by clicking the **Execute Workflow** button) and automatically (when the workflow is **Active** and triggered by an event or schedule).
 
 ## Manual executions
 


### PR DESCRIPTION
Chore; found and changed all mentions of the button 'Test Workflow' to read 'Execute Workflow' to align with UI in n8n.io

Docs language examples prior to change:
<img width="1087" height="335" alt="Screenshot 2025-07-17 at 3 56 21 PM" src="https://github.com/user-attachments/assets/fb1dca99-bc34-4f10-9bfc-29c0da5d1ae1" />
<img width="1113" height="661" alt="Screenshot 2025-07-17 at 3 56 00 PM" src="https://github.com/user-attachments/assets/58eefcae-2dee-44de-802c-e64a58397b40" />

n8n.io UI example (as of 7/17/25):
<img width="982" height="388" alt="Screenshot 2025-07-17 at 3 54 56 PM" src="https://github.com/user-attachments/assets/6ce33cb3-755f-4b00-8e66-1fbd6d63ca36" />

Located 18 instances needed changing. Confirmed via local grep and VSCode Exact string matching:
``` 
git grep "Test Workflow" | wc -l
      18
``` 