### PR TITLE
Changing verbiage on contributor page

### DIFF
--- a/docs/help-community/contributing.md
+++ b/docs/help-community/contributing.md
@@ -55,17 +55,6 @@ The repository for the docs is [here](https://github.com/n8n-io/n8n-docs) and th
 
 Share your own video or written guides on our [community-driven, searchable library of n8n tutorials and training materials](https://community.n8n.io/t/how-to-share-your-tutorials/48398). Tag them for easy discovery, and post in your language’s subcategory. Follow the contribution guidelines to help keep our growing library high-quality and accessible to everyone.
 
-### How to submit a post
-
-n8n appreciates all contributions. Publishing a tutorial on your own site that supports the community is a great contribution. If you want n8n to highlight your post on the blog, follow these steps: 
-
-1. Email your idea to [marketing@n8n.io](mailto:marketing@n8n.io) with the subject "Blog contribution: [Your Topic]."
-2. Submit your draft:
-      - Write your post in a Google Doc following the [style guide](https://www.notion.so/97dc73436a624933b75ddc941a361b70?pvs=21).
-      - If your blog post includes example workflows, include the workflow JSON in a separate section at the end.
-      - For author credit, provide a second Google Doc with your full name, a short byline, and your image. n8n will use this to create your author page and credit you as the author of the post.
-3. Wait for feedback. We will respond if your draft fits with the blog's strategy and requirements. If you don't hear back within 30 days, it means we won't be moving forward with your blog post.
-
 ## Refer a candidate
 
 Do you know someone who would be a great fit for one of our [open positions](https://n8n.io/careers)? Refer them to us! In return, we'll pay you €1,000 when the referral successfully passes their probationary period.

--- a/docs/manage-cloud/cloud-data-management.md
+++ b/docs/manage-cloud/cloud-data-management.md
@@ -68,7 +68,7 @@ In your workflow settings:
 n8n automatically prunes execution logs after a certain time or once you reach the max storage limit, whichever comes first. The pruning always happens from oldest to newest and the limits depend on your Could plan:
 
 * Start and Starter plans: max 2500 executions saved and 7 days execution log retention;
-* Pro and Power plans: max 25000 executions saved and 30 days execution log retention;
+* Pro plans: max 25000 executions saved and 30 days execution log retention;
 * Enterprise plan: max 50000 executions saved and unlimited execution log retention time.
 
 ### Manual data pruning


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the blog post submission instructions from the contributing page and updates cloud data pruning limits to reference Pro plans (dropping Power).
> 
> - **Docs**:
>   - **Contributing**: Remove the "How to submit a post" guidance and related email/style doc steps from `docs/help-community/contributing.md` under community tutorials.
>   - **Cloud data management**: Adjust automatic pruning plan naming in `docs/manage-cloud/cloud-data-management.md` from `Pro and Power` to `Pro`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f6cf985f490f72a6eb82dbfd251d7f4d3566c87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->