### PR TITLE
Add Pylint workflow for Python code analysis

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,23 @@
+name: Pylint
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint
+    - name: Analysing the code with pylint
+      run: |
+        pylint $(git ls-files '*.py')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a GitHub Actions workflow that runs Pylint on every push for Python 3.8–3.10, linting all tracked .py files. This standardizes lint checks and flags issues early in CI.

<sup>Written for commit ed9e2b690eb7f50fc2789b6c1ba2515c33e69859. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

