### PR TITLE
Add Start node deprecation to v2.0 breaking changes

### DIFF
--- a/docs/2-0-breaking-changes.md
+++ b/docs/2-0-breaking-changes.md
@@ -40,8 +40,8 @@ The Start node is no longer supported. This node was the original way to begin w
 
 **Migration path:** Replace the Start node based on how you use your workflow:
 
-- **Manual executions:** Replace the Start node with a [Manual Trigger](/integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger/) node.
-- **Sub-workflows:** If another workflow calls this workflow as a sub-workflow, replace the Start node with an [Execute Workflow Trigger](/integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger/) node and activate the workflow.
+- **Manual executions:** Replace the Start node with a [Manual Trigger](/integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger.md) node.
+- **Sub-workflows:** If another workflow calls this workflow as a sub-workflow, replace the Start node with an [Execute Workflow Trigger](/integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger.md) node and activate the workflow.
 - **Disabled Start nodes:** If the Start node is disabled, delete it from the workflow.
 
 ### Removed nodes for retired services


### PR DESCRIPTION
## Summary
- Adds documentation for the Start node deprecation in n8n v2.0
- Includes migration paths for replacing the Start node with Manual Trigger or Execute Workflow Trigger
- Documents that disabled Start nodes should be deleted









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the Start node removal in n8n v2.0 and adds clear migration guidance. Shows how to replace Start with Manual Trigger for manual runs, or Execute Workflow Trigger and activate the workflow for sub-workflows, and to delete disabled Start nodes.

<sup>Written for commit d5070b647742bb36a4772b7d8b53ee121874062f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









