### PR TITLE
Documentation for thinking budget option in Google Vertex Model node

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgooglevertex.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgooglevertex.md
@@ -26,7 +26,8 @@ You can find authentication information for this node [here](/integrations/built
 * **Maximum Number of Tokens**: Enter the maximum number of tokens used, which sets the completion length.
 * **Sampling Temperature**: Use this option to control the randomness of the sampling process. A higher temperature creates more diverse sampling, but increases the risk of hallucinations.
 * **Top K**: Enter the number of token choices the model uses to generate the next token.
-* **Top P**: Use this option to set the probability the completion should use. Use a lower value to ignore less probable options. 
+* **Top P**: Use this option to set the probability the completion should use. Use a lower value to ignore less probable options.
+* **Thinking Budget**: Controls reasoning tokens for thinking models. Set to 0 to disable automatic thinking. Set to -1 for dynamic thinking. Leave empty for auto mode.
 * **Safety Settings**: Gemini supports adjustable safety settings. Refer to Google's [Gemini API safety settings](https://ai.google.dev/docs/safety_setting_gemini) for information on the available filters and levels.
 
 ## Templates and examples


### PR DESCRIPTION
Adding a note about the new thinking mode option available on google vertex sub nodes.

Support for this option added here: https://github.com/n8n-io/n8n/pull/19591