### PR TITLE
Typo fixes

### DIFF
--- a/_snippets/self-hosting/installation/latest-next-version.md
+++ b/_snippets/self-hosting/installation/latest-next-version.md
@@ -1,6 +1,6 @@
 /// note | Latest and Next versions
 n8n releases a new minor version most weeks. The `latest` version is for production use. `next` is the most recent release. You should treat `next` as a beta: it may be unstable. To report issues, use the [forum](https://community.n8n.io/c/questions/12).
 
-Current `latest`: 1.119.1  
-Current `next`: 1.119.0
+Current `latest`: 1.119.2  
+Current `next`: 1.119.3
 ///

--- a/docs/data/data-tables.md
+++ b/docs/data/data-tables.md
@@ -44,7 +44,7 @@ There are two parts to working with data tables: creating them and interacting w
 
 ### Step 2: Interacting with Data tables in workflows
 
-Interact with data tables in your workflow using the **Data table** node, which allows you to retreive, update, and manipulate the data stored in a Data table.
+Interact with data tables in your workflow using the **Data table** node, which allows you to retrieve, update, and manipulate the data stored in a Data table.
 
 See [Data table node](/integrations/builtin/core-nodes/n8n-nodes-base.datatable/index.md).
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates displayed latest/next versions and fixes a typo in the Data tables documentation.
> 
> - **Docs**:
>   - **Self-hosting snippet**: Update displayed versions — `latest` to `1.119.2` and `next` to `1.119.3` in `_snippets/self-hosting/installation/latest-next-version.md`.
>   - **Data tables guide**: Fix spelling of “retrieve” in `docs/data/data-tables.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34a659a5cdf5e2491c38ca76a336648248bb3d57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->