### PR TITLE
Document new Guardrails node (for 1.118.0)

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -47,12 +47,9 @@ This release contains bug fixes.
 ### Guardrails Node
 The Guardrails node provides a set of rules and policies that control an AI agent's behavior by filtering its inputs and outputs. This helps safeguard from malicious input and from generating unsafe or undesirable responses.
 <br>
-<br>	
 The default presets and prompts are adapted from the open-source [guardrails package](https://github.com/openai/openai-guardrails-js) made available by OpenAI.
-<br>
 <br>	
-For more info, see [Guardrails documentation](/integrations/builtin/cluster-nodes/index.md)
-/integrations/builtin/core-nodes/n8n-nodes-langchain.guardrails.md
+For more info, see [Guardrails documentation](/integrations/builtin/core-nodes/n8n-nodes-langchain.guardrails.md)
 </div>
 
 


### PR DESCRIPTION
This needs to go into 1.118.0 which does not yet exist.

Added details about the new Guardrails node, including its purpose and references to documentation.