### PR TITLE
feat(Pipedrive Node): Add searching for leads

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.pipedrive.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.pipedrive.md
@@ -50,6 +50,7 @@ Refer to [Pipedrive credentials](/integrations/builtin/credentials/pipedrive.md)
     * Delete a lead
     * Get data of a lead
     * Get data of all leads
+    * Search a lead
     * Update a lead
 * Note
     * Create a note


### PR DESCRIPTION
This is the follow-up docs update PR for [#24022](https://github.com/n8n-io/n8n/pull/24022)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added “Search a lead” to the Pipedrive node docs to reflect the new lead search operation. This makes it clear users can now search leads in Pipedrive from n8n.

<sup>Written for commit bfc02611873832e7ea94987ec6e3ba08b4ae66dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

