### PR TITLE
fix: remove redundant redirect for data mapping section

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -315,7 +315,6 @@
 /code-examples/expressions/variables/   /code/builtin/  301
 /code-examples/javascript-functions/methods/   /code/builtin/  301
 /code-examples/javascript-functions/variables/  /code/builtin/  301
-/data/data-mapping/   /data/data-mapping/  301
 
 # Editor UI
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes DOC-1754 by removing a self-redirect that caused an infinite loop when clicking Data Mapping in the docs. The page now loads correctly from the Data section.

<sup>Written for commit 8470cf6d162d4df9f154cd3ea9449f564ee08713. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

