### PR TITLE
:rocket: Release note 2.3.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,6 +32,25 @@ n8n uses [semantic versioning](https://semver.org/). All version numbers are in 
 You can find the release notes for older versions of n8n: [1.x](/release-notes/1-x.md) and [0.x](/release-notes/0-x.md)
 ///
 
+
+
+## n8n@2.3.0
+
+View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.2.0...n8n@2.3.0) for this version.<br />
+**Release date:** 2026-01-05
+
+This release contains bug fixes.
+
+### Contributors
+
+[Shashwat-06](https://github.com/Shashwat-06)  
+[ByteEVM](https://github.com/ByteEVM)  
+[mithredate](https://github.com/mithredate)  
+[belyas](https://github.com/belyas)  
+[saurabhssonkar](https://github.com/saurabhssonkar)  
+
+For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
+
 ## n8n@2.2.0
 
 View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.1.0...n8n@2.2.0) for this version.<br />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added release notes for n8n 2.3.0 to the docs, including release date, links to commits and full release details, and a contributors list. This makes the 2.3.0 bug fix release discoverable in our documentation.

<sup>Written for commit a588f60a7bd66c9238e55dca4c9349ffd623af91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

