### PR TITLE
docs: clarify Projects vs Personal project in navigation On Chapter 1

### DIFF
--- a/docs/courses/level-one/chapter-1.md
+++ b/docs/courses/level-one/chapter-1.md
@@ -42,7 +42,7 @@ On the left side of the **Editor UI**, there is a panel which contains the core 
 The panel contains the following sections:
 
 -   **Overview**: Contains all the workflows and credentials you have access to. During this course, create new workflows here.
--   **Personal**: Every user gets a default **Personal project**. If you don’t create a custom project, your workflows and credentials are stored here.
+-   **Personal**: Every user gets a default Personal project. If you don’t create a custom project, your workflows and credentials are stored here.
 -   **Projects**: Projects let you group workflows and credentials together. You can assign [roles](/user-management/rbac/role-types.md) to users in a project to control what they can do. Projects aren’t available on the Community edition.
 -   **Admin Panel**: n8n Cloud only. Access your n8n instance usage, billing, and version settings.
 -   **Templates**: A collection of pre-made workflows. Great place to get started with common use cases.

--- a/docs/courses/level-one/chapter-1.md
+++ b/docs/courses/level-one/chapter-1.md
@@ -41,16 +41,15 @@ On the left side of the **Editor UI**, there is a panel which contains the core 
 
 The panel contains the following sections:
 
-- **Overview**: Contains all the workflows and credentials you have access to. During this course, create new workflows here.
-
-- **Projects**: Projects let you group workflows and credentials together. You can assign [roles](/user-management/rbac/role-types.md) to users in a project to control what they can do. Projects aren’t available on the Community edition.
-- **Personal**: Every user gets a default **Personal project**. If you don’t create a custom project, your workflows and credentials are stored here.
-- **Admin Panel**: n8n Cloud only. Access your n8n instance usage, billing, and version settings.
-- **Templates**: A collection of pre-made workflows. Great place to get started with common use cases.
-- **Variables**: Used to store and access fixed data across your workflows. This feature is available on the Pro and Enterprise Plans.
-- **Insights**: Provides analytics and insights about your workflows.
-- **Help**: Contains resources around n8n product and community.
-- **What’s New**: Shows the latest product updates and features.
+-   **Overview**: Contains all the workflows and credentials you have access to. During this course, create new workflows here.
+-   **Personal**: Every user gets a default **Personal project**. If you don’t create a custom project, your workflows and credentials are stored here.
+-   **Projects**: Projects let you group workflows and credentials together. You can assign [roles](/user-management/rbac/role-types.md) to users in a project to control what they can do. Projects aren’t available on the Community edition.
+-   **Admin Panel**: n8n Cloud only. Access your n8n instance usage, billing, and version settings.
+-   **Templates**: A collection of pre-made workflows. Great place to get started with common use cases.
+-   **Variables**: Used to store and access fixed data across your workflows. This feature is available on the Pro and Enterprise Plans.
+-   **Insights**: Provides analytics and insights about your workflows.
+-   **Help**: Contains resources around n8n product and community.
+-   **What’s New**: Shows the latest product updates and features.
 
 <figure style="text-align: center;"><img src="/_images/courses/level-one/chapter-one/l1-c1-side-panel.png" alt="Editor UI left-side menu" style="height: 600px;"><figcaption align = "center"><i>Editor UI left-side menu</i></figcaption></figure>
 

--- a/docs/courses/level-one/chapter-1.md
+++ b/docs/courses/level-one/chapter-1.md
@@ -43,13 +43,14 @@ The panel contains the following sections:
 
 - **Overview**: Contains all the workflows and credentials you have access to. During this course, create new workflows here.
 
-- **Projects**:  Projects group workflows and credentials. You can assign [roles](/user-management/rbac/role-types.md) to users in a project to control what they can do in a project. A **Personal** project is available by default. Projects aren't available on the Community edition.
+- **Projects**: Projects let you group workflows and credentials together. You can assign [roles](/user-management/rbac/role-types.md) to users in a project to control what they can do. Projects aren’t available on the Community edition.
+- **Personal**: Every user gets a default **Personal project**. If you don’t create a custom project, your workflows and credentials are stored here.
 - **Admin Panel**: n8n Cloud only. Access your n8n instance usage, billing, and version settings.
 - **Templates**: A collection of pre-made workflows. Great place to get started with common use cases.
 - **Variables**: Used to store and access fixed data across your workflows. This feature is available on the Pro and Enterprise Plans.
-- **Insights**: Provides analytics and insights about your workflows. 
+- **Insights**: Provides analytics and insights about your workflows.
 - **Help**: Contains resources around n8n product and community.
-- **What’s New**: Shows the latest product updates and features.  
+- **What’s New**: Shows the latest product updates and features.
 
 <figure style="text-align: center;"><img src="/_images/courses/level-one/chapter-one/l1-c1-side-panel.png" alt="Editor UI left-side menu" style="height: 600px;"><figcaption align = "center"><i>Editor UI left-side menu</i></figcaption></figure>
 


### PR DESCRIPTION
### Summary
This PR updates the documentation to clearly distinguish between **Projects** and the **Personal project** in the navigation overview. 

### Background
Previously, the docs mentioned Projects and Personal together, which created confusion for readers:
- It sounded as if "Personal" was part of the general Projects feature.
- In reality, **Projects** are a grouping feature (with RBAC, not available in Community edition).
- **Personal** is the default project available to every user for their own workflows and credentials.

### Changes
- Split the "Projects" and "Personal" sections into two separate items.
- Improved clarity by describing Projects as a grouping feature with roles/permissions.
- Explained Personal as the default project every user has by default.

### Why this matters
- Removes ambiguity and aligns the docs with the actual n8n UI and functionality.
- Makes it easier for new users to understand that *Personal* is separate from other *Projects*.
- Ensures consistency with official n8n documentation and prevents further confusion.

✅ This is a documentation-only change, safe to merge directly.
