### PR TITLE
Support PR: Updating the v2 breaking changes

### DIFF
--- a/docs/2-0-breaking-changes.md
+++ b/docs/2-0-breaking-changes.md
@@ -46,7 +46,7 @@ The Start node is no longer supported. This node was the original way to begin w
 
 ### Saving and publishing workflows
 
-The new workflow publishing system replaces the previous active/inactive toggle. This means that the old "Activate/Deactivate" toggles become the new "Publish/Unpublish" buttons. This change gives you better control over when your workflow changes go live, reducing the risk of accidentally deploying work-in-progress changes to production. More information can be found here: [Saving and publishing workflows.](/docs/workflows/publish.md)
+The new workflow publishing system replaces the previous active/inactive toggle. This means that the old "Activate/Deactivate" toggles become the new "Publish/Unpublish" buttons. This change gives you better control over when your workflow changes go live, reducing the risk of accidentally deploying work-in-progress changes to production. More information can be found here: [Saving and publishing workflows.](/workflows/publish.md)
 
 ### Removed nodes for retired services
 


### PR DESCRIPTION
Updating the v2 breaking changes to address the removal of the activate/deactivate toggle in favor of the new publish/unpublish path. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update v2 breaking changes docs to reflect the new publishing workflow: Activate/Deactivate is now Publish/Unpublish. Adds a “Saving and publishing workflows” section with a link to the full guide to reduce accidental deployments.

<sup>Written for commit 871936e5ac4119b23d5efc443fd790ed05dc45c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

