### PR TITLE
Docs: update Elasticsearch credentials documentation

### DIFF
--- a/docs/integrations/builtin/credentials/elasticsearch.md
+++ b/docs/integrations/builtin/credentials/elasticsearch.md
@@ -43,7 +43,7 @@ To set up the credential:
 
 ## Using basic auth
 
-To configure this credential method, you'll need an [Elasticsearch](https://www.elastic.co/) account with a [deployment](https://www.elastic.co/guide/en/cloud/current/ec-create-deployment.html) and:
+To configure this credential, you'll need an [Elasticsearch](https://www.elastic.co/) account with a [deployment](https://www.elastic.co/guide/en/cloud/current/ec-create-deployment.html) and:
 
 - A **Username**
 - A **Password**

--- a/docs/integrations/builtin/credentials/elasticsearch.md
+++ b/docs/integrations/builtin/credentials/elasticsearch.md
@@ -14,29 +14,50 @@ You can use these credentials to authenticate the following nodes:
 ## Supported authentication methods
 
 - Basic auth
+- API-Key and Endpoint Authentication
+
+You will need a **Base URL** (also known as the Elasticsearch endpoint) for either method. To find the endpoint:
+
+1. In Elasticsearch, go to **Deployments**.
+2. Select your deployment.
+3. Select **Manage this deployment**.
+4. In the **Applications** section, copy the endpoint of the **Elasticsearch** application.
 
 ## Related resources
 
 Refer to [Elasticsearch's documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html) for more information about the service.
 
-## Using basic auth
+## Using an API-Key and Endpoint (recommended)
 
-To configure this credential, you'll need an [Elasticsearch](https://www.elastic.co/) account with a [deployment](https://www.elastic.co/guide/en/cloud/current/ec-create-deployment.html) and:
+To configure this credential, you'll need an [Elasticsearch](https://www.elastic.co/) account with a [deployment](https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/create-an-organization) and:
 
-- A **Username**
-- A **Password**
-- Your Elasticsearch application's **Base URL** (also known as the Elasticsearch application endpoint)
+- An [API Key](https://www.elastic.co/docs/deploy-manage/api-keys/elasticsearch-api-keys)
+- Your Elasticsearch application's **Base URL**
 
 To set up the credential:
 
-1. Enter your Elasticsearch **Username**.
-2. Enter your Elasticsearch **Password**.
-3. In Elasticsearch, go to **Deployments**.
-4. Select your deployment.
-5. Select **Manage this deployment**.
-6. In the **Applications** section, copy the endpoint of the **Elasticsearch** application.
-7. Enter this in n8n as the **Base URL**.
-8. By default, n8n connects only if SSL certificate validation succeeds. If you'd like to connect even if SSL certificate validation fails, turn on **Ignore SSL Issues**.
+1. Enter your Elasticsearch **Base URL**
+2. Choose **API Key** as the Authentication type
+3. Enter your Elasticsearch **API Key**
+4. By default, n8n connects only if SSL certificate validation succeeds. If you'd like to connect even if SSL certificate validation fails, turn on **Ignore SSL Issues**.
+
+## Using basic auth
+
+To configure this credential method, you'll need an [Elasticsearch](https://www.elastic.co/) account with a [deployment](https://www.elastic.co/guide/en/cloud/current/ec-create-deployment.html) and:
+
+- A **Username**
+- A **Password**
+- Your Elasticsearch application's **Base URL**
+
+The basic auth method will **not** work with Elastic Serverless
+
+To set up the credential:
+
+1. Enter your Elasticsearch **Base URL**
+2. Choose **Basic Auth** as the Authentication type
+3. Enter your Elasticsearch **Username**.
+4. Enter your Elasticsearch **Password**.
+5. By default, n8n connects only if SSL certificate validation succeeds. If you'd like to connect even if SSL certificate validation fails, turn on **Ignore SSL Issues**.
 
 /// note | Custom endpoint aliases
 If you add a [custom endpoint alias](https://www.elastic.co/guide/en/cloud/current/ec-regional-deployment-aliases.html) to a deployment, update your n8n credential **Base URL** with the new endpoint.


### PR DESCRIPTION
Added API-Key and Endpoint authentication method details and updated instructions for configuring credentials in Elasticsearch.

This the documentation update for the feature PR here: https://github.com/n8n-io/n8n/pull/21405

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds API-Key + Endpoint auth to Elasticsearch credentials docs, updates Base URL guidance, and revises basic auth steps with a serverless caveat.
> 
> - **Docs**:
>   - **Elasticsearch credentials** (`docs/integrations/builtin/credentials/elasticsearch.md`):
>     - Add *API-Key and Endpoint* authentication with setup steps.
>     - Add shared instructions to locate the Elasticsearch **Base URL**.
>     - Revise *Basic auth* setup flow and clarify required fields; note incompatibility with Elastic Serverless.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bac8a943146986a96b53e54062454a3a30b58022. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->