### PR TITLE
Custom programmatic node tutorial

### DIFF
--- a/docs/integrations/creating-nodes/build/programmatic-style-node.md
+++ b/docs/integrations/creating-nodes/build/programmatic-style-node.md
@@ -3,7 +3,7 @@ contentType: tutorial
 ---
 # Build a programmatic-style node
 
-This tutorial walks through building a programmatic-style node. Before you begin, make sure this is the node style you need. Refer to [Choose your node building approach](/integrations/creating-nodes/plan/choose-node-method.md) for more information.
+This tutorial walks through building a programmatic-style node. Before you begin, make sure this is the node style you need. Refer to [Choose your node building approach](https://docs.n8n.io/integrations/creating-nodes/plan/choose-node-method/) for more information.
 
 /// note | ✨ New to n8n node development?
 The fastest way to get started is with the official CLI tool:
@@ -24,7 +24,7 @@ You need some understanding of:
 - JavaScript/TypeScript
 - REST APIs
 - git
-- [Expressions](/glossary.md#expression-n8n) in n8n
+- [Expressions](https://docs.n8n.io/code/expressions/) in n8n
 
 ## Build your node
 
@@ -62,7 +62,8 @@ Now create the following directories and files:
 `nodes/FriendGrid/FriendGrid.node.ts`  
 `credentials/FriendGridApi.credentials.ts`
 
-These are the key files required for any node. Refer to [Node file structure](/integrations/creating-nodes/build/reference/node-file-structure.md) for more information on required files and recommended organization.
+These are the key files required for any node. Refer to [Node file structure](https://docs.n8n.io/integrations/creating-nodes/build/reference/node-file-structure/
+) for more information on required files and recommended organization.
 
 Now install the project dependencies:
 
@@ -74,17 +75,13 @@ npm i
 
 Save the SendGrid SVG logo from [here](https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/SendGrid/sendGrid.svg) as `friendGrid.svg` in `nodes/FriendGrid/`.
 
-n8n recommends using an SVG for your node icon, but you can also use PNG. If using PNG, the icon resolution should be 60x60px. Node icons should have a square or near-square aspect ratio.
-
-/// note | Don't reference Font Awesome
-If you want to use a Font Awesome icon in your node, download and embed the image.
-///
+--8<-- "_snippets/integrations/creating-nodes/node-icons.md"
 
 ### Step 3: Define the node in the base file
 
-Every node must have a base file. Refer to [Node base file](/integrations/creating-nodes/build/reference/node-base-files.md) for detailed information about base file parameters.
+Every node must have a base file. Refer to [Node base file](https://docs.n8n.io/integrations/creating-nodes/build/reference/node-base-files/) for detailed information about base file parameters.
 
-In this example, the file is `FriendGrid.node.ts`. To keep this tutorial short, you'll place all the node functionality in this one file. When building more complex nodes, you should consider splitting out your functionality into modules. Refer to [Node file structure](/integrations/creating-nodes/build/reference/node-file-structure.md) for more information.
+In this example, the file is `FriendGrid.node.ts`. To keep this tutorial short, you'll place all the node functionality in this one file. When building more complex nodes, you should consider splitting out your functionality into modules. Refer to [Node file structure](https://docs.n8n.io/integrations/creating-nodes/build/reference/node-file-structure/) for more information.
 
 #### Step 3.1: Imports
 
@@ -93,21 +90,12 @@ Start by adding the import statements:
 ```typescript
 import {
 	IExecuteFunctions,
-	IDataObject,
 	INodeExecutionData,
+	IHttpRequestOptions,
 	INodeType,
 	INodeTypeDescription,
-	NodeConnectionType,
-	IRequestOptions,
 } from 'n8n-workflow';
 ```
-
-/// warning | Important API Changes (v1.0+)
-- All imports now come from `n8n-workflow` (not `n8n-core`)
-- Use `IRequestOptions` instead of the deprecated `OptionsWithUri`
-- Use `NodeConnectionType` enum instead of string literals
-- The `request` library has been replaced with modern HTTP helpers
-///
 
 #### Step 3.2: Create the main class
 
@@ -179,13 +167,13 @@ The resource object defines the API resource that the node uses. In this tutoria
 },
 ```
 
-`type` controls which UI element n8n displays for the resource, and tells n8n what type of data to expect from the user. `options` results in n8n adding a dropdown that allows users to choose one option. Refer to [Node UI elements](/integrations/creating-nodes/build/reference/ui-elements.md) for more information.
+`type` controls which UI element n8n displays for the resource, and tells n8n what type of data to expect from the user. `options` results in n8n adding a dropdown that allows users to choose one option. Refer to [Node UI elements](https://docs.n8n.io/integrations/creating-nodes/build/reference/ui-elements/) for more information.
 
 #### Step 3.5: Add operations
 
 The operations object defines what you can do with a resource. It usually relates to REST API verbs (GET, POST, and so on). In this tutorial, there's one operation: create a contact. It has one required field, the email address for the contact the user creates.
 
-Add the following to the `properties` array, after the resource object:
+Add the following to the `properties` array, after the `resource` object:
 
 ```typescript
 {
@@ -279,7 +267,7 @@ You've set up the node UI and basic information. It's time to map the node UI to
 
 The `execute` method runs every time the node runs. In this method, you have access to the input items and to the parameters that the user set in the UI, including the credentials.
 
-Add the following the execute method in the `FriendGrid.node.ts`:
+Add the following the `execute` method in the `FriendGrid.node.ts`:
 
 ```typescript
 // Handle data coming from previous nodes
@@ -390,7 +378,8 @@ export class FriendGridApi implements ICredentialType {
 }
 ```
 
-For more information about credentials files and options, refer to [Credentials file](/integrations/creating-nodes/build/reference/credentials-files.md).
+For more information about credentials files and options, refer to [Credentials file](https://docs.n8n.io/integrations/creating-nodes/build/reference/credentials-files/
+).
 
 ### Step 6: Add node metadata
 
@@ -421,7 +410,7 @@ Add the following code to the JSON file:
 }
 ```
 
-For more information on these parameters, refer to [Node codex files](/integrations/creating-nodes/build/reference/node-codex-files.md).
+For more information on these parameters, refer to [Node codex files](https://docs.n8n.io/integrations/creating-nodes/build/reference/node-codex-files/).
 
 ### Step 7: Update the npm package details
 
@@ -477,112 +466,14 @@ Your npm package details are in the `package.json` at the root of the project. I
 
 You need to update the `package.json` to include your own information, such as your name and repository URL. For more information on npm `package.json` files, refer to [npm's package.json documentation](https://docs.npmjs.com/cli/v8/configuring-npm/package-json).
 
+
 ## Test your node
 
-You can test your node as you build it by running it in a local n8n instance.
-
-1. Install n8n using npm:
-
-    ```shell
-    npm install n8n -g
-    ```
-
-2. When you are ready to test your node, build it:
-
-    ```shell
-    # In your node directory
-    npm run build
-    ```
-
-3. Install the node globally:
-
-    ```shell
-    npm install -g .
-    ```
-
-4. Start n8n:
-
-    ```shell
-    n8n start
-    ```
-
-5. Open n8n in your browser. You should see your nodes when you search for them in the nodes panel.
-
-/// note | Node names
-Make sure you search using the node name, not the package name. For example, if your npm package name is `n8n-nodes-weather-nodes`, and the package contains nodes named `rain`, `sun`, `snow`, you should search for `rain`, not `weather-nodes`.
-///
-
-## Troubleshooting
-
-If you don't see your custom node:
-
-1. **Check that the node was built successfully** - ensure the `dist/` folder contains compiled `.js` files
-2. **Verify the package.json `n8n` section** - ensure the paths to your node files are correct
-3. **Check n8n startup logs** - look for messages about loading your node package
-4. **Hard refresh your browser** - press `Ctrl+Shift+R` (Windows/Linux) or `Cmd+Shift+R` (Mac)
-5. **Check Node.js version** - ensure you're using Node.js v22 or higher
-
-## Migration Notes for Existing Nodes
-
-If you're updating an existing node from an older tutorial:
-
-### Updated Imports
-
-**Old (❌ Incorrect):**
-```typescript
-import { IExecuteFunctions } from 'n8n-core';
-import { INodeType } from 'n8n-workflow';
-import { OptionsWithUri } from 'request';
-```
-
-**New (✅ Correct):**
-```typescript
-import {
-	IExecuteFunctions,
-	INodeType,
-	IRequestOptions,
-} from 'n8n-workflow';
-```
-
-### Updated Connection Types
-
-**Old (❌ Incorrect):**
-```typescript
-inputs: ['main'],
-outputs: ['main'],
-```
-
-**New (✅ Correct):**
-```typescript
-inputs: [NodeConnectionType.Main],
-outputs: [NodeConnectionType.Main],
-```
-
-### Updated HTTP Requests
-
-**Old (❌ Incorrect):**
-```typescript
-const options: OptionsWithUri = {
-	uri: 'https://api.example.com/endpoint',
-	// ...
-};
-await this.helpers.request(options);
-```
-
-**New (✅ Correct):**
-```typescript
-const options: IRequestOptions = {
-	url: 'https://api.example.com/endpoint',
-	// ...
-};
-await this.helpers.httpRequest(options);
-// Or with authentication:
-await this.helpers.httpRequestWithAuthentication.call(this, 'credentialType', options);
-```
+--8<-- "_snippets/integrations/creating-nodes/testing.md"
 
 ## Next steps
 
-* [Deploy your node](/integrations/creating-nodes/deploy/).
+* [Deploy your node](https://docs.n8n.io/integrations/creating-nodes/deploy/).
 * View an example of a programmatic node: n8n's [Mattermost node](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/nodes/Mattermost). This is an example of a more complex programmatic node structure.
-* Learn about [node versioning](/integrations/creating-nodes/build/reference/node-versioning.md).
+* Learn about [node versioning](https://docs.n8n.io/integrations/creating-nodes/build/reference/node-versioning/).
 * Make sure you understand key concepts: [item linking](/data/data-mapping/data-item-linking/item-linking-concepts.md) and [data structures](/data/data-structure.md).


### PR DESCRIPTION
## Summary
Fixes outdated node tutorial with deprecated APIs causing build failures.

## Changes
- Import from `n8n-workflow` not `n8n-core`
- Use `NodeConnectionType.Main` enum not strings
- Use `IRequestOptions` not `OptionsWithUri`
- Update to modern HTTP helpers
- Add CLI tool recommendation

## Fixes
#3206 
