### PR TITLE
docs: clarify Ask Assistant feature is Cloud-only

### DIFF
--- a/docs/courses/level-one/chapter-1.md
+++ b/docs/courses/level-one/chapter-1.md
@@ -76,7 +76,8 @@ The **canvas** is the gray dotted grid background in the Editor UI. It displays 
 - A button to **Execute workflow** once you add your first node. When you click on it, n8n executes all nodes on the canvas in sequence.
 - A button with a **+** sign inside. This button opens the nodes panel.
 - A button with a note icon inside. This button adds a [sticky note](/workflows/components/sticky-notes.md) to the canvas (visible when hovering on the top right + icon).
-- A button labeled **Ask Assistant** appears on the right side of the canvas. You can ask the AI Assistant for help with building workflows.
+- **Ask Assistant**: A button labeled **Ask Assistant** appears on the right side of the canvas. You can ask the AI Assistant for help with building workflows.  
+  *Note: This feature is available only in n8n Cloud, not in self-hosted instances.*
 - A dotted square with the text "Add first step." This is where you add your first node.
 
 <figure><img src="/_images/courses/level-one/chapter-one/l1-c1-canvas.png" alt="Workflow canvas" style="width:100%"><figcaption align = "center"><i>Workflow canvas</i></figcaption></figure>


### PR DESCRIPTION
**### Description:**
This PR updates the Ask Assistant section in the editor UI documentation.
### **Before:**
Ask Assistant: A button labeled Ask Assistant appears on the right side of the canvas. You can ask the AI Assistant for help with building workflows.
### **After:**
Ask Assistant: A button labeled Ask Assistant appears on the right side of the canvas. You can ask the AI Assistant for help with building workflows. Note: This feature is available only in n8n Cloud, not in self-hosted instances.
### **Why this change:**
Prevents confusion for self-hosted users who don’t see the Ask Assistant button.
Makes feature availability clearer in docs.