### PR TITLE
docs: Add custom scopes section for Microsoft services in credentials…

### DIFF
--- a/docs/integrations/builtin/credentials/microsoft.md
+++ b/docs/integrations/builtin/credentials/microsoft.md
@@ -112,6 +112,13 @@ If you're using a government cloud tenant, you may also need to update the **Aut
 - Replace `{tenant}` with your tenant ID or use `common` for multi-tenant apps
 ///
 
+### Custom Scopes
+
+Define granular permissions for interacting with the following Microsoft services:
+
+* Microsoft Teams
+* Microsoft Excel
+
 ### Service-specific settings
 
 The following services require extra information for OAuth2:


### PR DESCRIPTION

## Summary by cubic
Added a “Custom Scopes” section to the Microsoft credentials docs to clarify how to define granular permissions for Microsoft Teams and Microsoft Excel. Addresses Linear doc-1733 by documenting Excel custom scopes.

<sup>Written for commit 89d8bb51e9be454360a2d4d72a31a355cbd7ea66. Summary will update on new commits.</sup>
