### PR TITLE
Document new Guardrails node in release notes - 1.119.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -51,8 +51,8 @@ The Guardrails node provides a set of rules and policies that control an AI agen
 
 - Check Text for Violations: Validate text against a set of policies (e.g. NSFW, prompt injection).
 - Sanitize Text: Detects and replaces specific data such as PII, URLs, or secrets with placeholders.
-<br>
-<br>
+
+
 The default presets and prompts are adapted from the open-source [guardrails package](https://github.com/openai/openai-guardrails-js) made available by OpenAI.
 <br>	
 For more info, see [Guardrails documentation](/integrations/builtin/core-nodes/n8n-nodes-langchain.guardrails.md)


### PR DESCRIPTION
Added details about the new Guardrails node, including its features and operations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new section in 1.119.0 release notes documenting the Guardrails node, its two operations, attribution, and link to detailed docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aeaf8f91c9b8e4fe3f0e38f218ea9ebc65c8f3a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->