### PR TITLE
:rocket: Release note 2.10.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -46,6 +46,13 @@ This release contains bug fixes.
 
 For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
 
+## n8n@2.9.2
+
+View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.9.1...n8n@2.9.2) for this version.<br />
+**Release date:** 2026-02-23
+
+For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
+
 ## n8n@2.9.1
 
 View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.9.0...n8n@2.9.1) for this version.<br />
@@ -59,6 +66,13 @@ This release contains bug fixes.
 
 For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
 
+## n8n@2.8.4
+
+View the [commits](https://github.com/n8n-io/n8n/compare/n8n@2.8.3...n8n@2.8.4) for this version.<br />
+
+**Release date:** 2026-02-23
+
+This release contains bug fixes.
 
 ## n8n@2.8.3
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add release notes for n8n 2.10.0 with release date, bug-fix note, contributor credits, and a 2.9.0→2.10.0 compare link. Updated 2.9.2 and restored 2.8.4; removed 2.9.2-exp.0; kept links to full release details.

<sup>Written for commit 25ddf37dc1a687cee16419bf4ab0da6c174eebfb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

