### PR TITLE
corrected the fact that admins can install nodes from npm on self-hosted

### DIFF
--- a/docs/integrations/community-nodes/installation/gui-install.md
+++ b/docs/integrations/community-nodes/installation/gui-install.md
@@ -4,10 +4,8 @@ contentType: howto
 
 # Install community nodes from npm in the n8n app
 
-/// note | Only for instance owners of self-hosted n8n instances
-Only the n8n instance owner of a self-hosted n8n instance can install and manage community nodes from npm. The instance owner is the person who sets up and manages user management.
-
-Admin accounts can also uninstall any community node, verified or unverified. This helps them remove problematic nodes that may affect the instance's health and functionality.
+/// note | Owner and Admin users only
+Only users with an Owner or Admin role can install and manage community nodes from npm on a self-hosted n8n instance. The instance owner is the person who sets up and manages user management.
 ///
 
 ## Install a community node


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the GUI install docs to clarify that on self-hosted n8n, both Owner and Admin users can install and manage community nodes from npm (not just the instance owner).

<sup>Written for commit 11a69fcef9e088a4d1bf27ff8417a82f87b22efd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

