### PR TITLE
Update TheHive5 webhook version

### DIFF
--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.thehive5trigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.thehive5trigger.md
@@ -69,7 +69,7 @@ To configure the webhook for your TheHive instance:
 		{
 			name: TESTING_WEBHOOK_NAME
 			url: TESTING_WEBHOOK_URL
-			version: 0
+			version: 1
 			wsConfig: {}
 			includedTheHiveOrganisations: ["ORGANIZATION_NAME"]
 			excludedTheHiveOrganisations: []
@@ -77,7 +77,7 @@ To configure the webhook for your TheHive instance:
 		{
 			name: PRODUCTION_WEBHOOK_NAME
 			url: PRODUCTION_WEBHOOK_URL
-			version: 0
+			version: 1
 			wsConfig: {}
 			includedTheHiveOrganisations: ["ORGANIZATION_NAME"]
 			excludedTheHiveOrganisations: []


### PR DESCRIPTION
The TheHive5 trigger in n8n now requires a webhook version of 1, as version 0 has been deprecated. Using version 0 causes the workflow to fail without an error message since the trigger expects the updated format
(https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/TheHiveProject/TheHiveProjectTrigger.node.ts#L251).

This commit updates the documentation to reflect the correct version.