### PR TITLE
Update latest and next version numbers

### DIFF
--- a/_snippets/self-hosting/installation/latest-next-version.md
+++ b/_snippets/self-hosting/installation/latest-next-version.md
@@ -1,6 +1,1 @@
-/// note | Stable and Beta versions
-n8n releases a new minor version most weeks. The `stable` version is for production use. `beta` is the most recent release. The `beta` version may be unstable. To report issues, use the [forum](https://community.n8n.io/c/questions/12).
-
-Current `stable`: 2.8.3
-Current `beta`: 2.9.1
-///
+/// note | Stable and Beta versions\nn8n releases a new minor version most weeks. The `stable` version is for production use. `beta` is the most recent release. The `beta` version may be unstable. To report issues, use the [forum](https://community.n8n.io/c/questions/12).\n\nCurrent `stable`: \nCurrent `beta`: \n///\n


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed hardcoded stable and beta version numbers from the self-hosting installation snippet to prevent stale info and prepare for automated updates.

<sup>Written for commit e786a830545a59bb64f364c886fe89e75909e3de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

