### PR TITLE
Correct data table storage limit to apply across the instance, not per table

### DIFF
--- a/docs/data/data-tables.md
+++ b/docs/data/data-tables.md
@@ -49,8 +49,8 @@ See [Data table node](/integrations/builtin/core-nodes/n8n-nodes-base.datatable/
 
 ## Considerations and limitations of data tables
 
-- Data tables are suitable for light to moderate data storage. By default, a data table can't contain more than 50MB of data. In self-hosted environments, you can increase this default size limit using the environment variable `N8N_DATA_TABLES_MAX_SIZE_BYTES`.
-- When a data table approaches 80% of your storage limit, a warning will alert you. A final warning appears when you reach the storage limit. Exceeding this limit will disable manual additions to tables and cause workflow execution errors during attempts to insert or update data.
+- Data tables are suitable for light to moderate data storage. By default, the total storage used by all data tables in an instance is limited to 50MB. In self-hosted environments, you can increase this default size limit using the environment variable `N8N_DATA_TABLES_MAX_SIZE_BYTES`.
+- When your data tables approach 80% of your storage limit, a warning will alert you. A final warning appears when you reach the storage limit. Exceeding this limit will disable manual additions to tables and cause workflow execution errors during attempts to insert or update data.
 - By default, data tables created within a project are accessible to all team members in that project.
 - Tables created in a **Personal** space are only accessible by their creator.
 


### PR DESCRIPTION
Spotted by David Mocilac!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected data tables documentation to state the 50MB storage cap applies across the instance, not per table. Updated warning language to reference total usage with alerts at 80% and at the limit.

<sup>Written for commit 9e7cb25330f290b0d00f8f0801a8c7d6f8f346a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

