### PR TITLE
docs(Custom Templates): Add info about `/workflows/templates/{id}` endpoint

### DIFF
--- a/_snippets/workflows/templates/custom-templates-library.md
+++ b/_snippets/workflows/templates/custom-templates-library.md
@@ -274,18 +274,79 @@ Detailed schemas for response objects:
 	          "typeVersion"
 	        ]
 	      }
+	    },
+	    "description": {
+	      "type": "string"
+	    },
+	    "image": {
+	      "type": "array",
+	      "items": {
+	        "type": "object",
+	        "properties": {
+	          "id": {
+	            "type": "number"
+	          },
+	          "url": {
+	            "type": "string"
+	          }
+	        }
+	      }
+	    },
+	    "categories": {
+	      "type": "array",
+	      "items": {
+	        "type": "object",
+	        "properties": {
+	          "id": {
+	            "type": "number"
+	          },
+	          "name": {
+	            "type": "string"
+	          }
+	        }
+	      }
+	    },
+	    "workflowInfo": {
+	      "type": "object",
+	      "properties": {
+	        "nodeCount": {
+	          "type": "number"
+	        },
+	        "nodeTypes": {
+	          "type": "object"
+	        }
+	      }
+	    },
+	    "workflow": {
+	      "type": "object",
+	      "properties": {
+	        "nodes": {
+	          "type": "array"
+	        },
+	        "connections": {
+	          "type": "object"
+	        },
+	        "settings": {
+	          "type": "object"
+	        },
+	        "pinData": {
+	          "type": "object"
+	        }
+	      },
+	      "required": [
+	        "nodes",
+	        "connections"
+	      ]
 	    }
 	  },
 	  "required": [
 	    "id",
 	    "name",
 	    "totalViews",
-	    "price",
-	    "purchaseUrl",
-	    "recentViews",
 	    "createdAt",
 	    "user",
-	    "nodes"
+	    "nodes",
+	    "workflow"
 	  ]
 	}
 	```


### PR DESCRIPTION
## Summary

Documented the `/workflows/templates/{id}` endpoint for custom template hosts and clarified the required flat response format.

The updated page: https://ado-4794-update-custom-templ.n8n-docs-d9c.pages.dev//embed/workflow-templates/

