### PR TITLE
Adding OAuth2 support for MCP Client Tool

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md
@@ -9,7 +9,7 @@ contentType: [integration, reference]
 The MCP Client Tool node is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) client, allowing you to use the tools exposed by an external MCP server. You can connect the MCP Client Tool node to your models to call external tools with n8n agents.
 
 ///  note  | Credentials
-The MCP Client Tool node supports both [Bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth) and generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth) authentication methods.
+The MCP Client Tool node supports [Bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), and [OAuth2](/integrations/builtin/credentials/httprequest.md#using-oauth2) authentication methods.
 ///
 
 ## Node parameters
@@ -17,7 +17,7 @@ The MCP Client Tool node supports both [Bearer](/integrations/builtin/credential
 Configure the node with the following parameters.
 
 * **SSE Endpoint**: The SSE endpoint for the MCP server you want to connect to.
-* **Authentication**: The authentication method for authentication to your MCP server. The MCP tool supports [bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth) and generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth) authentication. Select **None** to attempt to connect without authentication.
+* **Authentication**: The authentication method for authentication to your MCP server. The MCP tool supports [bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), and [OAuth2](/integrations/builtin/credentials/httprequest.md#using-oauth2) authentication. Select **None** to attempt to connect without authentication.
 * **Tools to Include**: Choose which tools you want to expose to the AI Agent:
 	* **All**: Expose all the tools given by the MCP server.
 	* **Selected**: Activates a **Tools to Include** parameter where you can select the tools you want to expose to the AI Agent.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Documents OAuth2 as a supported authentication method for the MCP Client Tool node.
> 
> - **Docs** (`docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md`):
>   - Add OAuth2 to supported authentication methods in the Credentials note.
>   - Update **Authentication** parameter description to include OAuth2 alongside bearer and header options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd4225d682bba85446e836e2cd83c4e8cc67260a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->