### PR TITLE
Edits to release notes and updated latest/next

### DIFF
--- a/_snippets/self-hosting/installation/latest-next-version.md
+++ b/_snippets/self-hosting/installation/latest-next-version.md
@@ -1,6 +1,6 @@
 /// note | Latest and Next versions
 n8n releases a new minor version most weeks. The `latest` version is for production use. `next` is the most recent release. You should treat `next` as a beta: it may be unstable. To report issues, use the [forum](https://community.n8n.io/c/questions/12).
 
-Current `latest`: 1.120.3
-Current `next`: 1.121.0
+Current `latest`: 1.120.4
+Current `next`: 1.121.2
 ///

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -33,14 +33,14 @@ You can find the release notes for older versions of n8n [here](/release-notes/0
 ///
 
 
-
 ## n8n@1.121.2
 
 View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.121.1...n8n@1.121.2) for this version.<br />
 
-**Release date:** 2025-11-20
+* Fixed an issue with MCP access scope in the core system.
+* Updated editor to improve notice background colors for better visibility.
 
-This release contains bug fixes.
+**Release date:** 2025-11-20
 
 For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
 
@@ -48,16 +48,18 @@ For full release details, refer to [Releases](https://github.com/n8n-io/n8n/rele
 
 View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.121.0...n8n@1.121.1) for this version.<br />
 
-This release contains .
+* Prepared patch release 1.121.1 by updating version numbers across all packages.
+* Added a changelog entry for version 1.121.1 to document the release.
+
+**Release date:** 2025-11-19
 
 For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
 
 ## n8n@1.121.0
 
 View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.120.0...n8n@1.121.0) for this version.<br />
-**Release date:** 2025-11-18
 
-This release contains bug fixes.
+**Release date:** 2025-11-18
 
 <div class="n8n-new-features" markdown>
 ### Instance-level MCP connections (beta)
@@ -100,9 +102,11 @@ For full release details, refer to [Releases](https://github.com/n8n-io/n8n/rele
 ## n8n@1.120.4
 
 View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.120.3...n8n@1.120.4) for this version.<br />
+
 **Release date:** 2025-11-19
 
-This release contains .
+* Prepared for release 1.120.4 by updating version numbers across all core, backend, AI/LLM, frontend, and tooling packages.
+* Added a changelog entry for version 1.120.4 to document the release.
 
 For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates release notes (adds details for 1.121.2 and clarifies 1.121.1/1.120.4) and bumps Latest/Next to 1.120.4/1.121.2.
> 
> - **Release notes (`docs/release-notes.md`)**:
>   - Add details for `n8n@1.121.2` (MCP access scope fix; editor notice background updates) and set release date.
>   - Clarify `n8n@1.121.1` and `n8n@1.120.4` entries (version bumps + changelog notes; add release dates).
>   - Minor formatting/order tweaks around release date text in `1.121.0`.
> - **Self-hosting snippet (`_snippets/self-hosting/installation/latest-next-version.md`)**:
>   - Update `Current latest` to `1.120.4` and `Current next` to `1.121.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f81ee0130c0085508bb061d86e85ce2cae5c2a67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->