### PR TITLE
Add details for output field options in documentation

### DIFF
--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.aggregate.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.aggregate.md
@@ -27,6 +27,7 @@ Refer to [Node options](#node-options) for more configuration options.
 ### All Item Data
 
 * **Put Output in Field**: Enter the name of the field to output the data in.
+* 
 * **Include**: Select which fields to include in the output. Choose from:
 	* **All fields**: The output includes data from all fields with no further parameters.
 	* **Specified Fields**: If you select this option, enter a comma-separated list of fields the output should include data from in the **Fields To Include** parameter. The output will include only the fields in this list.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified the Aggregate node’s All Item Data options, documenting how to set the output field and how field inclusion works. This helps users configure “Put Output in Field” and choose between all fields or specified fields.

<sup>Written for commit b720db292973f59cfcee9c241be3f07972d7789e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

