### PR TITLE
docs: update Outlook.com IMAP documentation to reflect removal of Bas…

### DIFF
--- a/docs/integrations/builtin/credentials/imap/outlook.md
+++ b/docs/integrations/builtin/credentials/imap/outlook.md
@@ -23,6 +23,8 @@ for more information.
 
 IMAP access for Outlook.com and Microsoft 365 accounts is no longer supported in n8n due to Microsoft's deprecation of Basic Authentication. You cannot use IMAP (with a regular password or app password) to connect to Outlook.com or Microsoft 365 accounts.
 
-**To connect your Outlook.com or Microsoft 365 email, use the [Microsoft Outlook node](/integrations/builtin/app-nodes/n8n-nodes-base.microsoftoutlook/), which uses OAuth 2.0 as required by Microsoft.**
+To replace IMAP triggers for incoming email, use the [Microsoft Outlook Trigger node](/integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftoutlooktrigger.md), which supports the Message Received event.
+
+For general Microsoft Outlook automation, use the [Microsoft Outlook node](/integrations/builtin/app-nodes/n8n-nodes-base.microsoftoutlook.md), which uses OAuth 2.0 as required by Microsoft.
 
 For more information, refer to [Microsoft's deprecation notice](https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/deprecation-of-basic-authentication-exchange-online#what-we-are-changing).


### PR DESCRIPTION
…ic Authentication

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Outlook.com IMAP credential docs to reflect Microsoft’s removal of Basic Auth for Outlook.com/Microsoft 365, addressing Linear DOC-1776. Removed outdated setup/connection/app-password steps and added a clear warning with guidance to use the `Microsoft Outlook` (OAuth 2.0) and `Microsoft Outlook Trigger` nodes; fixed the Outlook link.

<sup>Written for commit 362871f6e91a44fd1ef0f222e1141b85d1026885. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

