### PR TITLE
Update ServiceNow credentials doc to reflect changes on PR 17926

### DIFF
--- a/docs/integrations/builtin/credentials/servicenow.md
+++ b/docs/integrations/builtin/credentials/servicenow.md
@@ -30,7 +30,9 @@ To configure this credential, you'll need:
 
 - A **User** name: Enter your ServiceNow username.
 - A **Password**: Enter your ServiceNow password.
-- A **Subdomain**: The subdomain for your servicenow instance is in your instance URL: `https://<subdomain>.service-now.com/`. For example, if the full URL is `https://dev99890.service-now.com`, then the subdomain is `dev99890`.
+- Either
+    - A **Subdomain**: The subdomain for your servicenow instance is in your instance URL: `https://<subdomain>.service-now.com/`. For example, if the full URL is `https://dev99890.service-now.com`, then the subdomain is `dev99890`.
+    - A **Custom host** – For self-hosted or vanity domains, enter the full base URL (e.g. `https://sn.acme.local`, without a trailing slash).
 
 ## Using OAuth2
 
@@ -38,7 +40,9 @@ To configure this credential, you'll need:
 
 - A **Client ID**: Generated once you register a new app.
 - A **Client Secret**: Generated once you register a new app.
-- A **Subdomain**: The subdomain for your servicenow instance is in your instance URL: `https://<subdomain>.service-now.com/`. For example, if the full URL is `https://dev99890.service-now.com`, then the subdomain is `dev99890`.
+- Either
+    - A **Subdomain**: The subdomain for your servicenow instance is in your instance URL: `https://<subdomain>.service-now.com/`. For example, if the full URL is `https://dev99890.service-now.com`, then the subdomain is `dev99890`.
+    - A **Custom host** – For self-hosted or vanity domains, enter the full base URL (e.g. `https://sn.acme.local`, without a trailing slash).
 
 To generate your **Client ID** and **Client Secret**, register a new app in **System OAuth > Application Registry > New > Create an OAuth API endpoint for external clients**. Use these settings for your app:
 


### PR DESCRIPTION
https://github.com/n8n-io/n8n/pull/17926

Until now, ServiceNow credentials in n8n accepted **only a sub-domain**, which excluded
users whose instances sit behind a reverse proxy or run on a completely custom host.
This PR adds an optional **“Use custom host?”** toggle plus **Custom Host** field to both
Basic-Auth and OAuth2 credentials, enabling any ServiceNow URL.