### PR TITLE
docs: clarify how expressions are evaluated in credential fields

### DIFF
--- a/docs/code/expressions.md
+++ b/docs/code/expressions.md
@@ -70,6 +70,17 @@ This expression:
 1. Accesses the incoming JSON-formatted data using n8n's custom `$json` variable.
 2. Finds the value of `city` (in this example, "New York"). Note that this example uses JMESPath syntax to query the JSON data. You can also write this expression as `{{$json['body']['city']}}`.
 
+### Using expressions in credentials
+
+You can also use expressions in credential fields. When you reference data using expressions (for example, `{{$json.body.city}}` or `{{ $('Webhook').item.json.headers.authorization }}`), n8n evaluates the expression within the context of the current workflow execution.
+
+This means that:
+
+- Expressions in credentials can access data available in the current execution context, including data from previous nodes.
+- Each workflow execution has its own data context.
+- Expressions are evaluated per execution, so different executions do not share data.
+
+For example, if a webhook node receives an access token and you reference it in a credential field using an expression, the value is resolved using the execution data of that specific workflow run.
 
 ### Example: Writing longer JavaScript
 


### PR DESCRIPTION
Closes #4149

This PR adds a section to the Expressions documentation clarifying how expressions are evaluated when used in credential fields.

It explains that expressions are evaluated within the current workflow execution context and that executions do not share data.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies how expressions are evaluated in credential fields: they run within the current workflow execution and can access data from previous nodes. Each execution is isolated, so credential expressions don’t share data across runs; includes a brief webhook token example.

<sup>Written for commit e5948985a3fcb3333cea5b5d1528fb4b2d87eb81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

