### PR TITLE
Document Crypto node credentials for v2 security changes (#4139)

### DIFF
--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.crypto.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.crypto.md
@@ -9,6 +9,10 @@ priority: medium
 
 Use the Crypto node to encrypt data in workflows.
 
+/// note | Credentials
+You can find authentication information for this node [here](/integrations/builtin/credentials/crypto.md).
+///
+
 ## Actions
 
 * [**Generate** a random string](#generate-parameters)
@@ -63,7 +67,6 @@ Node parameters depend on the action you select.
 	* **SHA385**
 	* **SHA512**
 * **Property Name**: Enter the name of the property you want to write the hash to.
-* **Secret**: Enter the secret or secret key used for decoding.
 * **Encoding**: Select the encoding type to use. Choose from:
 	* **BASE64**
 	* **HEX**
@@ -76,7 +79,6 @@ Node parameters depend on the action you select.
 * **Encoding**: Select the encoding type to use. Choose from:
 	* **BASE64**
 	* **HEX**
-* **Private Key**: Enter a private key to use when signing the string.
 
 ## Templates and examples
 

--- a/docs/integrations/builtin/credentials/crypto.md
+++ b/docs/integrations/builtin/credentials/crypto.md
@@ -1,0 +1,36 @@
+---
+title: Crypto credentials
+description: Documentation for the Crypto credentials. Use these credentials to authenticate Crypto in n8n, a workflow automation platform.
+contentType: [integration, reference]
+priority: medium
+---
+
+# Crypto credentials
+
+You can use these credentials to authenticate the following nodes:
+
+- [Crypto](/integrations/builtin/core-nodes/n8n-nodes-base.crypto.md)
+
+## Supported authentication methods
+
+- Secret and private key
+
+## Related resources
+
+Refer to the [Crypto node documentation](/integrations/builtin/core-nodes/n8n-nodes-base.crypto.md) for more information about the node.
+
+## Using secret and private key
+
+To configure this credential, you'll need:
+
+- An **Hmac Secret**: Enter the secret key used for HMAC operations. This is required when using the **Hmac** action.
+- A **Sign Private Key**: Enter the private key used for signing operations. This is required when using the **Sign** action. Enter the key in PEM format:
+    ```
+    -----BEGIN RSA PRIVATE KEY-----
+    KEY DATA GOES HERE
+    -----END RSA PRIVATE KEY-----
+    ```
+
+You only need to fill in the credential field(s) for the action(s) you plan to use:
+- For **Hmac** action: Fill in the **Hmac Secret**
+- For **Sign** action: Fill in the **Sign Private Key**

--- a/nav.yml
+++ b/nav.yml
@@ -860,6 +860,7 @@ nav:
         - integrations/builtin/credentials/copper.md
         - integrations/builtin/credentials/cortex.md
         - integrations/builtin/credentials/cratedb.md
+        - integrations/builtin/credentials/crypto.md
         - integrations/builtin/credentials/crowddev.md
         - integrations/builtin/credentials/crowdstrike.md
         - integrations/builtin/credentials/customerio.md


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add dedicated Crypto credentials docs and link them from the Crypto node to align with v2 security changes (NODE-4253). Centralizes HMAC secret and signing private key guidance in credentials, removes the inline Secret/Private Key fields from the node doc, and updates navigation.

<sup>Written for commit 21c5998c0ff3e07e63ba56562e0c9ae0b570bf7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

