### PR TITLE
update latest next

### DIFF
--- a/_snippets/self-hosting/installation/latest-next-version.md
+++ b/_snippets/self-hosting/installation/latest-next-version.md
@@ -1,6 +1,6 @@
 /// note | Stable and Beta versions
 n8n releases a new minor version most weeks. The `stable` version is for production use. `beta` is the most recent release. The `beta` version may be unstable. To report issues, use the [forum](https://community.n8n.io/c/questions/12).
 
-Current `stable`: 2.0.2
-Current `beta`: 2.1.0
+Current `stable`: 2.0.3
+Current `beta`: 2.1.1
 ///


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update self-hosting installation docs to reflect current releases. Stable is now 2.0.3 and beta is 2.1.1 so users install the correct versions.

<sup>Written for commit 529fe3c3362a4b4d3292d61b248e86d396a03073. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

