### PR TITLE
Explain when credential fields are committed to source control

### DIFF
--- a/docs/source-control-environments/using/push-pull.md
+++ b/docs/source-control-environments/using/push-pull.md
@@ -59,10 +59,7 @@ You must be an instance owner, instance admin, or project admin to push changes 
 n8n commits the following to Git:
 
 * Workflows, including their tags and the email address of the workflow owner. You can choose which workflows to push.
-* Credential stubs (ID, name, type)
-  /// info | When other fields get committed
-  Any fields within credentials are only committed if they contain [expressions](https://docs.n8n.io/code/expressions/). Plain text values are not committed to avoid security risks.
-  ///
+* Credential stubs - ID, name and type. Any other fields are included only if they are [expressions](https://docs.n8n.io/code/expressions/). You can choose which credentials to push.
 * Variable stubs (ID and name)
 * Projects
 * Folders


### PR DESCRIPTION
We missed documenting that any fields within credentials are only pushed to source control if they are expressions.