### PR TITLE
docs: Remove outdated link to credentials management section

### DIFF
--- a/docs/integrations/builtin/credentials/index.md
+++ b/docs/integrations/builtin/credentials/index.md
@@ -6,6 +6,4 @@ contentType: overview
 
 This section contains step-by-step information about authenticating the different nodes in n8n.
 
-To learn more about creating, managing, and sharing credentials, refer to [Manage credentials](/credentials/index.md).
-
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed an outdated link to the credentials management docs from the built-in credentials overview. Prevents sending readers to a dead or incorrect page.

<sup>Written for commit 48a85d2650d58031e7d1fdb264478584212bbe41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

