### PR TITLE
Add information for Slack signing secret

### DIFF
--- a/docs/integrations/builtin/credentials/slack.md
+++ b/docs/integrations/builtin/credentials/slack.md
@@ -10,17 +10,17 @@ priority: high
 
 You can use these credentials to authenticate the following nodes:
 
-- [Slack](/integrations/builtin/app-nodes/n8n-nodes-base.slack.md)
-- [Slack Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md)
+-   [Slack](/integrations/builtin/app-nodes/n8n-nodes-base.slack.md)
+-   [Slack Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md)
 
 ## Supported authentication methods
 
-- API access token:
-    - Required for the [Slack Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md) node.
-    - Works with the [Slack](/integrations/builtin/app-nodes/n8n-nodes-base.slack.md) node, but not recommended.
-- OAuth2:
-    - Recommended method for the [Slack](/integrations/builtin/app-nodes/n8n-nodes-base.slack.md) node.
-    - Doesn't work with the [Slack Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md) node.
+-   API access token:
+    -   Required for the [Slack Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md) node.
+    -   Works with the [Slack](/integrations/builtin/app-nodes/n8n-nodes-base.slack.md) node, but not recommended.
+-   OAuth2:
+    -   Recommended method for the [Slack](/integrations/builtin/app-nodes/n8n-nodes-base.slack.md) node.
+    -   Doesn't work with the [Slack Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md) node.
 
 ## Related resources
 
