### PR TITLE
:rocket: Release note 2.1.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,6 +32,23 @@ n8n uses [semantic versioning](https://semver.org/). All version numbers are in 
 You can find the release notes for older versions of n8n: [1.x](/release-notes/1-x.md) and [0.x](/release-notes/0-x.md)
 ///
 
+
+
+## n8n@2.1.0
+
+View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.0.0...n8n@2.1.0) for this version.<br />
+**Release date:** 2025-12-15
+
+This release contains bug fixes.
+
+### Contributors
+
+[Akcthecoder200](https://github.com/Akcthecoder200)  
+[rishiraj-58](https://github.com/rishiraj-58)  
+[rlafferty](https://github.com/rlafferty)  
+
+For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
+
 ## n8n@2.1.0
 
 View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.0.0...n8n@2.1.0) for this version.<br />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add 2.1.0 release notes to the docs with release date, bug-fix summary, contributors, and links to commits and the full GitHub release. Keeps the release notes current for users.

<sup>Written for commit fab4fc755b5451457f317593e00619a546ba0c02. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

