### PR TITLE
docs: Fix wording on MySQL deprecation

### DIFF
--- a/docs/1-0-migration-checklist.md
+++ b/docs/1-0-migration-checklist.md
@@ -35,7 +35,7 @@ Your existing workflows will use the legacy order, while new workflows will exec
 
 ### MySQL and MariaDB
 
-n8n has removed support for MySQL and MariaDB as storage backends for n8n. These database systems are used by only a few users, yet they require continuous development and maintenance efforts. n8n recommends migrating to PostgreSQL for better compatibility and long-term support.
+n8n has deprecated support for MySQL and MariaDB as storage backends for n8n. These database systems are used by only a few users, yet they require continuous development and maintenance efforts. n8n recommends migrating to PostgreSQL for better compatibility and long-term support.
 
 [PR #6189](https://github.com/n8n-io/n8n/pull/6189){:target=_blank .external link}
 

--- a/docs/hosting/configuration/environment-variables/database.md
+++ b/docs/hosting/configuration/environment-variables/database.md
@@ -14,7 +14,7 @@ hide:
 
 --8<-- "_snippets/self-hosting/file-based-configuration.md"
 
-By default, n8n uses SQLite. n8n also supports PostgreSQL. n8n [removed support for MySQL and MariaDB](/1-0-migration-checklist.md#mysql-and-mariadb) in v1.0.
+By default, n8n uses SQLite. n8n also supports PostgreSQL. n8n [deprecated support for MySQL and MariaDB](/1-0-migration-checklist.md#mysql-and-mariadb) in v1.0.
 
 This page outlines environment variables to configure your chosen database for your self-hosted n8n instance.
 


### PR DESCRIPTION
MySQL and MariaDB were deprecated in v1 and will be removed in v2.