### PR TITLE
docs: add Boond Manager credentials documentation

### DIFF
--- a/docs/integrations/builtin/credentials/boondmanager.md
+++ b/docs/integrations/builtin/credentials/boondmanager.md
@@ -1,0 +1,31 @@
+---
+title: BoondManager credentials
+description: Documentation for BoondManager credentials. Use these credentials to authenticate BoondManager in n8n, a workflow automation platform.
+contentType: [integration, reference]
+---
+
+# BoondManager credentials
+
+--8<-- "_snippets/integrations/builtin/credentials/cred-only-statement.md"
+
+## Prerequisites
+
+Create a [BoondManager](https://www.boondmanager.com/) account.
+
+## Supported authentication methods
+
+- JWT Client
+
+## Related resources
+
+Refer to [BoondManager's API documentation](https://doc.boondmanager.com/api-externe/) for more information about the service.
+
+## Using API key
+
+To configure this credential, you'll need:
+
+- A **User token**
+- A **Client token**
+- A **Client secret**
+
+You can find these tokens in the [BoondManager developer space](https://ui.boondmanager.com/administrator/developer/apisandbox).

--- a/nav.yml
+++ b/nav.yml
@@ -830,6 +830,7 @@ nav:
         - integrations/builtin/credentials/azurestorage.md
         - integrations/builtin/credentials/bamboohr.md
         - integrations/builtin/credentials/bannerbear.md
+        - integrations/builtin/credentials/boondmanager.md
         - integrations/builtin/credentials/baserow.md
         - integrations/builtin/credentials/beeminder.md
         - integrations/builtin/credentials/bitbucket.md


### PR DESCRIPTION
Documentation update linked to https://github.com/n8n-io/n8n/pull/24436

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added documentation for BoondManager credentials to help users set up authentication in n8n. It covers prerequisites, JWT Client auth, and where to find the required user token, client token, and client secret.

<sup>Written for commit 732599ca5f8698470521c6f1a902b1e111930b00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

