### PR TITLE
Update YouTube to ChatGPT workflow documentationUpdate index.md

### DIFF
--- a/docs/integrations/builtin/credentials/google/index.md
+++ b/docs/integrations/builtin/credentials/google/index.md
@@ -1,4 +1,93 @@
----
+---{
+  "nodes": [
+    {
+      "parameters": {
+        "resource": "video",
+        "operation": "get",
+        "videoId": "YOUR_VIDEO_ID_HERE"
+      },
+      "id": "youtube-node",
+      "name": "YouTube",
+      "type": "n8n-nodes-base.youTube",
+      "typeVersion": 1,
+      "position": [400, 300],
+      "credentials": {
+        "youTubeApi": {
+          "id": "YOUR_YOUTUBE_CRED_ID",
+          "name": "YouTube Auth"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "model": "gpt-4o",
+        "messages": {
+          "messageValues": [
+            {
+              "role": "system",
+              "content": "You are an assistant for Digital Dar. Summarize the video details provided."
+            },
+            {
+              "content": "=Summarize this YouTube Video Title: {{ $node[\"YouTube\"].json[\"snippet\"][\"title\"] }} \n\nDescription: {{ $node[\"YouTube\"].json[\"snippet\"][\"description\"] }}"
+            }
+          ]
+        }
+      },
+      "id": "chatgpt-node",
+      "name": "OpenAI",
+      "type": "n8n-nodes-base.openAi",
+      "typeVersion": 1.2,
+      "position": [620, 300],
+      "credentials": {
+        "openAiApi": {
+          "id": "YOUR_OPENAI_CRED_ID",
+          "name": "OpenAI API Key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "mode": "jsonToBinary",
+        "convertAllData": false,
+        "sourceKey": "choices[0].message.content",
+        "destinationKey": "data",
+        "options": {
+          "fileName": "Digital_Dar_Summary.txt"
+        }
+      },
+      "id": "binary-node",
+      "name": "Convert to File",
+      "type": "n8n-nodes-base.moveBinaryData",
+      "typeVersion": 1,
+      "position": [840, 300]
+    }
+  ],
+  "connections": {
+    "YouTube": {
+      "main": [
+        [
+          {
+            "node": "OpenAI",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI": {
+      "main": [
+        [
+          {
+            "node": "Convert to File",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  }
+}
+
 title: Google credentials
 description: Documentation for Google credentials. Use these credentials to authenticate Google in n8n, a workflow automation platform.
 contentType: overview


### PR DESCRIPTION
Niche jo "Add a description" wala bada box hai, wahan aap ye likh sakte hain:
"I have updated the index.md file to better explain how to connect YouTube with ChatGPT for automated video summaries."

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a ready-to-use n8n workflow example in the Google credentials docs showing how to fetch a YouTube video’s title/description, summarize it with ChatGPT (gpt-4o), and save the result as a text file.

- **New Features**
  - Embedded workflow JSON: YouTube -> OpenAI -> Convert to File.
  - Placeholders for videoId and credential IDs; outputs Digital_Dar_Summary.txt.

<sup>Written for commit 9ddfaf0c46dc0644ae14b8cd802617aca8d1c444. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

