### PR TITLE
docs: Reduce runner task timeout default

### DIFF
--- a/docs/hosting/configuration/environment-variables/task-runners.md
+++ b/docs/hosting/configuration/environment-variables/task-runners.md
@@ -27,7 +27,7 @@ hide:
 | `N8N_RUNNERS_MAX_PAYLOAD` | Number | `1 073 741 824` | Maximum payload size in bytes for communication between a task broker and a task runner. |
 | `N8N_RUNNERS_MAX_OLD_SPACE_SIZE` | String |  | The `--max-old-space-size` option to use for a task runner (in MB). By default, Node.js will set this based on available memory. |
 | `N8N_RUNNERS_MAX_CONCURRENCY` | Number | `5` | The number of concurrent tasks a task runner can execute at a time. |
-| `N8N_RUNNERS_TASK_TIMEOUT` | Number | `300` | The maximum time, in seconds, a task can run before the runner stops it and restarts. This value must be greater than 0. |
+| `N8N_RUNNERS_TASK_TIMEOUT` | Number | `60` | The maximum time, in seconds, a task can run before the runner stops it and restarts. This value must be greater than 0. |
 | `N8N_RUNNERS_HEARTBEAT_INTERVAL` | Number | `30` | The interval, in seconds, at which the runner must send a heartbeat to the broker. If the runner doesn't send a heartbeat in time, the task stops and the runner restarts. This value must be greater than 0. |
 | `N8N_RUNNERS_INSECURE_MODE` | Boolean | `false` | Whether to disable all security measures in the task runner, for compatibility with modules that rely on insecure JS features. **Discouraged for production use.** |
 | `N8N_RUNNERS_TASK_REQUEST_TIMEOUT` | Number | `20` | How long (in seconds) a task request can wait for a runner to become available before timing out. This prevents workflows from hanging indefinitely when no runners are available. Must be greater than 0. |


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated task runners documentation to set N8N_RUNNERS_TASK_TIMEOUT default to 60 seconds (was 300). This shortens how long a task can run before the runner stops and restarts it.

<sup>Written for commit 26c8626cf91a7b76745194e73cccdd1065dfc413. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

https://github.com/n8n-io/n8n/pull/24437