### PR TITLE
fix: move credentials explanation to new file

### DIFF
--- a/docs/data/expressions-for-transformation.md
+++ b/docs/data/expressions-for-transformation.md
@@ -66,7 +66,7 @@ This means that:
 
 - Expressions in credentials can access data available in the current execution context, including data from previous nodes.
 - Each workflow execution has its own data context.
-- Expressions are evaluated per execution, so different executions do not share data.
+- Expressions are evaluated per execution, so different executions don't share data.
 
 For example, if a webhook node receives an access token and you reference it in a credential field using an expression, the value is resolved using the execution data of that specific workflow run.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved the credentials expression scope explanation to a dedicated doc, and tightened wording in the expressions-for-transformation page (“don't share data”) for clarity and consistency.

<sup>Written for commit 07b6aa5fb95b993023f1dd46e75ad11083e38564. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

