### PR TITLE
avoid pricing tier info going out of date; bonus Vale tweak

### DIFF
--- a/docs/manage-cloud/concurrency.md
+++ b/docs/manage-cloud/concurrency.md
@@ -11,16 +11,11 @@ This document discusses concurrency in n8n Cloud. Read [self-hosted n8n concurre
 
 Too many concurrent executions can cause performance degradation and unresponsiveness. To prevent this and improve instance stability, n8n sets concurrency limits for production executions in regular mode.
 
-Any executions beyond the limits queue for later processing. These executions remain in the queue until concurrency capacity frees up, and are then processed in FIFO order.
+Any executions beyond the limits queue for later processing. These executions remain in the queue until concurrency capacity frees up, and are then processed in FIFO order. 
 
 ## Concurrency limits
 
-n8n limits the number of concurrent executions for Cloud instances according to their plan:
-
-* Starter and Trial: 5
-* Pro (10k workflow executions, 15 active workflows): 20
-* Pro (50k workflow executions, 50 active workflows): 50
-* Enterprise (in regular mode): 200
+n8n limits the number of concurrent executions for Cloud instances according to their plan. Refer to [Pricing](https://n8n.io/pricing/) for details.
 
 You can view the number of active executions and your plan's concurrency limit at the top of a project's or workflow's executions tab.
 
@@ -29,7 +24,7 @@ You can view the number of active executions and your plan's concurrency limit a
 Some other details about concurrency to keep in mind:
 
 - Concurrency control applies only to production executions: those started from a webhook or trigger node. It doesn't apply to any other kinds, such as manual executions, sub-workflow executions, or error executions.
-- [Test evaluations](/glossary.md#evaluation-n8n) do not count towards concurrency limits. Your test evaluation concurrency limit is equal to, but separate from, your plan's regular concurrency limit.
+- [Test evaluations](/glossary.md#evaluation-n8n) don't count towards concurrency limits. Your test evaluation concurrency limit is equal to, but separate from, your plan's regular concurrency limit.
 - You can't retry queued executions. Cancelling or deleting a queued execution also removes it from the queue.
 - On instance startup, n8n resumes queued executions up to the concurrency limit and re-enqueues the rest.
 

--- a/styles/from-write-good/Weasel.yml
+++ b/styles/from-write-good/Weasel.yml
@@ -110,7 +110,7 @@ tokens:
   - loudly
   - luckily
   - madly
-  - many
+  - (?<![Tt]oo\s)many
   - mentally
   - mildly
   - monthly


### PR DESCRIPTION
Realised the info in the docs and on the pricing page was different. Suggest just linking to the pricing page (realistically, we won't reliably know when it changes)
As a bonus: I think I've persuaded Vale to ignore 'too many'.