### PR TITLE
docs: Add query parameters documentation with JSON schema

### DIFF
--- a/query-parameters-documentation.md
+++ b/query-parameters-documentation.md
@@ -1,0 +1,120 @@
+# Query Parameters Documentation
+
+## Overview
+
+This document describes the query parameters used for filtering and retrieving account records.
+
+## Parameters
+
+### numeroConta
+
+- **Type:** String
+- **Required:** Yes
+- **Description:** Número da conta habilitada (Enabled account number)
+- **Example:** `123456`
+
+```
+numeroConta=123456
+```
+
+### dataInicial
+
+- **Type:** String
+- **Required:** Yes
+- **Format:** `yyyy-MM-dd`
+- **Description:** Data inicial (Start date)
+- **Example:** `2025-01-01`
+
+```
+dataInicial=2025-01-01
+```
+
+### dataFinal
+
+- **Type:** String
+- **Required:** Yes
+- **Format:** `yyyy-MM-dd`
+- **Description:** Data final (End date)
+- **Example:** `2025-01-31`
+
+```
+dataFinal=2025-01-31
+```
+
+### situacao
+
+- **Type:** Integer
+- **Required:** Yes
+- **Description:** Situação do registro (Record status)
+- **Example:** `1`
+
+**Options:**
+
+| Value | Label | Description |
+|-------|-------|-------------|
+| `1` | Em aberto | Open |
+| `2` | Agendado | Scheduled |
+| `3` | Liquidado | Settled |
+| `4` | Baixado | Written off |
+
+```
+situacao=1
+```
+
+### tipoData
+
+- **Type:** Integer
+- **Required:** Yes
+- **Description:** Tipo de data para filtro (Date type for filtering)
+- **Example:** `1`
+
+**Options:**
+
+| Value | Label | Description |
+|-------|-------|-------------|
+| `1` | Vencimento | Due date |
+| `2` | Emissão | Issue date |
+| `3` | Inclusão | Inclusion date |
+
+```
+tipoData=1
+```
+
+## Example Request
+
+### Complete URL with Query Parameters
+
+```
+https://api.example.com/endpoint?numeroConta=123456&dataInicial=2025-01-01&dataFinal=2025-01-31&situacao=1&tipoData=1
+```
+
+### Using in n8n HTTP Request Node
+
+In the HTTP Request node, add these parameters under "Send Query Parameters":
+
+| Name | Value |
+|------|-------|
+| `numeroConta` | `123456` |
+| `dataInicial` | `2025-01-01` |
+| `dataFinal` | `2025-01-31` |
+| `situacao` | `1` |
+| `tipoData` | `1` |
+
+### JSON Format
+
+```json
+{
+  "numeroConta": "123456",
+  "dataInicial": "2025-01-01",
+  "dataFinal": "2025-01-31",
+  "situacao": 1,
+  "tipoData": 1
+}
+```
+
+## Usage Notes
+
+- All parameters are required for the request to succeed
+- Date parameters must follow the `yyyy-MM-dd` format
+- The `situacao` parameter controls which records are returned based on their current status
+- The `tipoData` parameter determines which date field is used for the date range filter (dataInicial/dataFinal)

--- a/query-parameters.json
+++ b/query-parameters.json
@@ -1,0 +1,95 @@
+{
+  "queryParameters": [
+    {
+      "name": "numeroConta",
+      "value": "123456",
+      "description": "Número da conta habilitada",
+      "description_en": "Enabled account number",
+      "type": "string",
+      "required": true,
+      "example": "123456"
+    },
+    {
+      "name": "dataInicial",
+      "value": "2025-01-01",
+      "description": "Data inicial",
+      "description_en": "Start date",
+      "type": "string",
+      "format": "yyyy-MM-dd",
+      "required": true,
+      "example": "2025-01-01"
+    },
+    {
+      "name": "dataFinal",
+      "value": "2025-01-31",
+      "description": "Data final",
+      "description_en": "End date",
+      "type": "string",
+      "format": "yyyy-MM-dd",
+      "required": true,
+      "example": "2025-01-31"
+    },
+    {
+      "name": "situacao",
+      "value": "1",
+      "description": "Situação do registro",
+      "description_en": "Record status",
+      "type": "integer",
+      "required": true,
+      "example": "1",
+      "options": [
+        {
+          "value": 1,
+          "label": "Em aberto",
+          "label_en": "Open"
+        },
+        {
+          "value": 2,
+          "label": "Agendado",
+          "label_en": "Scheduled"
+        },
+        {
+          "value": 3,
+          "label": "Liquidado",
+          "label_en": "Settled"
+        },
+        {
+          "value": 4,
+          "label": "Baixado",
+          "label_en": "Written off"
+        }
+      ]
+    },
+    {
+      "name": "tipoData",
+      "value": "1",
+      "description": "Tipo de data para filtro",
+      "description_en": "Date type for filtering",
+      "type": "integer",
+      "required": true,
+      "example": "1",
+      "options": [
+        {
+          "value": 1,
+          "label": "Vencimento",
+          "label_en": "Due date"
+        },
+        {
+          "value": 2,
+          "label": "Emissão",
+          "label_en": "Issue date"
+        },
+        {
+          "value": 3,
+          "label": "Inclusão",
+          "label_en": "Inclusion date"
+        }
+      ]
+    }
+  ],
+  "example_request": {
+    "url": "https://api.example.com/endpoint",
+    "method": "GET",
+    "query_string": "?numeroConta=123456&dataInicial=2025-01-01&dataFinal=2025-01-31&situacao=1&tipoData=1"
+  }
+}


### PR DESCRIPTION
Added comprehensive documentation for query parameters including:
- JSON schema with parameter definitions
- Markdown documentation with usage examples
- Support for account filtering parameters (numeroConta, dataInicial, dataFinal, situacao, tipoData)

https://claude.ai/code/session_01QTeweEwzBajZPSSwd2jChm

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added clear docs and a JSON schema for account query parameters to standardize filtering and speed up integrations. Includes usage examples, date format guidance, and valid values for status and date type.

- **New Features**
  - Added query-parameters.json with types, required flags, formats, and options for situacao and tipoData.
  - Added query-parameters-documentation.md with URL, n8n, and JSON examples for each parameter.
  - Documents required params: numeroConta, dataInicial, dataFinal, situacao, tipoData.

<sup>Written for commit efa434f263906d7195f3aa97365f0bfac3ae2ece. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

