### PR TITLE
docs: Add "Tidy up workflow" and "Convert node to sub-workflow" to Node controls

### DIFF
--- a/docs/workflows/components/nodes.md
+++ b/docs/workflows/components/nodes.md
@@ -59,7 +59,7 @@ To view node controls, hover over the node on the canvas:
 	* Convert node to sub-workflow
 	* Select all
 	* Clear selection
-	* Delete node
+    * Delete node
 
 ## Node settings
 

--- a/docs/workflows/components/nodes.md
+++ b/docs/workflows/components/nodes.md
@@ -55,9 +55,11 @@ To view node controls, hover over the node on the canvas:
 	* Pin node
 	* Copy node
 	* Duplicate node
+	* Tidy up workflow
+	* Convert node to sub-workflow
 	* Select all
 	* Clear selection
-	* Delete node
+	* Delete node
 
 ## Node settings
 


### PR DESCRIPTION
This pull request updates the documentation for Node controls to include two new, previously undocumented features: "Tidy up workflow" and "Convert node to sub-workflow." The current documentation lists the basic node context menu options but is incomplete.

This update aims to provide more accurate and comprehensive documentation for users. The added features are directly accessible from the node context menu and are crucial for managing and organizing complex workflows.

The changes are:

-   *Tidy up workflow*
    
-   *Convert node to sub-workflow*
    

These updates ensure the documentation is fully aligned with the latest n8n workflow UI, making it a more reliable and helpful resource for the community.