### PR TITLE
Adding new environment variable for workflow history

### DIFF
--- a/docs/hosting/configuration/environment-variables/workflow-history.md
+++ b/docs/hosting/configuration/environment-variables/workflow-history.md
@@ -1,0 +1,16 @@
+---
+title: Workflow history environment variables
+description: Environment variables to configure workflow history in n8n.
+contentType: reference
+tags:
+  - environment variables
+hide:
+  - toc
+  - tags
+---
+
+# Workflow history environment variables
+
+| Variable | Type  | Default  | Description |
+| :------- | :---- | :------- | :---------- |
+| `N8N_WORKFLOW_HISTORY_PRUNE_TIME` | Number | `-1` | How long to keep workflow history versions before automatically deleting them (in hours). Set to `-1` to keep all versions indefinitely. |

--- a/nav.yml
+++ b/nav.yml
@@ -1220,6 +1220,7 @@ nav:
         - Timezone and localization: hosting/configuration/environment-variables/timezone-localization.md
         - User management and 2FA: hosting/configuration/environment-variables/user-management-smtp-2fa.md
         - Workflows: hosting/configuration/environment-variables/workflows.md
+        - Workflow history: hosting/configuration/environment-variables/workflow-history.md
       - Configuration methods: hosting/configuration/configuration-methods.md
       - Configuration examples:
         - hosting/configuration/configuration-examples/index.md


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added documentation for N8N_WORKFLOW_HISTORY_PRUNE_TIME to control how long workflow history versions are kept (in hours), with -1 to keep indefinitely. Linked the new page in the Environment Variables navigation.

<sup>Written for commit a0ddff3d3012464fe6324bc55c642272cd060ecb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

