### PR TITLE
docs: add EXTERNAL_HOOK_FILES_SEPARATOR env var

### DIFF
--- a/docs/hosting/configuration/environment-variables/external-hooks.md
+++ b/docs/hosting/configuration/environment-variables/external-hooks.md
@@ -15,7 +15,8 @@ hide:
 
 You can define external hooks that n8n executes whenever a specific operation runs. Refer to [Backend hooks](/embed/configuration.md#backend-hooks) for examples of available hooks and [Hook files](/embed/configuration.md#backend-hook-files) for information on file formatting. 
 
-| Variable | Type  | Description |
-| :------- | :---- | :---------- |
-| `EXTERNAL_HOOK_FILES` | String | Files containing backend external hooks. Provide multiple files as a colon-separated list ("`:`"). |
-| `EXTERNAL_FRONTEND_HOOKS_URLS` | String | URLs to files containing frontend external hooks. Provide multiple URLs as a colon-separated list ("`:`"). |
+| Variable | Type  | Default | Description |
+| :------- | :---- | :------ | :---------- |
+| `EXTERNAL_HOOK_FILES` | String | - | Files containing backend external hooks. Provide multiple files separated by the character defined in `EXTERNAL_HOOK_FILES_SEPARATOR`. |
+| `EXTERNAL_HOOK_FILES_SEPARATOR` | String | `:` | Separator character for `EXTERNAL_HOOK_FILES`. Use `;` on Windows to avoid conflicts with drive-letter paths like `C:\`. |
+| `EXTERNAL_FRONTEND_HOOKS_URLS` | String | - | URLs to files containing frontend external hooks. Provide multiple URLs as a colon-separated list ("`:`"). |


### PR DESCRIPTION
## Summary
Document the new `EXTERNAL_HOOK_FILES_SEPARATOR` environment variable added in n8n core PR #26983.

## Changes
- Add `EXTERNAL_HOOK_FILES_SEPARATOR` documentation with default value (`:`)
- Update `EXTERNAL_HOOK_FILES` description to reference the configurable separator
- Add guidance for Windows users to use `;` separator to avoid conflicts with drive-letter paths

This aligns the docs with the external hooks configuration changes that support Windows file paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add docs for the new `EXTERNAL_HOOK_FILES_SEPARATOR` env var and update `EXTERNAL_HOOK_FILES` guidance. Clarifies the default `:` separator and recommends `;` on Windows to avoid drive-letter path conflicts.

<sup>Written for commit ad249573064d5246e543000a6100a703c1301595. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