@@ -30,7 +30,7 @@ Refer to [Slack's API documentation](https://api.slack.com/apis) for more inform
 
 To configure this credential, you'll need a [Slack](https://slack.com/) account and:
 
-- An **Access Token**
+-   An **Access Token**
 
 To generate an access token, create a Slack app:
 
@@ -40,11 +40,11 @@ To generate an access token, create a Slack app:
 4. Select the **Workspace** where you'll be developing your app.
 5. Select **Create App**. The app details open.
 6. In the left menu under **Features**, select **OAuth & Permissions**.
-8. In the **Scopes** section, select appropriate scopes for your app. Refer to [Scopes](#scopes) for a list of recommended scopes.
-9. After you've added scopes, go up to the **OAuth Tokens** section and select **Install to Workspace**. You must be a Slack workspace admin to complete this action.
-10. Select **Allow**.
-12. Copy the **Bot User OAuth Token** and enter it as the **Access Token** in your n8n credential.
-13. If you're using this credential for the [Slack Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md), follow the steps in [Slack Trigger configuration](#slack-trigger-configuration) to finish setting up your app.
+7. In the **Scopes** section, select appropriate scopes for your app. Refer to [Scopes](#scopes) for a list of recommended scopes.
+8. After you've added scopes, go up to the **OAuth Tokens** section and select **Install to Workspace**. You must be a Slack workspace admin to complete this action.
+9. Select **Allow**.
+10. Copy the **Bot User OAuth Token** and enter it as the **Access Token** in your n8n credential.
+11. If you're using this credential for the [Slack Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md), follow the steps in [Slack Trigger configuration](#slack-trigger-configuration) to finish setting up your app.
 
 Refer to the Slack API [Quickstart](https://api.slack.com/quickstart) for more information.
 
@@ -56,26 +56,32 @@ To use your Slack app with the [Slack Trigger](/integrations/builtin/trigger-nod
 2. Turn on the **Enable Events** control.
 3. In n8n, copy the **Webhook URL** and enter it as the **Request URL** in your Slack app.
 
-    ///  note  | Request URL
+    /// note | Request URL
     Slack only allows one request URL per app. If you want to test your workflow, you'll need to do one of the following:
 
     - Test with your **Test URL** first, then change your Slack app to use the **Production URL** once you've verified everything's working
     - Use the **Production URL** with execution logging.
-    ///
+      ///
 
-4. Once verified, select the bot events to subscribe to. Use the **Trigger on** field in n8n to filter these requests. 
+4. Once verified, select the bot events to subscribe to. Use the **Trigger on** field in n8n to filter these requests.
     - To use an event not in the list, add it as a bot event and select **Any Event** in the n8n node.
 
 Refer to [Quickstart | Configuring the app for event listening](https://api.slack.com/quickstart#listening) for more information.
 
+To provide additional security to your Slack Trigger with request signature verification:
+
+1. Go to **Settings** > **Basic Information**.
+2. Copy the value of **Signing Secret**.
+3. In n8n, Paste this value into the **Signature Secret** field for the credential.
+
 ## Using OAuth2
 
---8<-- "_snippets/integrations/builtin/credentials/cloud-oauth-button.md"
+--8<-- "\_snippets/integrations/builtin/credentials/cloud-oauth-button.md"
 
 If you're [self-hosting n8n](/hosting/index.md) and need to configure OAuth2 from scratch, you'll need a [Slack](https://slack.com/) account and:
 
-- A **Client ID**
-- A **Client Secret**
+-   A **Client ID**
+-   A **Client Secret**
 
 To get both, create a Slack app:
 
@@ -86,15 +92,15 @@ To get both, create a Slack app:
 5. Select **Create App**. The app details open.
 6. In **Settings > Basic Information**, open the **App Credentials** section.
 7. Copy the **Client ID** and **Client Secret**. Paste these into the corresponding fields in n8n.
-6. In the left menu under **Features**, select **OAuth & Permissions**.
-7. In the **Redirect URLs** section, select **Add New Redirect URL**.
-8. Copy the **OAuth Callback URL** from n8n and enter it as the new Redirect URL in Slack.
-9. Select **Add**.
-10. Select **Save URLs**.
-11. In the **Scopes** section, select appropriate scopes for your app. Refer to [Scopes](#scopes) for a list of scopes.
-13. After you've added scopes, go up to the **OAuth Tokens** section and select **Install to Workspace**. You must be a Slack workspace admin to complete this action.
-14. Select **Allow**.
-15. At this point, you should be able to select the OAuth button in your n8n credential to connect.
+8. In the left menu under **Features**, select **OAuth & Permissions**.
+9. In the **Redirect URLs** section, select **Add New Redirect URL**.
+10. Copy the **OAuth Callback URL** from n8n and enter it as the new Redirect URL in Slack.
+11. Select **Add**.
+12. Select **Save URLs**.
+13. In the **Scopes** section, select appropriate scopes for your app. Refer to [Scopes](#scopes) for a list of scopes.
+14. After you've added scopes, go up to the **OAuth Tokens** section and select **Install to Workspace**. You must be a Slack workspace admin to complete this action.
+15. Select **Allow**.
+16. At this point, you should be able to select the OAuth button in your n8n credential to connect.
 
 Refer to the Slack API [Quickstart](https://api.slack.com/quickstart) for more information. Refer to the Slack [Installing with OAuth](https://api.slack.com/authentication/oauth-v2) documentation for more details on the OAuth flow itself.
 
@@ -102,33 +108,33 @@ Refer to the Slack API [Quickstart](https://api.slack.com/quickstart) for more i
 
 Scopes determine what permissions an app has.
 
-* If you want your app to act on behalf of users who authorize the app, add the required scopes under the **User Token Scopes** section.
-* If you're building a bot, add the required scopes under the **Bot Token Scopes** section.
+-   If you want your app to act on behalf of users who authorize the app, add the required scopes under the **User Token Scopes** section.
+-   If you're building a bot, add the required scopes under the **Bot Token Scopes** section.
 
 Here's the list of scopes the OAuth credential requires, which are a good starting point:
 
-| **Scope name** | **Notes** |
-| --- | --- |
-| `channels:read` | |
-| `channels:write` | Not available as a bot token scope |
-| `chat:write` | |
-| `files:read` | |
-| `files:write` | |
-| `groups:read` | |
-| `im:read` | |
-| `mpim:read` | |
-| `reactions:read` | |
-| `reactions:write` | |
-| `stars:read`| Not available as a bot token scope |
-| `stars:write` | Not available as a bot token scope |
-| `usergroups:read` | |
-| `usergroups:write` | | 
-| `users.profile:read` | |
+| **Scope name**        | **Notes**                          |
+| --------------------- | ---------------------------------- |
+| `channels:read`       |                                    |
+| `channels:write`      | Not available as a bot token scope |
+| `chat:write`          |                                    |
+| `files:read`          |                                    |
+| `files:write`         |                                    |
+| `groups:read`         |                                    |
+| `im:read`             |                                    |
+| `mpim:read`           |                                    |
+| `reactions:read`      |                                    |
+| `reactions:write`     |                                    |
+| `stars:read`          | Not available as a bot token scope |
+| `stars:write`         | Not available as a bot token scope |
+| `usergroups:read`     |                                    |
+| `usergroups:write`    |                                    |
+| `users.profile:read`  |                                    |
 | `users.profile:write` | Not available as a bot token scope |
-| `users:read` | |
+| `users:read`          |                                    |
 
 ## Common issues
 
 ### Token expired
 
---8<-- "_snippets/integrations/builtin/credentials/slack/token-rotation.md"
+--8<-- "\_snippets/integrations/builtin/credentials/slack/token-rotation.md"

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
@@ -12,46 +12,46 @@ Use the Slack Trigger node to respond to events in [Slack](https://slack.com/) a
 
 On this page, you'll find a list of events the Slack Trigger node can respond to and links to more resources.
 
-///  note  | Credentials
+/// note | Credentials
 You can find authentication information for this node [here](/integrations/builtin/credentials/slack.md).
 ///
-///  note  | Examples and templates
+/// note | Examples and templates
 For usage examples and templates to help you get started, refer to n8n's [Slack integrations](https://n8n.io/integrations/slack-trigger/) page.
 ///
 
 ## Events
 
-* **Any Event**: The node triggers on any event in Slack.
-* **Bot / App Mention**: The node triggers when your bot or app is [mentioned](https://slack.com/help/articles/205240127-Use-mentions-in-Slack) in a channel the app is in.
-* **File Made Public**: The node triggers when a file is [made public](https://slack.com/help/articles/4412651915539-Manage-public-file-sharing).
-* **File Shared**: The node triggers when a file is [shared](https://slack.com/help/articles/201330736-Add-files-to-Slack) in a channel the app is in.
-* **New Message Posted to Channel**: The node triggers when a new message is posted to a channel the app is in.
-* **New Public Channel Created**: The node triggers when a new [public channel](https://slack.com/help/articles/360017938993-What-is-a-channel) is created.
-* **New User**: The node triggers when a new user is added to Slack.
-* **Reaction Added**: The node triggers when a [reaction](https://slack.com/help/articles/202931348-Use-emoji-and-reactions) is added to a message the app is added to.
+-   **Any Event**: The node triggers on any event in Slack.
+-   **Bot / App Mention**: The node triggers when your bot or app is [mentioned](https://slack.com/help/articles/205240127-Use-mentions-in-Slack) in a channel the app is in.
+-   **File Made Public**: The node triggers when a file is [made public](https://slack.com/help/articles/4412651915539-Manage-public-file-sharing).
+-   **File Shared**: The node triggers when a file is [shared](https://slack.com/help/articles/201330736-Add-files-to-Slack) in a channel the app is in.
+-   **New Message Posted to Channel**: The node triggers when a new message is posted to a channel the app is in.
+-   **New Public Channel Created**: The node triggers when a new [public channel](https://slack.com/help/articles/360017938993-What-is-a-channel) is created.
+-   **New User**: The node triggers when a new user is added to Slack.
+-   **Reaction Added**: The node triggers when a [reaction](https://slack.com/help/articles/202931348-Use-emoji-and-reactions) is added to a message the app is added to.
 
 ## Parameters
 
 Once you've set the events to trigger on, use the remaining parameters to further define the node's behavior:
 
-* **Watch Whole Workspace**: Whether the node should watch for the selected **Events** in all channels in the workspace (turned on) or not (turned off, default).
+-   **Watch Whole Workspace**: Whether the node should watch for the selected **Events** in all channels in the workspace (turned on) or not (turned off, default).
 
     ///warning | Caution
     This will use one execution for every event in any channel your bot or app is in. Use with caution!
     ///
 
-* **Channel to Watch**: Select the channel your node should watch for the selected **Events**. This parameter only appears if you don't turn on **Watch Whole Workspace**. You can select a channel:
-    * **From list**: The node uses your credential to look up a list of channels in the workspace so you can select the channel you want.
-    * **By ID**: Enter the ID of a channel you want to watch. Slack displays the channel ID at the bottom of the channel details with a one-click copy button.
-    * **By URL**: Enter the URL of the channel you want to watch, formatted as `https://app.slack.com/client/<channel-address>`.
-* **Download Files**: Whether to download files and use them in the node's output (turned on) or not (turned off, default). Use this parameter with the **File Made Public** and **File Shared** events.
+-   **Channel to Watch**: Select the channel your node should watch for the selected **Events**. This parameter only appears if you don't turn on **Watch Whole Workspace**. You can select a channel:
+    -   **From list**: The node uses your credential to look up a list of channels in the workspace so you can select the channel you want.
+    -   **By ID**: Enter the ID of a channel you want to watch. Slack displays the channel ID at the bottom of the channel details with a one-click copy button.
+    -   **By URL**: Enter the URL of the channel you want to watch, formatted as `https://app.slack.com/client/<channel-address>`.
+-   **Download Files**: Whether to download files and use them in the node's output (turned on) or not (turned off, default). Use this parameter with the **File Made Public** and **File Shared** events.
 
 ## Options
 
 You can further refine the node's behavior when you **Add Option**s:
 
-* **Resolve IDs**: Whether to resolve the IDs to their respective names and return them (turned on) or not (turned off, default).
-* **Usernames or IDs to ignore**: Select usernames or enter a comma-separated string of encoded user IDs to ignore events from. Choose from the list, or specify IDs using an [expression](/code/expressions.md).
+-   **Resolve IDs**: Whether to resolve the IDs to their respective names and return them (turned on) or not (turned off, default).
+-   **Usernames or IDs to ignore**: Select usernames or enter a comma-separated string of encoded user IDs to ignore events from. Choose from the list, or specify IDs using an [expression](/code/expressions.md).
 
 ## Related resources
 
@@ -69,13 +69,17 @@ You must add the appropriate scopes to your Slack app for this trigger node to w
 
 The node requires scopes for the [conversations.list](https://api.slack.com/methods/conversations.list) and [users.list](https://api.slack.com/methods/users.list) methods at minimum. Check out the [Scopes | Slack credentials](/integrations/builtin/credentials/slack.md#scopes) list for a more complete list of scopes.
 
+## Verify the webhook
+
+From version `1.106.0` you can now set a [Slack Signing Secret](https://api.slack.com/authentication/verifying-requests-from-slack#signing_secrets_admin_page) in the [Slack credentials | Slack Trigger configuration](/integrations/builtin/credentials/slack.md#slack-trigger-configuration), If set the Slack trigger node will automatically verify that the requests are from Slack and are correctly signed. We recommend setting this to ensure you are only processing requests sent from Slack.
+
 ## Common issues
 
 Here are some common errors and issues with the Slack Trigger node and steps to resolve or troubleshoot them.
 
 ### Workflow only works in testing or production
 
-Slack only allows you to register a single webhook per app. This means that you can't switch from using the testing URL to the production URL (and vice versa) without reconfiguring the registered webhook URL. 
+Slack only allows you to register a single webhook per app. This means that you can't switch from using the testing URL to the production URL (and vice versa) without reconfiguring the registered webhook URL.
 
 You may have trouble with this if you try to test a workflow that's also active in production. Slack will only send events to one of the two webhook URLs, so the other will never receive event notifications.
 
@@ -94,4 +98,4 @@ This temporarily disables your production workflow for testing. Your workflow wi
 
 ### Token expired
 
---8<-- "_snippets/integrations/builtin/credentials/slack/token-rotation.md"
+--8<-- "\_snippets/integrations/builtin/credentials/slack/token-rotation.md"


### PR DESCRIPTION
This PR adds information about the Slack signature verification for incoming webhooks. We also link from the product to `#verify-the-webhook`