### PR TITLE
Deprecating Github Document Loader

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentgithubloader.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentgithubloader.md
@@ -6,6 +6,10 @@ contentType: [integration, reference]
 
 # GitHub Document Loader node
 
+/// warning | Deprecated
+This node is deprecated, and will be removed in a future version.
+///
+
 Use the GitHub Document Loader node to load data from a GitHub repository for [vector stores](/glossary.md#ai-vector-store) or summarization.
 
 On this page, you'll find the node parameters for the GitHub Document Loader node, and links to more resources.


### PR DESCRIPTION
The Github document loader is currently broken - we have decided to hide and deprecate it as the default document loader can do the same job.

PR hiding: https://github.com/n8n-io/n8n/pull/22138