### PR TITLE
:rocket: Release note 1.123.5

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,6 +32,17 @@ n8n uses [semantic versioning](https://semver.org/). All version numbers are in 
 You can find the release notes for older versions of n8n: [1.x](/release-notes/1-x.md) and [0.x](/release-notes/0-x.md)
 ///
 
+
+
+## n8n@1.123.5
+
+View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.123.0...n8n@1.123.5) for this version.<br />
+**Release date:** 2025-12-12
+
+This release contains bug fixes.
+
+For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
+
 ## n8n@2.0.1
 
 View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.0.0...n8n@2.0.1) for this version.<br />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add n8n@1.123.5 to docs/release-notes.md, marking it as a bug-fix release with links to the commit diff and the GitHub Releases page. Includes the 2025-12-12 release date.

<sup>Written for commit cb60449f4ae77b4d19cbcc6cc7a6e8c94d7f898a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

