### PR TITLE
docs(learning-path): restructure onboarding flow and refine microcopy

### DIFF
--- a/docs/learning-path.md
+++ b/docs/learning-path.md
@@ -2,61 +2,62 @@
 description: A suggested learning path to get started with n8n through tutorials, courses, and step-by-step guides.
 contentType: overview
 ---
-This guide outlines a series of tutorials and resources designed to get you started with n8n. 
 
-It's not necessary to complete all items listed to start using n8n. Use this as a reference to navigate to the most relevant parts of the documentation and other resources according to your needs.
-
-## Join the community
-
-n8n has an active community where you can get and offer help. Connect, share, and learn with other n8n users:
-
-- [Ask questions](https://community.n8n.io/t/readme-welcome-to-the-n8n-community/44381) and [make feature requests](https://community.n8n.io/c/feature-requests) in the Community Forum.
-- [Report bugs](https://github.com/n8n-io/n8n/issues) and [contribute](https://github.com/n8n-io/n8n/blob/master/CONTRIBUTING.md) on GitHub.
+Explore this collection of resources to start automating with n8n. Treat it as a map to navigate through our knowledge base and community.
 
 ## Set up your n8n
 
-If you don't have an account yet, sign up to a [free trial on n8n Cloud](https://app.n8n.cloud/register) or install n8n's community edition with [Docker](/hosting/installation/docker.md) (recommended) or [npm](/hosting/installation/npm.md). See [Choose your n8n](/choose-n8n.md) for more details.
+- Sign up for a [free trial on n8n Cloud](https://app.n8n.cloud/register), or install the community edition with [Docker](/hosting/installation/docker.md) (recommended) or [npm](/hosting/installation/npm.md)
+- Check out other [installation options](/choose-n8n.md) to meet your needs
 
-## Try it out
+## Automate right away
 
-Start with the quickstart guides to help you get up and running with building basic workflows. 
+Try n8n out with these first-time user guides:
 
-- [A very quick quickstart](/try-it-out/quickstart.md)
-- [A longer introduction](/try-it-out/tutorial-first-workflow.md)
-- [Build an AI workflow in n8n](/advanced-ai/intro-tutorial.md)
+- [Quickstart](/try-it-out/quickstart.md) in 3 steps
+- Build an [n8n workflow](/try-it-out/tutorial-first-workflow.md) from scratch
+- Develop an [AI chat agent](/advanced-ai/intro-tutorial.md)
 
-## Structured Courses
+## Join a mingling community
 
-n8n offers two sets of courses.
+Journey through all things automation with fellow n8n builders and enthusiasts:
+
+- [ask questions](https://community.n8n.io/t/readme-welcome-to-the-n8n-community/44381) and [make feature requests](https://community.n8n.io/c/feature-requests) in the community forum
+- [report bugs](https://github.com/n8n-io/n8n/issues) and [contribute](https://github.com/n8n-io/n8n/blob/master/CONTRIBUTING.md) on GitHub
+
+## Manage the learning path
+
+We've developed video and text-based courses to aid your n8n adoption and simplify the learning curve.
 
 ### Video courses
 
-Learn key concepts and n8n features, while building examples as you go.
+Learn key concepts and n8n features while building examples as you go.
 
 - The [Beginner](https://www.youtube.com/playlist?list=PLlET0GsrLUL59YbxstZE71WszP3pVnZfI) course covers the basics of n8n.
-- The [Advanced](https://www.youtube.com/playlist?list=PLlET0GsrLUL5bxmx5c1H1Ms_OtOPYZIEG) course covers more complex workflows, more technical nodes, and enterprise features
+- The [Advanced](https://www.youtube.com/playlist?list=PLlET0GsrLUL5bxmx5c1H1Ms_OtOPYZIEG) course dives into more sophisticated workflows, details technical nodes, and introduces enterprise features.
 
 ### Text courses
 
-Build more complex workflows while learning key concepts along the way. Earn a badge and an avatar in your community profile. 
+[Level 1: Beginner course](https://blog.n8n.io/announcing-the-n8n-certification-course-for-beginners-level-1/) walks through the Editor UI, showcases data structures in n8n, and explains node/workflow configuration. **Achievements** upon completion include a 2-node workflow that retrieves articles from Hacker News and a 7-node workflow that pulls and analyzes records from a data warehouse.
 
-- [Level 1: Beginner Course](https://blog.n8n.io/announcing-the-n8n-certification-course-for-beginners-level-1/)
-- [Level 2: Intermediate Course](https://blog.n8n.io/announcing-course-level-two/)
+[Level 2: Intermediate course](https://blog.n8n.io/announcing-course-level-two/) focuses on understanding data structures in n8n and handling a range of data-driven use cases. **Achievements** upon completion include the ability to process different data types, merge data from different sources, and manage error workflows.
 
-## Self-hosting n8n
+## Self-host n8n
 
-Explore various [self-hosting options in n8n](/hosting/index.md). If you’re not sure where to start, these are two popular options: 
-
-- [Hosting n8n on DigitalOcean](/hosting/installation/server-setups/digital-ocean.md)
-- [Hosting n8n on Amazon Web Services](/hosting/installation/server-setups/aws.md)
+- Choose your fighter among n8n’s various [self-hosting offerings](/hosting/index.md)
+- If in doubt, consider popular [DigitalOcean](/hosting/installation/server-setups/digital-ocean.md) or [AWS](/hosting/installation/server-setups/aws.md) options
 
 ## Build a node
 
-If you can't find a node for a specific app or a service, you can build a node yourself and share with the community. See what others have built on [npm website](https://www.npmjs.com/search?q=keywords:n8n-community-node-package). 
+If you can't find a node for a specific app or service, build one yourself and share it with the community.
 
-- [Build a declarative-style node](/integrations/creating-nodes/build/declarative-style-node.md)
-- [Learn how to build your own n8n nodes (Youtube Video)](https://www.youtube.com/live/OI6zHJ56eW0?si=SMD7L1J5fZ2mf79W)
+- Follow a 7-step tutorial to develop a [declarative-style node](/integrations/creating-nodes/build/declarative-style-node.md)
+- Watch a YouTube webinar to build [custom n8n nodes](https://www.youtube.com/live/OI6zHJ56eW0?si=SMD7L1J5fZ2mf79W)
+- Explore a collection of [independent node contributions](https://www.npmjs.com/search?q=keywords:n8n-community-node-package)
 
-## Stay updated
-- Follow new features and bug fixes in the [Release Notes](/release-notes.md)
-- Follow n8n on socials: [Twitter/X](https://twitter.com/n8n_io), [Discord](https://discord.com/invite/vWwMVThRta), [LinkedIn](https://www.linkedin.com/company/n8n/), [YouTube](https://www.youtube.com/@n8n-io)
+## Stay tuned
+
+- Discover new features and bug fixes in the [release notes](/release-notes.md)
+- Follow n8n on socials: [Discord](https://discord.com/invite/vWwMVThRta), [X (former Twitter)](https://twitter.com/n8n_io), [YouTube](https://www.youtube.com/@n8n-io), and [LinkedIn](https://www.linkedin.com/company/n8n/)
+
+Keep automating as every workflow you build adds to what our community learns together!


### PR DESCRIPTION
<h3>Summary</h3>

<p>This PR aims at transforming the available list of resources at the <a href="https://docs.n8n.io/learning-path/">Learning Path</a> page into a guided onboarding journey. The new structure introduces a clear progression:

 <b>Set up → Automate → Join community → Manage learning → Self-host → Build a node</b>

 and refines the microcopy for tone, consistency, and readability. These suggestions try to bridge the n8n’s community voice and UX design principles, making the learning flow more intuitive and engaging.</p>

<hr>

<h3>Key improvements</h3>

<h4>🧭 Overall structure and hierarchy</h4>

<ul>
<li>Reorganized the page into cohesive onboarding stages to reflect user intent: <b>Access → Action → Belonging → Mastery → Ownership</b>.</li>
<li>The intent is to keep the flow as a <em>learning journey</em>, rather than an index—reducing cognitive friction and enhancing motivation.</li>
</ul>

<h4>✍️ Intro section</h4>

<p>Replaced the generic overview with an action-oriented hook:</p>

<blockquote><em>“Explore this collection of resources to start automating with n8n. Treat it as a map to navigate through our knowledge base and community.”</em></blockquote>

 <p>The intent here is to use active verbs, highlight outcomes, and adhere to a visual balance.</p>

<h4>⚙️ “Set up your n8n”</h4>

<ul>
<li>Condensed setup instructions into parallel, verb-led bullets</li>
<li>Changed the tone (“Explore other installation options that fit your setup”) for approachability and flow</li>
</ul>

<h4>🚀 “Automate right away” (formerly “Try it out”)</h4>

<ul>
<li>Rebranded the section to emphasize <em>immediate engagement</em></li>
<li>Fixed some redundant phrasing (“A very quick quickstart”)</li>
<li>Ensured grammatical cohesion across bullets</li>
</ul>

<h4>🤝 “Join a mingling community”</h4>

<ul>
<li>Added a short narrative bridge sentence for smoother flow</li>
<li>Adopted lowercase bullet style and removed terminal punctuation per MMoS/CMoS</li>
<li>Adjusted phrasing (“in the community forum”) for rhythm and consistency</li>
</ul>

<h4>🎓 “Manage the learning path”</h4>

<ul>
<li>Reframed “Structured courses” as an active concept (“Manage”) to imply agency</li>
<li>Grouped video and text courses with clear achievement-based outcomes</li>
</ul>

<h4>🖥️ “Self-host n8n”</h4>
<ul>
<li>Reorganized and clarified hosting options</li>
<li>Retained the playful “Choose your fighter” phrase for community tone, but easily adaptable to “Choose your preferred setup” for enterprise consistency</li>
</ul>

<h4>🧩 “Build a node”</h4>

<ul>
<li>Refined the motivational close of the learning path</li>
<li>Smoothed syntax (“Build your own and share it with the community”)</li>
<li>Unified cross-channel resources (docs, YouTube, npm) based on my assumption which ones need user boost</li>
</ul>

<hr>

<h3>UX and readability desirable impact</h3>

Criterion | Previous version | Updated version
-- | -- | --
Line economy | Long, repetitive intros | Short, focused blocks
Whitespace balance | Uneven spacing | Consistent rhythm (~2 lines + list)
Heading cadence | Mixed noun/verb style | Unified imperative tone
Cognitive flow | Table-of-contents-like | Cohesive narrative
Voice | Institutional | Inviting, confident, expert


<p>The net impact of these changes targets cohesive storytelling, while taking a shot at enhancing motivation, scan-readability, and UX consistency across the documentation.</p>

<p>Any constructive feedback is strongly appreciated.</p>
