### PR TITLE
Revert "Remove deprecated environment variable N8N_RUNNERS_ENABLED"

### DIFF
--- a/docs/hosting/installation/docker.md
+++ b/docs/hosting/installation/docker.md
@@ -38,6 +38,7 @@ docker run -it --rm \
  -e GENERIC_TIMEZONE="<YOUR_TIMEZONE>" \
  -e TZ="<YOUR_TIMEZONE>" \
  -e N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=true \
+ -e N8N_RUNNERS_ENABLED=true \
  -v n8n_data:/home/node/.n8n \
  docker.n8n.io/n8nio/n8n
 ```


### PR DESCRIPTION
Reverts n8n-io/n8n-docs#4203

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-add N8N_RUNNERS_ENABLED=true to the Docker run example. This keeps the installation docs accurate for versions that still honor the variable and helps prevent setup errors.

<sup>Written for commit 968ed7b1093b5ed9b9dba638b42c9b336df11d5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

