### PR TITLE
docs: add feature-based versioning documentation

### DIFF
--- a/docs/integrations/creating-nodes/build/reference/node-base-files/declarative-style-parameters.md
+++ b/docs/integrations/creating-nodes/build/reference/node-base-files/declarative-style-parameters.md
@@ -119,3 +119,11 @@ _Number_ or _Array_ | _Optional_
 If you have one version of your node, this can be a number. If you want to support more than one version, turn this into an array, containing numbers for each node version.
 
 n8n supports two methods of node versioning, but declarative-style nodes must use the light versioning approach. Refer to [Node versioning](/integrations/creating-nodes/build/reference/node-versioning.md) for more information.
+
+## `features`
+
+_Object_ | _Optional_
+
+Define named feature flags evaluated against the node version. Use features to control parameter visibility with `@feature` in `displayOptions`.
+
+Refer to [Feature-based versioning](/integrations/creating-nodes/build/reference/node-versioning.md#feature-based-versioning) for more information.

--- a/docs/integrations/creating-nodes/build/reference/node-base-files/programmatic-style-parameters.md
+++ b/docs/integrations/creating-nodes/build/reference/node-base-files/programmatic-style-parameters.md
@@ -68,3 +68,11 @@ If you have one version of your node, this can be a number. If you want to suppo
 
 n8n support two methods of node versioning. Programmatic-style nodes can use either. Refer to [Node versioning](/integrations/creating-nodes/build/reference/node-versioning.md) for more information.
 
+## `features`
+
+_Object_ | _Optional_
+
+Define named feature flags evaluated against the node version. Use features to control parameter visibility with `@feature` in `displayOptions`, or check them in code with `this.isNodeFeatureEnabled()`.
+
+Refer to [Feature-based versioning](/integrations/creating-nodes/build/reference/node-versioning.md#feature-based-versioning) for more information.
+

--- a/docs/integrations/creating-nodes/build/reference/node-versioning.md
+++ b/docs/integrations/creating-nodes/build/reference/node-versioning.md
@@ -48,6 +48,78 @@ As an example, say you want to add versioning to the NasaPics node from the [Dec
 }
 ```
 
+## Feature-based versioning
+
+Feature flags let you control parameter visibility and execution logic based on named features tied to node versions.
+
+### Defining features
+
+Add a `features` object to your node type description. Each feature uses `@version` conditions to specify which versions enable it:
+
+```js
+{
+    version: [2, 2.1, 2.2, 2.3, 2.4],
+    features: {
+        useNewApi: { '@version': [{ _cnd: { gte: 2.2 } }] },
+        useLegacyAuth: { '@version': [{ _cnd: { lte: 2.1 } }] },
+        useSpecialMode: { '@version': [2] },
+    },
+    // More basic parameters here
+}
+```
+
+Available conditions: `gte`, `lte`, `gt`, `lt`. Pass a plain version number to match a specific version.
+
+### Using `@feature` in `displayOptions`
+
+Use `@feature` in `displayOptions` to control parameter visibility based on feature flags:
+
+```js
+{
+    displayName: 'New API Field',
+    name: 'newApiField',
+    type: 'string',
+    displayOptions: {
+        show: {
+            '@feature': ['useNewApi'],
+        },
+    },
+}
+```
+
+To show a parameter when a feature is **not** enabled, use the condition syntax:
+
+```js
+displayOptions: {
+    show: {
+        '@feature': [{ _cnd: { not: 'useNewApi' } }],
+    },
+}
+```
+
+You can combine `@feature` with other display conditions:
+
+```js
+displayOptions: {
+    show: {
+        resource: ['myResource'],
+        '@feature': [{ _cnd: { eq: 'useNewApi' } }],
+    },
+}
+```
+
+### Checking features in code
+
+Use `this.isNodeFeatureEnabled()` in execution contexts (such as `IExecuteFunctions` or `IWebhookFunctions`):
+
+```js
+if (this.isNodeFeatureEnabled('useNewApi')) {
+    // Process with new API
+} else {
+    // Process with legacy API
+}
+```
+
 ## Full versioning
 
 This isn't available for declarative-style nodes.


### PR DESCRIPTION
Document the new `@feature` display condition, `features` property in node type descriptions, and `isNodeFeatureEnabled()` method.