### PR TITLE
docs: Add critical security update notice to release notes

### DIFF
--- a/docs/release-notes/1-x.md
+++ b/docs/release-notes/1-x.md
@@ -343,6 +343,12 @@ View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.120.0...n8n@1.121
 **Release date:** 2025-11-18
 
 <div class="n8n-new-features" markdown>
+### Critical security update
+
+This release contains a critical security update. For more information, see [Security Advisory: Security Vulnerability in n8n Versions 1.65-1.120.4](https://blog.n8n.io/security-advisory-20260108/).
+</div>
+
+<div class="n8n-new-features" markdown>
 ### Instance-level MCP connections (beta)
 
 You can now enable MCP connections at the instance level, giving MCP-compatible AI platforms access to all selected workflows through a single oAuth-secured connection.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a critical security update notice to the 1.x release notes with a direct link to the advisory covering versions 1.65–1.120.4, making the risk and remediation guidance easy to find.

<sup>Written for commit 1003ea276cd93e1f299bd666b2eaf431f14cda6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

