### PR TITLE
Fix documentation for file-based configurarion on the runner image

### DIFF
--- a/docs/hosting/configuration/environment-variables/task-runners.md
+++ b/docs/hosting/configuration/environment-variables/task-runners.md
@@ -12,7 +12,7 @@ hide:
 # Task runner environment variables
 
 /// note | File-based configuration
-Unlike the main n8n image, you CANNOT use file-based configuration for secrets in the task runner image. This means that variables with a `_FILE` prefix added will not be recognized.
+Unlike the main n8n image, you CANNOT use file-based configuration for secrets in the task runner image. This means that variables with a `_FILE` suffix added will not be recognized.
 ///
 
 [Task runners](/hosting/configuration/task-runners.md) execute code defined by the [Code node](/integrations/builtin/core-nodes/n8n-nodes-base.code/index.md).


### PR DESCRIPTION
`_FILE ` suffixed environment variables are not supported for the task runner image. See: https://github.com/n8n-io/n8n/issues/23709

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified task runner documentation: file-based configuration for secrets is not supported, so `_FILE`-suffixed environment variables will not be recognized. This aligns docs with actual behavior and helps prevent misconfiguration.

<sup>Written for commit 6710bbfe60d19be3972ba6b7d5595ebd9b814887. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

