### PR TITLE
Update n8n-nodes-base.sendemail.md

### DIFF
--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.sendemail.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.sendemail.md
@@ -141,6 +141,12 @@ The following options are also available:
 * **Limit Wait Time**: Whether the workflow will automatically resume execution after a specified time limit. This can be an interval or a specific wall time.
 * **Append n8n Attribution**: Set whether to include the phrase `This email was sent automatically with n8n` at the end of the email (turned on) or not (turned off).
 
+### Limitation
+
+The Send Email (SMTP) node does not support setting headers like In-Reply-To and References, which are required for email threading. As a result, each email is treated as a new conversation instead of appearing in the same thread.
+
+* **Workaround**: Use the Gmail node’s Reply operation or a custom node (e.g., n8n-nodes-better-send-mail) that supports custom headers.
+
 ## Templates and examples
 
 <!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->


### PR DESCRIPTION
This PR updates the Send Email (SMTP) node documentation to include a limitation about email threading.
Currently, emails sent with this node do not appear in the same thread because the node does not support setting headers like In-Reply-To and References. This can cause each email to be treated as a new conversation in most email clients (e.g., Gmail, Outlook).

Changes

Added a Limitations section under the Send Email (SMTP) node docs.
Explained why threading does not work by default.
Added recommended workarounds: using the Gmail node’s Reply operation or community nodes that allow custom headers.