### PR TITLE
Update Custom Node Inputs/Outputs Syntax in Documentation

### DIFF
--- a/docs/integrations/creating-nodes/build/programmatic-style-node.md
+++ b/docs/integrations/creating-nodes/build/programmatic-style-node.md
@@ -90,6 +90,7 @@ import {
 	INodeExecutionData,
 	INodeType,
 	INodeTypeDescription,
+    NodeConnectionType
 } from 'n8n-workflow';
 
 import {
@@ -132,8 +133,8 @@ description: 'Consume SendGrid API',
 defaults: {
 	name: 'FriendGrid',
 },
-inputs: ['main'],
-outputs: ['main'],
+inputs: [NodeConnectionType.Main],
+outputs: [NodeConnectionType.Main],
 credentials: [
 	{
 		name: 'friendGridApi',


### PR DESCRIPTION
### Pull Request: Update Custom Node Inputs/Outputs Syntax

This updates the n8n [custom node documentation](https://docs.n8n.io/integrations/creating-nodes/build/programmatic-style-node/) to replace the outdated `inputs: ['main']` and `outputs: ['main']` syntax with the correct usage of `inputs: [NodeConnectionType.Main]` and `outputs: [NodeConnectionType.Main]`.

This change fixes TypeScript type errors and aligns the documentation with current n8n development practices, improving clarity and accuracy for developers building custom nodes.
