### PR TITLE
Update Insights feature description in chapter-1.md

### DIFF
--- a/docs/courses/level-one/chapter-1.md
+++ b/docs/courses/level-one/chapter-1.md
@@ -47,7 +47,7 @@ The panel contains the following sections:
 -   **Admin Panel**: n8n Cloud only. Access your n8n instance usage, billing, and version settings.
 -   **Templates**: A collection of pre-made workflows. Great place to get started with common use cases.
 -   **Variables**: Used to store and access fixed data across your workflows. This feature is available on the Pro and Enterprise Plans.
--   **Insights**: Provides analytics and insights about your workflows.
+-   **Insights**: This feature is only available in n8n’s Pro and Enterprise Plans. It provides analytics and insights about your workflows and is not available in the local/self-hosted version.
 -   **Help**: Contains resources around n8n product and community.
 -   **What’s New**: Shows the latest product updates and features.
 


### PR DESCRIPTION
Updated the Left-side panel text to clarify that the analytics/insights feature is only available in Pro and Enterprise plans. Added note that this feature is not available in the local/self-hosted version. Suggested updating old images/screenshots if necessary to match current UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies the `Insights` section in `docs/courses/level-one/chapter-1.md` to note it’s available only on Pro/Enterprise and not on local/self-hosted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91c68c0b138ce2b063ab49465eea55072c259aba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->