### PR TITLE
Release note updates

### DIFF
--- a/_snippets/self-hosting/installation/latest-next-version.md
+++ b/_snippets/self-hosting/installation/latest-next-version.md
@@ -1,6 +1,6 @@
 /// note | Stable and Beta versions
 n8n releases a new minor version most weeks. The `stable` version is for production use. `beta` is the most recent release. The `beta` version may be unstable. To report issues, use the [forum](https://community.n8n.io/c/questions/12).
 
-Current `stable`: 1.123.4
-Current `beta`: 2.0.0
+Current `stable`: 1.123.5
+Current `beta`: 2.0.1
 ///

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,6 +32,15 @@ n8n uses [semantic versioning](https://semver.org/). All version numbers are in 
 You can find the release notes for older versions of n8n: [1.x](/release-notes/1-x.md) and [0.x](/release-notes/0-x.md)
 ///
 
+## n8n@2.0.1
+
+View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.0.0...n8n@2.0.1) for this version.<br />
+**Release date:** 2025-12-10
+
+This release contains bug fixes.
+
+For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
+
 ## n8n@2.0.0
 
 View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.0.0-rc.3...n8n@2.0.0) for this version.<br />

--- a/docs/release-notes/1-x.md
+++ b/docs/release-notes/1-x.md
@@ -43,6 +43,15 @@ This release contains bug fixes.
 
 For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
 
+## n8n@1.123.5
+
+View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.123.4...n8n@1.123.5) for this version.<br />
+**Release date:** 2025-12-10
+
+This release contains bug fixes.
+
+For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
+
 
 ## n8n@1.123.3
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated release notes and version snippet: added entries for n8n@2.0.1 and n8n@1.123.5 (bug-fix releases) and set current stable to 1.123.5 and beta to 2.0.1. Keeps docs current and links users to commit diffs and GitHub Releases.

<sup>Written for commit 027b5e6bf27c4d40bbdb12376fe3635f6bf7cfc2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

