### PR TITLE
:rocket: Release note 1.123.18

### DIFF
--- a/docs/release-notes/1-x.md
+++ b/docs/release-notes/1-x.md
@@ -38,6 +38,17 @@ You can find the release notes for older versions of n8n [here](/release-notes/0
 ## n8n@1.123.18
 
 View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.123.17...n8n@1.123.18) for this version.<br />
+**Release date:** 2026-02-04
+
+This release contains bug fixes.
+
+For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
+
+
+
+## n8n@1.123.18
+
+View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.123.17...n8n@1.123.18) for this version.<br />
 **Release date:** 2026-01-29
 
 This release contains bug fixes.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added the 1.123.18 release entry to the docs, noting it’s a bug-fix release and including the release date, commit comparison, and link to full details on GitHub.

<sup>Written for commit b51479c02cc14a23c27c680a4efa989414ef54ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

