### PR TITLE
Correct wait time cutoff

### DIFF
--- a/docs/2-0-breaking-changes.md
+++ b/docs/2-0-breaking-changes.md
@@ -16,7 +16,7 @@ The release of n8n 2.0 continues n8n's commitment to providing a secure, reliabl
 
 Previously, when an execution (parent) called a sub-execution (child) that contained a node that causes the sub-execution to enter the waiting state and the parent-execution is set up to wait for the sub-execution's completion, the parent-execution would receive incorrect results.
 
-Entering the waiting state would happen for example if the sub-execution contains a Wait node with a timeout higher than 60 seconds or a webhook call or a form submission, or a human-in-the-loop node, like the slack node.
+Entering the waiting state would happen for example if the sub-execution contains a Wait node with a timeout higher than 65 seconds or a webhook call or a form submission, or a human-in-the-loop node, like the slack node.
 
 Parent-Workflow:
 ![Parent-Workflow](/_images/v2/parentworkflow1.png)


### PR DESCRIPTION
The docs describe the cutoff between a short wait -- where we don't actually go to `waiting` state -- and a long wait as 60s, but it should be 65s [as seen in the code](https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/Wait/Wait.node.ts#L570).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the docs to reflect the correct Wait node cutoff: timeouts higher than 65 seconds (not 60) enter the waiting state, matching the implementation.
This clarifies when short waits do not transition to waiting.

<sup>Written for commit f5187c2ce03bf105d90ed0f6e7c43d844f17421c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

