### PR TITLE
Only accessible with 127.0.0.1 (localhost)

### DIFF
--- a/docs/hosting/installation/server-setups/docker-compose.md
+++ b/docs/hosting/installation/server-setups/docker-compose.md
@@ -149,7 +149,7 @@ services:
     image: docker.n8n.io/n8nio/n8n
     restart: always
     ports:
-      - "127.0.0.1:5678:5678"
+      - "5678:5678"
     labels:
       - traefik.enable=true
       - traefik.http.routers.n8n.rule=Host(`${SUBDOMAIN}.${DOMAIN_NAME}`)


### PR DESCRIPTION
Only accessible with 127.0.0.1 (localhost). As a result, **127.0.0.1** is removed from

```
services:
  ...
  n8n:
    image: docker.n8n.io/n8nio/n8n
    ...
    ports:
      - "127.0.0.1:5678:5678"
  ...
```