### PR TITLE
docs: include example for separate runner pod in K8s

### DIFF
--- a/docs/hosting/configuration/task-runners.md
+++ b/docs/hosting/configuration/task-runners.md
@@ -159,7 +159,10 @@ spec:
             - name: N8N_RUNNERS_TASK_BROKER_URI
               value: http://n8n-task-broker.n8n-test.svc.cluster.local:5679
             - name: N8N_RUNNERS_AUTH_TOKEN
-              value: "mysecr3t"
+              valueFrom:
+                secretKeyRef:
+                  name: n8n-test-auth-token
+                  key: auth-token
             - name: N8N_NATIVE_PYTHON_RUNNER
               value: "true"
 ```


### PR DESCRIPTION
I couldn't get the task runner working using the sidecar method, but a dedicated runner Pod works, so I thought it was a good idea to include in the docs.