### PR TITLE
:rocket: Release note 2.4.7

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -32,6 +32,17 @@ n8n uses [semantic versioning](https://semver.org/). All version numbers are in 
 You can find the release notes for older versions of n8n: [1.x](/release-notes/1-x.md) and [0.x](/release-notes/0-x.md)
 ///
 
+
+
+## n8n@2.4.7
+
+View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.4.6...n8n@2.4.7) for this version.<br />
+**Release date:** 2026-01-28
+
+This release contains a bug fix.
+
+For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
+
 ## n8n@2.5.2
 
 View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.5.1...n8n@2.5.2) for this version.<br />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added release notes entry for n8n@2.4.7, including the release date, commit comparison link, and a note that this version contains a bug fix.

<sup>Written for commit a01da98205d5e15c5c49e907f7cbfa586b36921d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

