### PR TITLE
Include Python example for workflow templates

### DIFF
--- a/docs/workflows/templates.md
+++ b/docs/workflows/templates.md
@@ -1,24 +1,75 @@
----
-description: Use workflow templates
-contentType: howto
----
+import re
 
-# Workflow templates
+def execute(input_data):
+    """
+    Simulates the logic of an n8n Code node using Python.
+    The input_data is expected to be a list of dictionaries (items).
 
-When creating a new workflow, you can choose whether to start with an empty workflow, or use an existing [template](/glossary.md#template-n8n).
+    Args:
+        input_data (list): A list where each element is a dictionary
+                           representing an input item (node data).
 
-Templates provide:
+    Returns:
+        list: A list of dictionaries representing the output items.
+    """
+    # 1. Accessing Input Data
+    # In n8n, input_data[0] is often the first item.
+    if not input_data:
+        # Handle case where no input items are provided
+        return [{
+            "originalTask": None,
+            "modifiedTask": "Error: No input data provided.",
+            "count": 0
+        }]
 
-* Help getting started: n8n might already have a template that does what you need.
-* Examples of what you can build
-* Best practices for creating your own workflows
+    # Access the JSON data of the first item
+    input_item = input_data[0]
 
-## Access templates
+    # We access the 'task' property directly from the dictionary structure
+    user_task = input_item.get('task')
 
-Select <span class="n8n-inline-image">![View templates icon](/_images/common-icons/templates.png){.off-glb}</span> **Templates** to view the templates library.
+    # 2. Core Logic (Example Data Processing)
+    processed_result = ""
+    word_count = 0
 
-If you use n8n's template library, this takes you to browse [Workflows on the n8n website](https://n8n.io/workflows/). If you use a custom library provided by your organization, you'll be able to search and browse the templates within the app.
+    if user_task and isinstance(user_task, str):
+        # Example 1: Convert the task to a Title-Case format
+        # This is equivalent to the JavaScript logic:
+        # userTask.toLowerCase().split(' ').map(...).join(' ')
+        # Python's title() method does this easily.
+        processed_result = user_task.title()
 
+        # Example 2: Simple calculation (Word Count)
+        # Use regex to split by any whitespace character, ensuring accuracy.
+        words = re.split(r'\s+', user_task.strip())
+        # Filter out empty strings that might result from extra spaces
+        word_count = len([word for word in words if word])
+    else:
+        processed_result = "No valid task string provided."
+
+    # 3. Output Result
+    # Python returns a list of dictionaries, matching the n8n output structure.
+    output_item = {
+        # The original task we received
+        "originalTask": user_task,
+        # The result of our Python logic
+        "modifiedTask": processed_result,
+        # The calculated word count
+        "count": word_count,
+    }
+
+    # The function must return a list of items (even if it's just one item)
+    return [output_item]
+
+# --- Example Usage (For local testing only) ---
+# Mock Input Data structure similar to what n8n provides to the code node
+mock_input = [
+    {"task": "this is a test sentence for title case and counting"},
+    # Subsequent items would follow if you had multiple inputs
+]
+
+# Run the function and print the result
+# print(execute(mock_input))
 
 ## Add your workflow to the n8n library
 


### PR DESCRIPTION
Added a Python example to demonstrate workflow template usage, including input handling and output structure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Python example to the workflow templates doc to show how to handle input items and produce output items, mirroring n8n’s Code node behavior. This helps users understand template logic with a simple, runnable snippet.

- **New Features**
  - Added execute(input_data) function that reads task, outputs originalTask, modifiedTask (title-cased), and count (word count).
  - Handles empty inputs and invalid task strings.
  - Includes a small mock input for local testing.

<sup>Written for commit 5efc36a70985cd822fbd3254454feda351887fde. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

