### PR TITLE
docs: clarify Insights feature availability in Left-side panel

### DIFF
--- a/docs/courses/level-one/chapter-1.md
+++ b/docs/courses/level-one/chapter-1.md
@@ -48,7 +48,7 @@ The panel contains the following sections:
 -   **Admin Panel**: n8n Cloud only. Access your n8n instance usage, billing, and version settings.
 -   **Templates**: A collection of pre-made workflows. Great place to get started with common use cases.
 -   **Variables**: Used to store and access fixed data across your workflows. This feature is available on the Pro and Enterprise Plans.
--   **Insights**: Provides analytics and insights about your workflows.
+-   - **Insights**: Provides analytics and insights about your workflows. _Available only on Pro and Enterprise plans; upgrade required._
 -   **Help**: Contains resources around n8n product and community.
 -   **What’s New**: Shows the latest product updates and features.
 


### PR DESCRIPTION
### **Description:**
This PR updates the Insights section in the Left-side panel documentation.
### **Before:**
Insights: Provides analytics and insights about your workflows.
### **After:**
Insights: Provides analytics and insights about your workflows. Available only on Pro and Enterprise plans; upgrade required.
### **Why this change:**
Prevents confusion for Community edition users who can’t find the Insights option.
Makes documentation more accurate by reflecting feature availability.
Improves transparency for new users exploring n8n.