### PR TITLE
docs: add Project/Workspace breadcrumb (Personal) to Editor UI top bar

### DIFF
--- a/docs/courses/level-one/chapter-1.md
+++ b/docs/courses/level-one/chapter-1.md
@@ -57,7 +57,7 @@ The panel contains the following sections:
 
 The top bar of the **Editor UI** contains the following information:
 
-- **Project/Workspace**: Shows the project or workspace that the workflow belongs to, for example **Personal** in a trial account.
+- **Project/Workspace**: Shows the project or workspace that the workflow belongs to, for example "Personal" in a trial account.
 - **Workflow Name**: By default, n8n names a new workflow as "My workflow", but you can edit the name at any time.
 - **+ Add Tag**: Tags help you organise your workflows by category, use case, or whatever is relevant for you. Tags are optional.
 - **Inactive/active toggle**: This button activates or deactivates the current workflow. By default, workflows are deactivated.

--- a/docs/courses/level-one/chapter-1.md
+++ b/docs/courses/level-one/chapter-1.md
@@ -57,6 +57,7 @@ The panel contains the following sections:
 
 The top bar of the **Editor UI** contains the following information:
 
+- **Project/Workspace**: Shows the project or workspace that the workflow belongs to, for example **Personal** in a trial account.
 - **Workflow Name**: By default, n8n names a new workflow as "My workflow", but you can edit the name at any time.
 - **+ Add Tag**: Tags help you organise your workflows by category, use case, or whatever is relevant for you. Tags are optional.
 - **Inactive/active toggle**: This button activates or deactivates the current workflow. By default, workflows are deactivated.


### PR DESCRIPTION
### What
Added a short bullet in the "Top bar" section to explain the **Project/Workspace** breadcrumb shown before the workflow name.  
Example: **Personal / My workflow** in trial accounts.

### Why
The current UI shows a breadcrumb (like *Personal* or a workspace name) before the workflow name, but this behavior was not documented.  
This PR documents it for clarity.

### Scope
- Applies to Cloud and self-hosted instances with Projects/Workspaces enabled.

### Screenshot
(see below)
<img width="1920" height="1080" alt="Untitled design (2)" src="https://github.com/user-attachments/assets/674527fd-cd10-4b0c-9f39-9b1409f46be5" />