### PR TITLE
Update Azure Geo wording to EU

### DIFF
--- a/docs/privacy-security/privacy.md
+++ b/docs/privacy-security/privacy.md
@@ -40,7 +40,7 @@ This is a list of sub-processors authorized to process customer data for n8n's s
 
 | Sub-processor name | Purpose | Contact details | Geographic location of processing |
 | ------------------ | --------------- | --------------- | --------------------------------- |
-| Microsoft Azure | Cloud service provider | Microsoft Azure <br /> 1 Microsoft Way <br /> Redmond <br /> WA 98052 <br /> USA <br /> Contact information: https://privacy.microsoft.com/en-GB/privacystatement#mainhowtocontactusmodule | EU (e.g. Germany, Sweden) |
+| Microsoft Azure | Cloud service provider | Microsoft Azure <br /> 1 Microsoft Way <br /> Redmond <br /> WA 98052 <br /> USA <br /> Contact information: https://privacy.microsoft.com/en-GB/privacystatement#mainhowtocontactusmodule | EU (for example, Germany, Sweden) |
 | Hetzner Online | Cloud service provider | Hetzner Online GmbH <br /> Industriestr. 25 <br /> 91710 Gunzenhausen <br /> Germany <br /> data-protection@hetzner.com | Germany |
 | OpenAI | AI provider	| 1455 3rd Street <br /> San Francisco, CA 94158 <br /> United States |	US |
 | Anthropic	| AI provider	| Anthropic Ireland, Limited <br /> 6th Floor South Bank House, Barrow Street, Dublin 4 <br /> Ireland	| US |


### PR DESCRIPTION
As we are expanding the regions for n8n Cloud beyond just the existing Frankfurt region, we need to adjust the documentation to reflect this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update privacy docs to list Microsoft Azure processing as “EU (for example, Germany, Sweden)” instead of “Germany (West Central Region)”. Reflects new n8n Cloud regions and fixes example formatting.

<sup>Written for commit 3554804a294e19431337df096f709e9257e64c69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

