### PR TITLE
fix: Admin users should be able to install community nodes

### DIFF
--- a/docs/integrations/community-nodes/installation/verified-install.md
+++ b/docs/integrations/community-nodes/installation/verified-install.md
@@ -4,10 +4,8 @@ contentType: howto
 
 # Install verified community nodes in the n8n app
 
-/// note | Limited to n8n instance owners
-Only the n8n instance owner can install and manage verified community nodes. The instance owner is the person who sets up and manages user management. All members of an n8n instance can use already installed community nodes in their workflows.
-
-Admin accounts can also uninstall any community node, verified or unverified. This helps them remove problematic nodes that may affect the instance's health and functionality.
+/// note | Limited to n8n instance owners and admins
+The n8n instance owner and admin accounts can install and manage verified community nodes. The instance owner is the person who sets up and manages user management. All members of an n8n instance can use already installed community nodes in their workflows.
 ///
 
 ## Install a community node


### PR DESCRIPTION
The admin role already had the scope `communityPackage:install` required and could install community packages by calling the n8n api directly. The n8n UI now correctly reflects that the admins can install community packages.

Linked issue: https://linear.app/n8n/issue/NODE-4258/community-issue-cant-install-community-node-as-admin
Linked changes: https://github.com/n8n-io/n8n/pull/26296