### PR TITLE
docs: Add 1Password external secrets provider

### DIFF
--- a/docs/external-secrets.md
+++ b/docs/external-secrets.md
@@ -8,7 +8,7 @@ contentType: howto
 
 /// info | Feature availability
 * External secrets are available on Enterprise Self-hosted and Enterprise Cloud plans.
-* n8n supports the following secret providers: 1Password, AWS Secrets Manager, Azure Key Vault, GCP Secrets Manager, and HashiCorp Vault.
+* n8n supports the following secret providers: 1Password (via [Connect Server](https://developer.1password.com/docs/connect/get-started/)), AWS Secrets Manager, Azure Key Vault, GCP Secrets Manager, and HashiCorp Vault.
 * From n8n version 2.10.0 you can connect multiple vaults per secret provider. Older versions only support one vault per provider.
 * n8n doesn't support [HashiCorp Vault Secrets](https://developer.hashicorp.com/hcp/docs/vault-secrets).
 ///
@@ -38,7 +38,11 @@ As long as this store is connected, you can reference its secrets in credentials
 
 ### 1Password
 
-Provide your **Connect Server URL** and **Access Token**. You need a running [1Password Connect Server](https://developer.1password.com/docs/connect/get-started/). The Connect Server URL is the address of your server (for example, `http://localhost:8080`). The Access Token is the token you created for the Connect Server integration.
+/// note | 1Password Connect Server required
+n8n integrates with [1Password Connect Server](https://developer.1password.com/docs/connect/get-started/), a self-hosted API for machine access to 1Password. This isn't the same as a personal or team 1Password account. You must deploy and run a Connect Server to use this provider.
+///
+
+Provide your **Connect Server URL** and **Access Token**. The Connect Server URL is the address where your server is accessible (for example, `http://localhost:8080`). The Access Token is the token you created for the Connect Server integration.
 
 n8n reads all vaults and items accessible to the token. Each 1Password item becomes a secret, with the item's fields accessible as properties. Use `{{ $secrets.<vault-name>.<item-title>.<field-label> }}` to access a specific field value.
 


### PR DESCRIPTION
## Summary

- Add 1Password Connect Server as a supported external secrets provider
- Restructure provider configuration from inline bullet points into separate `###` sections for better readability and navigation
- Document 1Password-specific configuration: Connect Server URL, Access Token, and structured item/field access pattern

Relates to: https://github.com/n8n-io/n8n/pull/26307

## Test plan

- [ ] Verify the external secrets page renders correctly with `mkdocs serve`
- [ ] Confirm all provider sections display with correct headings
- [ ] Check the 1Password Connect Server link resolves
- [ ] Verify expression syntax examples render properly in code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 1Password as an external secrets provider via Connect Server and splits the page into per‑provider sections for faster setup. Also clarifies that 1Password requires a self‑hosted Connect Server.

- **New Features**
  - Documents 1Password setup (Connect Server URL, Access Token) and field access: {{ $secrets.<vault-name>.<item-title>.<field-label> }}.
  - Adds 1Password to the supported providers list and notes it requires Connect Server, not a personal/team account.

- **Refactors**
  - Moves provider instructions to H3 sections (1Password, AWS, Azure, GCP, HashiCorp Vault) and moves the “reference secrets while connected” note out of the steps.
  - Expands AWS IAM policy examples (all secrets vs scoped ARNs) and clarifies required permissions.

<sup>Written for commit 5141d8b386e5f3f71e15d1e6fa087a67e118af1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

