### PR TITLE
:rocket: Release note 2.1.5

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,6 +32,17 @@ n8n uses [semantic versioning](https://semver.org/). All version numbers are in 
 You can find the release notes for older versions of n8n: [1.x](/release-notes/1-x.md) and [0.x](/release-notes/0-x.md)
 ///
 
+
+
+## n8n@2.1.5
+
+View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.1.4...n8n@2.1.5) for this version.<br />
+**Release date:** 2025-12-30
+
+This release contains bug fixes.
+
+For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
+
 ## n8n@2.2.0
 
 View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.1.0...n8n@2.2.0) for this version.<br />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add release notes for n8n 2.1.5 in docs/release-notes.md.

Notes it’s a bug-fix-only release, includes the release date, and links to the commit compare and GitHub Releases for details.

<sup>Written for commit 5a5f80f90c74f8cb508c155afe7dfe200309829f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

