### PR TITLE
docs(Ollama): Add API key authentication documentation for remote instances

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatollama/common-issues.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatollama/common-issues.md
@@ -20,9 +20,11 @@ In sub-nodes, the expression always resolves to the first item. For example, giv
 
 ## Can't connect to a remote Ollama instance
 
-The Ollama Chat Model node is only designed to connect to a locally hosted Ollama instance. It doesn't include the authentication features you'd need to connect to a remotely hosted Ollama instance.
+The Ollama Chat Model node supports Bearer token authentication for connecting to remote Ollama instances behind authenticated proxies (such as Open WebUI).
 
-To use the Ollama Chat Model, follow the [Ollama credentials instructions](/integrations/builtin/credentials/ollama.md) to set up Ollama locally and configure the instance URL in n8n.
+For remote authenticated connections, configure both the remote URL and API key in your Ollama credentials. 
+
+Follow the [Ollama credentials instructions](/integrations/builtin/credentials/ollama.md) for more information.
 
 ## Can't connect to a local Ollama instance when using Docker
 

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmollama/common-issues.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmollama/common-issues.md
@@ -19,7 +19,8 @@ Most nodes, including [root nodes](/glossary.md#root-node-n8n), take any number 
 In sub-nodes, the expression always resolves to the first item. For example, given an input of five name values, the expression `{{ $json.name }}` always resolves to the first name.
 
 ## Can't connect to a remote Ollama instance
-The Ollama Model node supports Bearer token authentication for connecting to remote Ollama instances behind authenticated proxies (such as OpenWebUI).
+
+The Ollama Model node supports Bearer token authentication for connecting to remote Ollama instances behind authenticated proxies (such as Open WebUI).
 
 For remote authenticated connections, configure both the remote URL and API key in your Ollama credentials. 
 

--- a/docs/integrations/builtin/credentials/ollama.md
+++ b/docs/integrations/builtin/credentials/ollama.md
@@ -21,7 +21,6 @@ Create and run an [Ollama](https://ollama.com/) instance with one user. Refer to
 ## Supported authentication methods
 
 - Instance URL
-- Instance URL + API Key
 
 ## Related resources
 
@@ -33,23 +32,14 @@ Refer to [Ollama's API documentation](https://github.com/ollama/ollama/blob/main
 
 To configure this credential, you'll need:
 
-- The **Base URL** of your Ollama instance.
+- The **Base URL** of your Ollama instance or remote authenticated Ollama instances.
+- (Optional) The **API Key** for Bearer token authentication if connecting to a remote, authenticated proxy.
 
 The default **Base URL** is `http://localhost:11434`, but if you've set the `OLLAMA_HOST` environment variable, enter that value. If you have issues connecting to a local n8n server, try `127.0.0.1` instead of `localhost`.
 
+If you're connecting to Ollama through authenticated proxy services (such as [Open WebUI](https://docs.openwebui.com/getting-started/api-endpoints/#-ollama-api-proxy-support)) you must include an API key. If you don't need authentication, leave this field empty. When provided, the API key is sent as a Bearer token in the `Authorization` header of the request to the Ollama API.
+
 Refer to [How do I configure Ollama server?](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-do-i-configure-ollama-server) for more information.
-
-## Using instance URL + API Key
-To configure this credential for remote authenticated Ollama instances, you'll need:
-
-- The **Base URL** of the authenticated proxy service
-- An **API Key** for Bearer token authentication
-
-This method is used when connecting to Ollama through authenticated proxy services (such as [OpenWebUI](https://docs.openwebui.com/getting-started/api-endpoints/#-ollama-api-proxy-support)) that require API key authentication.
-
-The **API Key** is optional and only needed if your Ollama instance requires authentication. If you don't need authentication, you can leave this field empty.
-
-When provided, the API key is sent as a Bearer token in the `Authorization` header of the request to the Ollama API.
 
 ### Ollama and self-hosted n8n
 


### PR DESCRIPTION
## Summary
Updates Ollama (credentials) documentation to reflect new API key authentication support for connecting to remote Ollama instances behind authenticated proxies. (Pull request [https://github.com/n8n-io/n8n/pull/17857](https://github.com/n8n-io/n8n/pull/17857))

## Changes Made
- **Updated `ollama.md`**: Added documentation for optional API key authentication.
- **Updated `common-issues.md`**: Changed "Can't connect to remote Ollama instance" section to not allow remote instances
