### PR TITLE
docs: Add N8N_AI_TIMEOUT_MAX environment variable

### DIFF
--- a/docs/hosting/configuration/environment-variables/executions.md
+++ b/docs/hosting/configuration/environment-variables/executions.md
@@ -20,6 +20,7 @@ This page lists environment variables to configure workflow execution settings.
 | `EXECUTIONS_MODE` | Enum string: `regular`, `queue` | `regular` | Whether executions should run directly or using queue.<br><br>Refer to [Queue mode](/hosting/scaling/queue-mode.md) for more details. |
 | `EXECUTIONS_TIMEOUT` | Number | `-1` | Sets a default timeout (in seconds) to all workflows after which n8n stops their execution. Users can override this for individual workflows up to the duration set in `EXECUTIONS_TIMEOUT_MAX`. Set `EXECUTIONS_TIMEOUT` to `-1` to disable. |
 | `EXECUTIONS_TIMEOUT_MAX` | Number | `3600` | The maximum execution time (in seconds) that users can set for an individual workflow. |
+| `N8N_AI_TIMEOUT_MAX` | Number | `3600000` | Sets the HTTP request timeout in milliseconds for AI and LLM nodes (such as OpenAI, Anthropic, Mistral, and Ollama). This controls how long n8n waits for responses from AI services before timing out. Useful for slower local AI services or complex prompts that require longer processing time. |
 | `EXECUTIONS_DATA_SAVE_ON_ERROR` | Enum string: `all`, `none` | `all` | Whether n8n saves execution data on error. |
 | `EXECUTIONS_DATA_SAVE_ON_SUCCESS` | Enum string: `all`, `none` | `all` | Whether n8n saves execution data on success. |
 | `EXECUTIONS_DATA_SAVE_ON_PROGRESS` | Boolean | `false` | Whether to save progress for each node executed (true) or not (false). |


### PR DESCRIPTION
## Summary                                                                
Documents the new `N8N_AI_TIMEOUT_MAX` environment variable for configuring HTTP request timeouts on AI/LLM nodes                         
                                                                            
## Related                                                                
n8n PR: https://github.com/n8n-io/n8n/pull/24292
Linear ticket: https://linear.app/n8n/issue/DOC-1722/docs-for-community-issue-ai-nodes-timeout-after-5m                     
                                                                            
## Details                                                                
Added to the executions environment variables page since it controls timeout behavior, alongside existing `EXECUTIONS_TIMEOUT` and `EXECUTIONS_TIMEOUT_MAX` variables.                                       
                                                                            
The variable sets the HTTP request timeout (in milliseconds) for AI nodes including OpenAI, Anthropic, Mistral, Ollama, and others. Default is 3,600,000ms (1 hour).    

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added documentation for the N8N_AI_TIMEOUT_MAX environment variable on the executions configuration page. It sets the HTTP request timeout in milliseconds for LLM nodes (e.g., OpenAI, Anthropic, Mistral, Ollama); default is 3,600,000 ms (1 hour).

<sup>Written for commit 6013e556fed9032632a56b285b675b4adacbd213. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

