### PR TITLE
Added Project Name Explaination in Top Bar Tutorial

### DIFF
--- a/docs/courses/level-one/chapter-1.md
+++ b/docs/courses/level-one/chapter-1.md
@@ -59,6 +59,7 @@ The panel contains the following sections:
 
 The top bar of the **Editor UI** contains the following information:
 
+- **Project Name:** By default, n8n assigns the project name as "Personal", but you can change it to organize your workflows under different projects.
 - **Workflow Name**: By default, n8n names a new workflow as "My workflow", but you can edit the name at any time.
 - **+ Add Tag**: Tags help you organise your workflows by category, use case, or whatever is relevant for you. Tags are optional.
 - **Inactive/active toggle**: This button activates or deactivates the current workflow. By default, workflows are deactivated.


### PR DESCRIPTION
### PR Description

### Docs Update – Project Name (Top Bar)

This PR updates the n8n documentation to include details about the Project Name shown in the top bar of the Editor UI.

- Added explanation for the default project name (Personal).
- Clarified that users can change the project name to better organize workflows under different projects.
- Keeps consistency with the existing Top Bar documentation (Workflow Name, Tags, Save, etc.).

### New Section Added:

**Project Name:** By default, n8n assigns the project name as "Personal", but you can change it to organize your workflows under different projects.