### PR TITLE
feat: Add Atals Cloud model node

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatatlascloud.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatatlascloud.md
@@ -1,0 +1,77 @@
+---
+title: Atlas Cloud Chat Model node documentation
+description: Learn how to use the Atlas Cloud Chat Model node in n8n. Follow technical documentation to integrate Atlas Cloud Chat Model node into your workflows.
+contentType: [integration, reference]
+priority: high
+---
+
+# Atlas Cloud Chat Model node
+
+Use the Atlas Cloud Chat Model node to use Atlas Cloud's chat models with conversational [agents](/glossary.md#ai-agent).
+
+On this page, you'll find the node parameters for the Atlas Cloud Chat Model node and links to more resources.
+
+/// note | Credentials
+You can find authentication information for this node [here](/integrations/builtin/credentials/atlascloud.md).
+///
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
+
+## Node parameters
+
+### Model
+
+Select the model to use to generate the completion.
+
+n8n dynamically loads models from Atlas Cloud and you'll only see the models available to your account.
+
+## Node options
+
+Use these options to further refine the node's behavior.
+
+### Base URL
+
+Enter a URL here to override the default URL for the API.
+
+### Frequency Penalty
+
+Use this option to control the chances of the model repeating itself. Higher values reduce the chance of the model repeating itself.
+
+### Maximum Number of Tokens
+
+Enter the maximum number of tokens used, which sets the completion length.
+
+### Response Format
+
+Choose **Text** or **JSON**. **JSON** ensures the model returns valid JSON.
+
+### Presence Penalty
+
+Use this option to control the chances of the model talking about new topics. Higher values increase the chance of the model talking about new topics.
+
+### Sampling Temperature
+
+Use this option to control the randomness of the sampling process. A higher temperature creates more diverse sampling, but increases the risk of hallucinations.
+
+### Timeout
+
+Enter the maximum request time in milliseconds.
+
+### Max Retries
+
+Enter the maximum number of times to retry a request.
+
+### Top P
+
+Use this option to set the probability the completion should use. Use a lower value to ignore less probable options.
+
+## Templates and examples
+
+<!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->
+[[ templatesWidget(page.title, 'atlas-cloud-chat-model') ]]
+
+## Related resources
+
+As Atlas Cloud is API-compatible with OpenAI, you can refer to [LangChain's OpenAI documentation](https://js.langchain.com/docs/integrations/chat/openai/) for more information about the service.
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"

--- a/docs/integrations/builtin/credentials/atlascloud.md
+++ b/docs/integrations/builtin/credentials/atlascloud.md
@@ -1,0 +1,39 @@
+---
+title: Atlas Cloud credentials
+description: Documentation for the Atlas Cloud credentials. Use these credentials to authenticate the Atlas Cloud in n8n, a workflow automation platform.
+contentType: [integration, reference]
+priority: critical
+---
+
+# Atlas Cloud credentials
+
+You can use these credentials to authenticate the following nodes:
+
+- [Chat Atlas Cloud](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatatlascloud.md)
+
+## Prerequisites
+
+Create an [Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=n8n_docs) account.
+
+## Supported authentication methods
+
+- API key
+
+## Related resources
+
+Refer to the [Atlas Cloud documentation](https://www.atlascloud.ai/docs) for more information about the service.
+
+## Using API key
+
+To configure this credential, you'll need:
+
+- An **API Key**
+
+To generate your API Key:
+
+1. [Login to Atlas Cloud](https://console.atlascloud.ai/) or [create an account](https://www.atlascloud.ai/login?utm_source=github&utm_medium=link&utm_campaign=n8n_docs).
+2. Open your [API keys](https://console.atlascloud.ai/settings) page.
+3. Select **Create API Key** to create an API key, optionally naming the key.
+4. Copy your key and add it as the **API Key** in n8n.
+
+Refer to the [Get Started](https://www.atlascloud.ai/docs/models/get-start) page for more information.

--- a/nav.yml
+++ b/nav.yml
@@ -748,6 +748,7 @@ nav:
           - Embeddings Ollama: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsollama.md
           - Embeddings OpenAI: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsopenai.md
           - Anthropic Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatanthropic.md
+          - Atlas Cloud Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatatlascloud.md
           - AWS Bedrock Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatawsbedrock.md
           - Azure OpenAI Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatazureopenai.md
           - Cohere Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatcohere.md
@@ -818,6 +819,7 @@ nav:
         - integrations/builtin/credentials/alienvault.md
         - integrations/builtin/credentials/amqp.md
         - integrations/builtin/credentials/anthropic.md
+        - integrations/builtin/credentials/atlascloud.md
         - integrations/builtin/credentials/apitemplateio.md
         - integrations/builtin/credentials/asana.md
         - integrations/builtin/credentials/auth0management.md


### PR DESCRIPTION
Documentation update linked to https://github.com/n8n-io/n8n/pull/23518



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added docs for the Atlas Cloud Chat Model node and Atlas Cloud credentials so users can use Atlas Cloud chat models in n8n with API key auth. Updated navigation to surface both pages.

<sup>Written for commit bdaf6969c097ded74d4dc0809f2e71b3eb4ffafe. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



