### PR TITLE
remove unused cooke consent control

### DIFF
--- a/docs/privacy-security/privacy.md
+++ b/docs/privacy-security/privacy.md
@@ -159,9 +159,7 @@ Data is only sent to AI services if workspaces have opted in to use the assistan
 
 ### Documentation telemetry
 
-n8n's documentation (this website) uses cookies to recognize your repeated visits and preferences, as well as to measure the effectiveness of n8n's documentation and whether users find what they're searching for. With your consent, you're helping n8n to make our documentation better.
-
-[Change cookie settings](#__consent){ .md-button }
+n8n's documentation (this website) uses cookies to recognize your repeated visits and preferences, as well as to measure the effectiveness of n8n's documentation and whether users find what they're searching for. With your consent, you're helping n8n to make our documentation better. You can control cookie consent using the cookie widget.
 
 ## Retention and deletion of personal identifiable data
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,8 +49,6 @@ theme:
     - navigation.top
     # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=navigation+tabs#anchor-tracking
     - navigation.tracking
-copyright: >
-  <a href="#__consent">Change cookie settings</a>
 extra:
   analytics:
     provider: google


### PR DESCRIPTION
As we're now using a cookie widget and no longer using the built-in cookie consent, remove the link to modify the built-in consent (it does nothing now)