### PR TITLE
docs: Update Google Chat compatibility to support both OAuth2 and Ser…

### DIFF
--- a/docs/integrations/builtin/credentials/google/index.md
+++ b/docs/integrations/builtin/credentials/google/index.md
@@ -36,7 +36,7 @@ Once configured, you can use your credentials to authenticate the following node
 | [Google BigQuery](/integrations/builtin/app-nodes/n8n-nodes-base.googlebigquery.md) | :white_check_mark: | :white_check_mark: |
 | [Google Books](/integrations/builtin/app-nodes/n8n-nodes-base.googlebooks.md) | :white_check_mark: | :white_check_mark: |
 | [Google Calendar](/integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/index.md) | :white_check_mark: | :x: |
-| [Google Chat](/integrations/builtin/app-nodes/n8n-nodes-base.googlechat.md) | :x: | :white_check_mark: |
+| [Google Chat](/integrations/builtin/app-nodes/n8n-nodes-base.googlechat.md) | :white_check_mark: | :white_check_mark: |
 | [Google Cloud Storage](/integrations/builtin/app-nodes/n8n-nodes-base.googlecloudstorage.md) | :white_check_mark: | :x: |
 | [Google Contacts](/integrations/builtin/app-nodes/n8n-nodes-base.googlecontacts.md) | :white_check_mark: | :x: |
 | [Google Cloud Firestore](/integrations/builtin/app-nodes/n8n-nodes-base.googlecloudfirestore.md) | :white_check_mark: | :white_check_mark: |


### PR DESCRIPTION
…vice Account authentication

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Google credentials docs to show Google Chat supports both OAuth2 and Service Account authentication. This corrects the compatibility table so users know both methods are supported.

<sup>Written for commit 920053acefcd08f47fb4a0309924fb879519dc6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

