### PR TITLE
Update latest and next version numbers

### DIFF
--- a/_snippets/self-hosting/installation/latest-next-version.md
+++ b/_snippets/self-hosting/installation/latest-next-version.md
@@ -1,6 +1,6 @@
 /// note | Stable and Beta versions
 n8n releases a new minor version most weeks. The `stable` version is for production use. `beta` is the most recent release. The `beta` version may be unstable. To report issues, use the [forum](https://community.n8n.io/c/questions/12).
 
-Current `stable`: 2.8.3
-Current `beta`: 2.9.1
+Current `stable`: 2.9.2
+Current `beta`: 2.10.0
 ///


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the self-hosting installation snippet to reflect the latest releases so users see accurate versions. Stable is now 2.9.2 and beta is 2.10.0.

<sup>Written for commit 10dd4ac7fbcbbe9056ab8f67a9511e2da61fed4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

