### PR TITLE
Small update to execution data node page to clarify feature availability

### DIFF
--- a/_snippets/workflows/executions/custom-execution-data-availability.md
+++ b/_snippets/workflows/executions/custom-execution-data-availability.md
@@ -4,5 +4,4 @@ Custom executions data is available on:
 * Cloud: Pro, Enterprise
 * Self-Hosted: Enterprise, registered Community
 
-Available in version 0.222.0 and above.
 ///

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.executiondata.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.executiondata.md
@@ -12,9 +12,7 @@ Use this node to save metadata for workflow executions. You can then search by t
 
 You can retrieve custom execution data during workflow execution using the Code node. Refer to [Custom executions data](/workflows/executions/custom-executions-data.md) for more information.
 
-/// info | Feature availability
-Available on Pro and Enterprise plans.
-///
+--8<-- "_snippets/workflows/executions/custom-execution-data-availability.md"
 
 ## Operations
 


### PR DESCRIPTION
Updated feature availability block to include registered community as pro, enterprise or registered community is needed to store custom execution data and filter by it in the executions view.