### PR TITLE
docs: document workflow options menu (three dots next to Save)

### DIFF
--- a/docs/workflows/settings.md
+++ b/docs/workflows/settings.md
@@ -78,3 +78,5 @@ When enabled, the **Timeout After** option appears. Here, you can set the time (
 An estimate of the number of minutes each of execution of this workflow saves you.
 
 Setting this lets n8n calculate the amount of time saved for [insights](/insights.md).
+
+> **Note:** Access to *Insights* requires an active subscription (Pro/Enterprise) or the latest version of n8n.

--- a/docs/workflows/sharing.md
+++ b/docs/workflows/sharing.md
@@ -21,6 +21,21 @@ Users can share workflows they created. Instance owners, and users with the admi
 3. In **Add users**, find and select the users you want to share with.
 4. Select **Save**.
 
+### Workflow options menu
+
+Next to the **Save** button, there is an options menu (three dots).  
+This menu includes the following actions:
+
+- **Duplicate**: Create a copy of the workflow  
+- **Download**: Export the workflow as a file  
+- **Change owner**: Assign the workflow to another user  
+- **Rename**: Rename the workflow  
+- **Import from URL...**: Import a workflow directly from a URL  
+- **Import from File...**: Import a workflow from a local file  
+- **Push to Git**: Push the workflow to a connected Git repository (if configured)  
+- **Settings**: Configure workflow-level settings  
+- **Archive**: Archive the workflow  
+
 ## View shared workflows
 
 You can browse and search workflows on the **Workflows** list. The workflows in the list depend on the project:


### PR DESCRIPTION
## Summary
This PR improves the workflow sharing documentation by adding the missing workflow options menu (three dots next to the Save button).  

## Details
The workflow options menu gives users quick access to several important actions, but it was not documented.  
This PR adds a dedicated section listing the available options:

- Duplicate
- Download
- Change owner
- Rename
- Import from URL
- Import from File
- Push to Git
- Settings
- Archive

## Why this change?
Including these details in the documentation helps users:
- Better understand the full range of workflow management options.  
- Quickly find and use these features without trial and error.  
- Keep the documentation consistent with the actual UI.  

This improves clarity and makes the docs more user-friendly.