### PR TITLE
:rocket: Release note 2.2.4

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,6 +32,17 @@ n8n uses [semantic versioning](https://semver.org/). All version numbers are in 
 You can find the release notes for older versions of n8n: [1.x](/release-notes/1-x.md) and [0.x](/release-notes/0-x.md)
 ///
 
+
+
+## n8n@2.2.4
+
+View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.2.3...n8n@2.2.4) for this version.<br />
+**Release date:** 2026-01-06
+
+This release contains a bug fix.
+
+For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
+
 ## n8n@2.3.0
 
 View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.2.0...n8n@2.3.0) for this version.<br />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added release notes for n8n@2.2.4 with the release date and links to commits and full details on GitHub. Clarifies that this version is a bug fix release and keeps docs up to date.

<sup>Written for commit 044b95191dc2a2b7a32b10e58941016f3875c9ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

