### PR TITLE
docs: Update Milvus Vector Store Node documentation

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremilvus.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremilvus.md
@@ -88,6 +88,14 @@ The connections flow would look like this: AI agent (tools connector) -> Vector 
 
 --8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-root-nodes/vector-store-metadata-filter.md"
 
+### Distance Strategy
+
+Available in **Get Many** and **Retrieve Documents** modes. Selects the method to calculate the distance between two vectors. The default is `L2`.
+
+### Index Type
+
+Available in **Get Many** and **Retrieve Documents** modes. Selects the type of index used in the Milvus database. The default is `AUTOINDEX`.
+
 ### Clear Collection
 
 Available in **Insert Documents** mode. Deletes all data from the collection before inserting the new data.

--- a/docs/integrations/builtin/credentials/milvus.md
+++ b/docs/integrations/builtin/credentials/milvus.md
@@ -32,3 +32,4 @@ To configure this credential, you'll need:
 * **Base URL**: The base URL of your Milvus instance. The default is `http://localhost:19530`.
 * **Username**: The username to authenticate to your Milvus instance. The default value is `root`.
 * **Password**: The password to authenticate to your Milvus instance. The default value is `Milvus`.
+* **Database Name**: The name of the database to use. The default is `default`.


### PR DESCRIPTION
Document updates made in https://github.com/n8n-io/n8n/pull/28082. Add notes detailing the new distance strategy and index type options, as well as the additional database name field in the credentials.