### PR TITLE
docs: clarify client host name requirements for Send Email credentials

### DIFF
--- a/docs/integrations/builtin/credentials/sendemail/index.md
+++ b/docs/integrations/builtin/credentials/sendemail/index.md
@@ -41,7 +41,7 @@ To configure this credential, you'll need:
   - Turn **OFF** for port `587` (uses STARTTLS explicit encryption)
   - Turn **OFF** for port `25` (no encryption)
 - **Disable STARTTLS**: When SSL/TLS is disabled, the SMTP server can still try to [upgrade the TCP connection using STARTTLS](https://en.wikipedia.org/wiki/Opportunistic_TLS). Turning this on prevents that behaviour.
-- **Client Host Name**: If needed by your provider, add a client host name. This name identifies the client to the server.
+- **Client Host Name**: This name identifies the client to the server. May not be required for Gmail, Outlook.com, or Yahoo. Leave this field empty unless your email provider or administrator specifically requests it. If you do need to provide a value, use a fully qualified domain name (FQDN) such as `mail.yourdomain.com`. Avoid generic values like `localhost`.
 
 ### Provider instructions
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified the “Client Host Name” field in Send Email credential docs to explain when it’s needed and how to fill it. Addresses Linear DOC-1190.

- Noted it’s typically not required for Gmail, Outlook.com, or Yahoo; leave blank unless your provider/admin asks.
- Added example FQDN (`mail.yourdomain.com`) and guidance to avoid generic values like `localhost`.

<sup>Written for commit 81100aea88130a67bff0d0821669dce2d19b724d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

