### PR TITLE
docs: update curl examples in Webhook node documentation to use corre…

### DIFF
--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.webhook/common-issues.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.webhook/common-issues.md
@@ -60,7 +60,7 @@ curl --request GET <https://your-n8n.url/webhook/path> --header 'key=value'
 Make an HTTP request to send a file:
 
 ```sh
-curl --request GET <https://your-n8n.url/webhook/path> --form 'key=@/path/to/file'
+curl --request POST <https://your-n8n.url/webhook/path> --form 'key=@/path/to/file'
 ```
 Replace `/path/to/file` with the path of the file you want to send.
 


### PR DESCRIPTION
…ct HTTP methods

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix curl examples in the Webhook node docs to use correct HTTP methods and flags. Changed body and file upload examples to POST, and replaced invalid `--from` with `--form` for uploads. Addresses Linear DOC-1777.

<sup>Written for commit 5b6e6d93a93666f25875cd87f0d9aaf41c356a72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

