### PR TITLE
docs: add rustfs as object storage support for S3 node

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.s3.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.s3.md
@@ -14,6 +14,7 @@ Use the S3 node for non-AWS S3 solutions like:
 * [MinIO](https://min.io/)
 * [Wasabi](https://wasabi.com/)
 * [Digital Ocean spaces](https://www.digitalocean.com/products/spaces)
+* [RustFS](https://rustfs.com)
 
 On this page, you'll find a list of operations the S3 node supports and links to more resources.
 

--- a/docs/integrations/builtin/credentials/s3.md
+++ b/docs/integrations/builtin/credentials/s3.md
@@ -18,6 +18,7 @@ Create an account on an S3-compatible server. Use the S3 node for generic or non
 * [DigitalOcean Spaces](https://www.digitalocean.com/products/spaces)
 * [MinIO](https://min.io/)
 * [Wasabi](https://wasabi.com/)
+* [RustFS](https://rustfs.com)
 
 ## Supported authentication methods
 


### PR DESCRIPTION
Recently, minio announced the [minio/minio](https://github.com/minio/minio) repo will be under maintenance mode, [RustFS](https://rustfs.com) is as an alternative to replace the minio. RustFS is also an object storage open source project licensed with Apache 2.0, and now has more than 16k star. So add the RustFS as a object storage support for S3 node.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added RustFS to the S3 node and credentials docs as a supported S3-compatible object storage provider.

<sup>Written for commit 8c4715025afc069347143d42d20a9cdfa479cf79. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





