### PR TITLE
docs: add missing top bar menu options in Editor UI

### DIFF
--- a/docs/courses/level-one/chapter-1.md
+++ b/docs/courses/level-one/chapter-1.md
@@ -63,6 +63,12 @@ The top bar of the **Editor UI** contains the following information:
 - **Share**: You can share and collaborate with others on workflows on the Starter, Pro, and Enterprise plans.
 - **Save**: This button saves the current workflow.
 - **History**: Once you save your workflow, you can view previous versions here.
+- **More options (⋮)**: Provides additional actions:  
+  - Duplicate workflow  
+  - Rename workflow  
+  - Download workflow as JSON  
+  - Import workflow from URL  
+  - Import workflow from file
 
 <figure><img src="/_images/courses/level-one/chapter-one/l1-c1-top-bar.png" alt="Editor UI top bar" style="width:100%"><figcaption align = "center"><i>Editor UI top bar</i></figcaption></figure>
 


### PR DESCRIPTION
Updated the Top Bar documentation to include the three-dots (⋮) menu.  This section now documents the ability to duplicate, rename, download workflows,  and import workflows from URL or file. This makes the description of the Editor UI  more complete for new users.