### PR TITLE
docs: Update Stripe credentials to mention SIgnature Secret

### DIFF
--- a/docs/integrations/builtin/credentials/stripe.md
+++ b/docs/integrations/builtin/credentials/stripe.md
@@ -14,17 +14,13 @@ You can use these credentials to authenticate the following nodes:
 
 ## Supported authentication methods
 
-- API key
+- Secret key
+
+You'll also need a Stripe **Signature Secret** or endpoint secret, which is a unique key for each webhook endpoint used to verify incoming requests, ensuring they truly came from Stripe.
 
 ## Related resources
 
-Refer to [Stripe's API documentation](https://docs.stripe.com/api) for more information about the service.
-
-## Using API key
-
-To configure this credential, you'll need a [Stripe](https://stripe.com/) admin or developer account and:
-
-- An API **Secret Key**
+To configure this credential, you'll need a Stripe admin or developer account. Refer to [Stripe's API documentation](https://docs.stripe.com/api) for more information about the service.
 
 Before you generate an API key, decide whether to generate it in live mode or test mode. Refer to [Test mode and live mode](#test-mode-and-live-mode) for more information about the two modes.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified Stripe credential docs to use “Secret key” and documented the need for a Stripe Signature Secret (endpoint secret) to verify webhooks. This reduces confusion and helps users set up secure webhook verification.

<sup>Written for commit adac1aa3cb7f17ffbfab6959d7ffad611547e828. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

