### PR TITLE
docs: add Pega Launchpad node and credentials documentation

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.pegalaunchpad.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.pegalaunchpad.md
@@ -1,0 +1,124 @@
+---
+title: Launchpad by Pegasystems node documentation
+description: Learn how to use the Launchpad by Pegasystems node in n8n. Follow technical documentation to integrate Launchpad by Pegasystems node into your workflows.
+contentType: [integration, reference]
+priority: medium
+---
+
+# Launchpad by Pegasystems node
+
+Use the Launchpad by Pegasystems node to automate work in Launchpad and integrate Launchpad by Pegasystems with other applications. n8n has built-in support for a wide range of Launchpad features, including managing cases, assignments, attachments, pulses, and users through the DX API v2.
+
+On this page, you'll find a list of operations the Launchpad by Pegasystems node supports and links to more resources.
+
+/// note | Credentials
+Refer to [Launchpad by Pegasystems credentials](/integrations/builtin/credentials/launchpad.md) for guidance on setting up authentication.
+///
+
+## Operations
+
+* Agent
+    * Get the final response from an agent conversation
+    * Initiate a new conversation with an AI agent
+    * Send a message to an existing agent conversation
+* Assignment
+    * Get an assignment
+    * Perform an action on an assignment
+* Attachment
+    * Delete an attachment from a case
+    * Get an attachment from a case
+    * Upload an attachment to a case
+* Case
+    * Create a case
+    * Get a case
+* Pulse
+    * Add a pulse message to a case
+    * Get pulse messages for a case
+    * Reply to a pulse message on a case
+* User
+    * Mark a user as active
+    * Mark a user as inactive
+
+## Node parameters
+
+### Base URL
+
+The base URL of your Launchpad instance (without a trailing slash). For example: `https://your-launchpad-domain.com`.
+
+### Resource
+
+Select the resource you want to work with:
+
+- **Agent**: Interact with Pega AI agents — start conversations, send messages, and retrieve final responses.
+- **Assignment**: View and perform actions on work assignments.
+- **Attachment**: Manage file attachments on cases.
+- **Case**: Create and retrieve cases.
+- **Pulse**: Post and view collaboration messages on cases.
+- **User**: Manage user availability status.
+
+## Working with AI agents
+
+The Agent resource allows you to interact with Pega AI agents through a conversational workflow. A typical flow involves three steps:
+
+1. **Initiate Conversation**: Start a new conversation with an AI agent by providing the agent name and a context ID. The context ID is an encoded identifier that ties the conversation to a specific case or context in your Pega application.
+
+2. **Send Message**: Send a message (prompt) to the agent within the active conversation. You need the Agent ID and Conversation ID returned from the initiation step.
+
+3. **Get Final Response**: Retrieve the agent's final response for a conversation. This uses a data view (`GetAgentFinalResponse`) and requires only the Conversation ID.
+
+### Agent parameters
+
+| Parameter | Operation | Description |
+|-----------|-----------|-------------|
+| **Agent Name** | Initiate Conversation | The fully qualified name of the AI agent (e.g., `TestApp__SummaryAgent`) |
+| **Context ID** | Initiate Conversation | The encoded context ID for the conversation |
+| **Execute Starter Question** | Initiate Conversation | *(Optional)* Whether to execute the starter question when initiating |
+| **Agent ID** | Send Message | The ID (fully qualified name) of the AI agent |
+| **Conversation ID** | Send Message, Get Final Response | The ID of the conversation |
+| **Request** | Send Message | The message text to send to the agent |
+
+### Example: Complete agent conversation flow
+
+1. Use **Initiate Conversation** with your agent name and context ID
+2. From the response, extract the `ConversationID` and `AgentID`
+3. Use **Send Message** with the agent ID, conversation ID, and your prompt
+4. Use **Get Final Response** with the conversation ID to retrieve the agent's answer
+
+## Templates and examples
+
+<!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->
+[[ templatesWidget(page.title, 'pega-launchpad') ]]
+
+## Related resources
+
+Refer to [Pegasystems' Launchpad documentation](https://docs.pega.com/bundle/launchpad/page/platform/launchpad/introducing-launchpad.html) for more information about the service.
+
+Refer to [Pegasystems' DX API documentation](https://docs.pega.com/bundle/launchpad/page/platform/launchpad/dx-api-endpoints.html) for detailed API reference.
+
+## Working with the If-Match header
+
+Some operations (Perform Action on Assignment, Mark User as Active, Mark User as Inactive) require an `If-Match` header value. This is the ETag of the resource, which you receive in the response when you get the resource.
+
+The Pega DX API returns ETags in the standard weak ETag format: `W/"<value>"` (for example, `W/"3"`). The node passes this value directly to the `If-Match` header.
+
+To chain operations, use an expression like `{{ $json.responseHeaders.etag }}` to pass the ETag from a GET response into the If-Match field of a subsequent update operation.
+
+## Common issues
+
+Here are some common errors and issues with the Launchpad by Pegasystems node and steps to resolve or troubleshoot them.
+
+### Authentication errors
+
+Make sure you've correctly configured the OAuth2 Client Credentials in the [Launchpad by Pegasystems credentials](/integrations/builtin/credentials/launchpad.md). Verify that:
+
+- The **Access Token URL** points to your Launchpad instance's OAuth2 token endpoint.
+- The **Client ID** and **Client Secret** are correct.
+- Your OAuth2 client has the necessary permissions to access the DX API.
+
+### If-Match header errors
+
+If you receive a `412 Precondition Failed` error when performing actions on assignments or updating user status, the ETag value you're using may be outdated. Get the resource again to obtain the latest ETag value before retrying the operation.
+
+### Base URL issues
+
+Ensure the Base URL doesn't include a trailing slash or API path. It should be just the domain, for example: `https://your-launchpad-domain.com`, not `https://your-launchpad-domain.com/` or `https://your-launchpad-domain.com/dx/api/`.

--- a/docs/integrations/builtin/credentials/launchpad.md
+++ b/docs/integrations/builtin/credentials/launchpad.md
@@ -1,0 +1,53 @@
+---
+title: Launchpad by Pegasystems credentials
+description: Documentation for the Launchpad by Pegasystems credentials. Use these credentials to authenticate Launchpad by Pegasystems in n8n, a workflow automation platform.
+contentType: [integration, reference]
+priority: medium
+---
+
+# Launchpad by Pegasystems credentials
+
+You can use these credentials to authenticate the following nodes:
+
+- [Launchpad by Pegasystems](/integrations/builtin/app-nodes/n8n-nodes-base.pegalaunchpad.md)
+
+## Supported authentication methods
+
+- OAuth2 (Client Credentials)
+
+## Related resources
+
+Refer to [Pegasystems' DX API documentation](https://docs.pega.com/bundle/launchpad/page/platform/launchpad/dx-api-endpoints.html) for more information about the API.
+
+Refer to [Pegasystems' Launchpad documentation](https://docs.pega.com/bundle/launchpad/page/platform/launchpad/introducing-launchpad.html) for more information about the service.
+
+## Using OAuth2
+
+To configure this credential, you'll need a [Launchpad](https://www.pega.com/products/launchpad) account and:
+
+- An **Access Token URL**: The OAuth2 token endpoint for your Launchpad instance.
+- A **Client ID**: The client ID of your registered OAuth2 client.
+- A **Client Secret**: The client secret of your registered OAuth2 client.
+- A **Scope** (optional): The OAuth2 scope for your Launchpad API access.
+
+To set up the OAuth2 Client Credentials in Launchpad:
+
+1. Log in to your Launchpad instance as an administrator.
+2. Navigate to the OAuth 2.0 client registration. In Dev Studio, go to **Records** > **Security** > **OAuth 2.0 Client Registration**.
+3. Create a new client registration or open an existing one.
+4. Set the **Grant Type** to **Client Credentials**.
+5. Copy the **Client ID** from the registration and paste it into the n8n credential.
+6. Copy or generate a **Client Secret** and paste it into the n8n credential.
+7. Set the **Access Token URL** in n8n. This is typically in the format:
+    ```
+    https://<your-launchpad-domain>/prweb/PRRestService/oauth2/v1/token
+    ```
+8. Optionally, enter a **Scope** if your Launchpad instance requires one.
+
+Refer to [Pegasystems' OAuth 2.0 documentation](https://docs.pega.com/bundle/launchpad/page/platform/launchpad/configure-oauth2-authentication-profile.html) for more information about setting up OAuth2 client credentials.
+
+Refer to [Pegasystems' DX API documentation](https://docs.pega.com/bundle/dx-api/page/platform/dx-api/dx-api-version-2-con.html) for detailed DX API reference.
+
+/// note | Client Credentials grant type
+The Launchpad by Pegasystems node uses the **Client Credentials** grant type. This means the node authenticates as the application itself, not on behalf of a specific user. Make sure your OAuth2 client is configured for Client Credentials and has the necessary access to the DX API endpoints.
+///

--- a/nav.yml
+++ b/nav.yml
@@ -492,6 +492,7 @@ nav:
         - Oura: integrations/builtin/app-nodes/n8n-nodes-base.oura.md
         - Paddle: integrations/builtin/app-nodes/n8n-nodes-base.paddle.md
         - PagerDuty: integrations/builtin/app-nodes/n8n-nodes-base.pagerduty.md
+        - Launchpad by Pegasystems: integrations/builtin/app-nodes/n8n-nodes-base.pegalaunchpad.md
         - PayPal: integrations/builtin/app-nodes/n8n-nodes-base.paypal.md
         - Peekalink: integrations/builtin/app-nodes/n8n-nodes-base.peekalink.md
         - Perplexity: integrations/builtin/app-nodes/n8n-nodes-langchain.perplexity.md
@@ -1008,6 +1009,7 @@ nav:
         - integrations/builtin/credentials/oura.md
         - integrations/builtin/credentials/paddle.md
         - integrations/builtin/credentials/pagerduty.md
+        - integrations/builtin/credentials/launchpad.md
         - integrations/builtin/credentials/paypal.md
         - integrations/builtin/credentials/peekalink.md
         - integrations/builtin/credentials/perplexity.md


### PR DESCRIPTION
Add documentation for the Launchpad by Pegasystems integration node:
- Node page with all operations (Agent, Case, Assignment, Attachment, Pulse, User)
- AI Agent workflow documentation (Initiate Conversation, Send Message, Get Final Response)
- OAuth2 Client Credentials setup guide
- Common issues and troubleshooting
- Navigation entry in nav.yml

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds documentation for the Launchpad by Pegasystems node and credentials, including agent conversation workflows and OAuth2 setup. Updates navigation to surface the new pages.

- **New Features**
  - Node docs covering Agent, Assignment, Attachment, Case, Pulse, and User (DX API v2).
  - AI Agent workflow: Initiate Conversation, Send Message, Get Final Response.
  - OAuth2 Client Credentials setup guide.
  - Common issues and troubleshooting (auth, If-Match, base URL).
  - nav.yml entries for the node and credentials pages.

<sup>Written for commit 6a80b1521dbf4519a58cd05327a7a2ff65b60e2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

