### PR TITLE
docs: add note about subscription requirement for Insights feature

### DIFF
--- a/docs/workflows/settings.md
+++ b/docs/workflows/settings.md
@@ -78,3 +78,5 @@ When enabled, the **Timeout After** option appears. Here, you can set the time (
 An estimate of the number of minutes each of execution of this workflow saves you.
 
 Setting this lets n8n calculate the amount of time saved for [insights](/insights.md).
+
+> **Note:** Access to *Insights* requires an active subscription (Pro/Enterprise) or the latest version of n8n.


### PR DESCRIPTION
Description:
This pull request updates the documentation to clarify that the Insights feature requires a subscription.
The update ensures transparency, helping users understand that Insights is not available by default and reducing potential confusion.

Changes made:
Updated docs/workflows/settings.md under the Insights section.
Added a clear note about the subscription requirement.

Reason for change:
Users might assume Insights is free or included locally. This clarification improves documentation accuracy and sets correct expectations.