### PR TITLE
Support PR: LDAP and SAML are also available on the Business plan

### DIFF
--- a/_snippets/user-management/sso-saml-availability.md
+++ b/_snippets/user-management/sso-saml-availability.md
@@ -1,4 +1,4 @@
 /// info | Feature availability
-* Available on Enterprise plans.
+* Available on Business and Enterprise plans.
 * You need to be an instance owner or admin to enable and configure SAML.
 ///	

--- a/docs/user-management/ldap.md
+++ b/docs/user-management/ldap.md
@@ -6,7 +6,7 @@ contentType: howto
 # Lightweight Directory Access Protocol (LDAP)
 
 /// info | Feature availability
-* Available on Self-hosted Enterprise and Cloud Enterprise plans.
+* Available on Self-hosted Business and Enterprise, and Cloud Enterprise plans.
 * You need access to the n8n instance owner account.
 ///
 


### PR DESCRIPTION
We state on the [pricing page](https://n8n.io/pricing/) that LDAP and SAML are available on the Business plan, but on the docs, we only stated that it was available on Enterprise. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated docs to reflect that LDAP and SAML are available on Business plans, matching the pricing page. SAML now shows “Business and Enterprise”; LDAP now shows “Self-hosted Business and Enterprise, and Cloud Enterprise.”

<sup>Written for commit faf9229617eecb1ac3a64b5dcc5c32bd9f07a9f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

