### PR TITLE
Update Salesforce credentials documentation to emphasize External Client Apps

### DIFF
--- a/docs/integrations/builtin/credentials/salesforce.md
+++ b/docs/integrations/builtin/credentials/salesforce.md
@@ -122,7 +122,7 @@ Refer to Salesforce's [Create a Connected App in Your Org](https://developer.sal
 
 To configure this credential, you'll need a [Salesforce](https://www.salesforce.com/) account.
 
---8<-- \"_snippets/integrations/builtin/credentials/cloud-oauth-button.md\"
+--8<-- "_snippets/integrations/builtin/credentials/cloud-oauth-button.md"
 
 Cloud and hosted users will need to select your **Environment Type**. Choose between **Production** and **Sandbox**.
 


### PR DESCRIPTION
Update Salesforce credentials documentation to emphasize External Client Apps and enhance setup instructions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Salesforce credentials docs to prioritize External Client Apps and add clear, step-by-step setup for OAuth2 and JWT. Legacy Connected App steps remain; aligns with DOC-1728.

- **Migration**
  - New setups: create an External Client App. Existing Connected Apps continue to work.
  - OAuth2: enable Client Credentials Flow; use your n8n OAuth callback URL; select Full and Refresh Token scopes; leave Secret and PKCE requirements unchecked; copy Consumer Key to Client ID and Consumer Secret to Client Secret.
  - JWT: enable JWT Bearer Flow; upload your cert; use Consumer Key as Client ID; paste the private key in PEM format in n8n.

<sup>Written for commit 10a1259ec9cd28b0620e1116348d520a1a5c6988. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

