### PR TITLE
docs: Add Gladia node and credentials documentation

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.gladia.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.gladia.md
@@ -1,0 +1,60 @@
+---
+title: Gladia node documentation
+description: Learn how to use the Gladia node in n8n. Follow technical documentation to integrate Gladia node into your workflows.
+contentType: [integration, reference]
+---
+
+# Gladia node
+
+Use the Gladia node to automate work in Gladia, and integrate Gladia with other applications. n8n has built-in support for Gladia's async speech-to-text transcription API, enabling you to transcribe audio files from URLs or binary data.
+
+On this page, you'll find a list of operations the Gladia node supports, and links to more resources.
+
+///  note  | Credentials
+Refer to [Gladia credentials](/integrations/builtin/credentials/gladia.md) for guidance on setting up authentication.
+///
+
+## Operations
+
+* **Transcription**
+    * Transcribe an audio file
+
+## Node parameters
+
+### Audio Source
+
+Choose how to provide the audio file:
+
+- **URL**: Provide a direct URL to the audio file.
+- **Binary Data**: Use binary data from a previous node. Specify the **Input Binary Field** name (defaults to `data`).
+
+### Wait for Completion
+
+When enabled (default), the node polls the Gladia API until the transcription is complete and returns the full result. When disabled, the node returns the transcription ID immediately for later retrieval.
+
+### Options
+
+- **Context Prompt**: Provide context to improve transcription accuracy.
+- **Custom Vocabulary**: Comma-separated list of custom vocabulary terms.
+- **Detect Language**: Automatically detect the spoken language.
+- **Diarization**: Enable speaker diarization with optional min/max speaker settings.
+- **Enable Code Switching**: Support multi-language conversations.
+- **Language**: Specify a language code (e.g., `en`, `fr`, `de`).
+- **Named Entity Recognition**: Identify named entities in the transcription.
+- **Polling Interval (Seconds)**: How often to check for completion (default: 5).
+- **Polling Timeout (Seconds)**: Maximum wait time for completion (default: 600).
+- **Sentiment Analysis**: Enable sentiment analysis on the transcription.
+- **Subtitles**: Generate subtitles in SRT and/or VTT formats.
+- **Summarization**: Generate a summary of the transcription.
+- **Translation**: Translate the transcription to target languages.
+
+## Templates and examples
+
+<!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->
+[[ templatesWidget(page.title, 'gladia') ]]
+
+## Related resources
+
+Refer to [Gladia's API documentation](https://docs.gladia.io/) for more information about the service.
+
+--8<-- "_snippets/integrations/builtin/app-nodes/operation-not-supported.md"

--- a/docs/integrations/builtin/credentials/gladia.md
+++ b/docs/integrations/builtin/credentials/gladia.md
@@ -1,0 +1,35 @@
+---
+title: Gladia credentials
+description: Documentation for the Gladia credentials. Use these credentials to authenticate Gladia in n8n, a workflow automation platform.
+contentType: [integration, reference]
+---
+
+# Gladia credentials
+
+You can use these credentials to authenticate the following nodes:
+
+- [Gladia](/integrations/builtin/app-nodes/n8n-nodes-base.gladia.md)
+
+## Prerequisites
+
+Create a [Gladia](https://app.gladia.io/) account.
+
+## Supported authentication methods
+
+* API key
+
+## Related resources
+
+Refer to [Gladia's API documentation](https://docs.gladia.io/) for more information about the service.
+
+## Using API key
+
+To configure this credential, you'll need a [Gladia](https://app.gladia.io/) account and an **API Key**. To generate a new key:
+
+1. Log in to the [Gladia Dashboard](https://app.gladia.io/).
+2. Navigate to the **API Keys** section.
+3. Select **Create a new API Key**.
+4. Copy the generated key.
+5. Enter this as the **API Key** in your n8n credential.
+
+Refer to [Gladia's documentation](https://docs.gladia.io/) for more information about managing API keys.

--- a/nav.yml
+++ b/nav.yml
@@ -373,6 +373,7 @@ nav:
         - Freshworks CRM: integrations/builtin/app-nodes/n8n-nodes-base.freshworkscrm.md
         - GetResponse: integrations/builtin/app-nodes/n8n-nodes-base.getresponse.md
         - Ghost: integrations/builtin/app-nodes/n8n-nodes-base.ghost.md
+        - Gladia: integrations/builtin/app-nodes/n8n-nodes-base.gladia.md
         - GitHub: integrations/builtin/app-nodes/n8n-nodes-base.github.md
         - GitLab: integrations/builtin/app-nodes/n8n-nodes-base.gitlab.md
         - Gmail:
@@ -923,6 +924,7 @@ nav:
         - integrations/builtin/credentials/ftp.md
         - integrations/builtin/credentials/getresponse.md
         - integrations/builtin/credentials/ghost.md
+        - integrations/builtin/credentials/gladia.md
         - integrations/builtin/credentials/git.md
         - integrations/builtin/credentials/github.md
         - integrations/builtin/credentials/gitlab.md


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add documentation for the Gladia node and credentials, explaining setup and usage of Gladia’s async speech-to-text transcription in n8n. Covers audio input (URL or binary), wait-for-completion and polling options, and advanced features like diarization, language detection, subtitles, NER, sentiment, summarization, and translation; updates nav to include both pages.

<sup>Written for commit 6903e0df67cb342d192a9f35b1c5dca679fc842b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

