### PR TITLE
docs: Document dist-tags for community node installs (no-changelog)

### DIFF
--- a/docs/integrations/community-nodes/installation/gui-install.md
+++ b/docs/integrations/community-nodes/installation/gui-install.md
@@ -17,15 +17,28 @@ To install a community node from npm:
 3. Find the node you want to install:
     1. Select **Browse**. n8n takes you to an npm search results page, showing all npm packages tagged with the keyword `n8n-community-node-package`.
     2. Browse the list of results. You can filter the results or add more keywords.
-    3. Once you find the package you want, make a note of the package name. If you want to install a specific version, make a note of the version number as well.
+    3. Once you find the package you want, make a note of the package name. If you want to install a specific version or follow a release channel such as `beta`, make a note of that as well.
     4. Return to n8n.
-4. Enter the npm package name, and version number if required. For example, consider a community node designed to access a weather API called "Storms." The package name is n8n-node-storms, and it has three major versions.
-    * To install the latest version of a package called n8n-node-weather: enter `n8n-nodes-storms` in **Enter npm package name**.
-    * To install version 2.3: enter `n8n-node-storms@2.3` in **Enter npm package name**.
+4. Enter the npm package name. If you want to install an exact version or a release channel, add it after `@`. For example, consider a community node designed to access a weather API called "Storms." The package name is `n8n-nodes-storms`, and it has several releases:
+    * To install from the default `latest` channel: enter `n8n-nodes-storms` in **Enter npm package name**.
+    * To install the exact version `2.3.0`: enter `n8n-nodes-storms@2.3.0` in **Enter npm package name**.
+    * To install from the `beta` channel: enter `n8n-nodes-storms@beta` in **Enter npm package name**.
     <!-- vale off -->
 5. Agree to the [risks](/integrations/community-nodes/risks.md) of using community nodes: select **I understand the risks of installing unverified code from a public source.**
     <!-- vale on -->
 6. Select **Install**. n8n installs the node, and returns to the **Community Nodes** list in **Settings**.
+
+/// note | Supported package selectors
+The in-app installer supports:
+
+* package names, such as `n8n-nodes-storms`
+* exact versions, such as `n8n-nodes-storms@2.3.0`
+* npm dist-tags, such as `n8n-nodes-storms@beta` or `n8n-nodes-storms@next`
+
+If you install a package using a dist-tag, later update checks and the **Update** button keep following that same tag.
+
+The in-app installer doesn't support semver ranges or non-registry npm specs. For example, `^2.3.0`, `npm:other-package`, `file:`, git URLs, and tarball URLs aren't supported.
+///
 
 /// note | Nodes on the blocklist
 n8n maintains a blocklist of community nodes that it prevents you from installing. Refer to [n8n community node blocklist](/integrations/community-nodes/blocklist.md) for more information.
@@ -44,19 +57,22 @@ To uninstall a community node:
 /// warning | Breaking changes in versions
 Node developers may introduce breaking changes in new versions of their nodes. A breaking change is an update that breaks previous functionality. Depending on the node versioning approach that a node developer chooses, upgrading to a version with a breaking change could cause all workflows using the node to break. Be careful when upgrading your nodes. If you find that an upgrade causes issues, you can [downgrade](#downgrade-a-community-node).
 ///
-### Upgrade to the latest version
+### Upgrade from the node list
 
-You can upgrade community nodes to the latest version from the node list in **Settings** > **community nodes**.
+You can upgrade community nodes from the node list in **Settings** > **Community nodes**.
 
-When a new version of a community node is available, n8n displays an **Update** button on the node. Click the button to upgrade to the latest version.
+When a new version of a community node is available, n8n displays an **Update** button on the node.
 
-### Upgrade to a specific version
+* If you installed the package from the default `latest` channel, **Update** installs the latest version.
+* If you installed the package using a dist-tag such as `beta` or `next`, **Update** keeps following that same tag.
 
-To upgrade to a specific version (a version other than the latest), uninstall the node, then reinstall it, making sure to specify the target version. Follow the [Installation](#install-a-community-node) instructions for more guidance.
+### Upgrade to a specific version or tag
+
+To switch to a specific version or tag, uninstall the node, then reinstall it, making sure to enter the target version or tag. Follow the [Installation](#install-a-community-node) instructions for more guidance.
 
 ## Downgrade a community node
 
 If there is a problem with a particular version of a community node, you may want to roll back to a previous version.
 
-To do this, uninstall the community node, then reinstall it, targeting a specific node version. Follow the [Installation](#install-a-community-node) instructions for more guidance.
+To do this, uninstall the community node, then reinstall it, targeting a specific node version. Use an exact version number if you need to return to a known release. Follow the [Installation](#install-a-community-node) instructions for more guidance.
 


### PR DESCRIPTION
## Summary

Updates the GUI community node installation docs to match the new backend behavior for npm package selectors.

This PR:
- adds examples for installing community nodes with npm dist-tags such as `beta`
- documents which selectors the in-app installer supports: package name, exact version, and dist-tag
- clarifies that semver ranges and non-registry npm specs aren't supported in the in-app installer
- explains that the **Update** button keeps following the original dist-tag when a package was installed from a tagged channel
- clarifies that downgrades should use an exact version when you need to return to a known release

## Related issues

Refs n8n-io/n8n#27401

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update community node installation docs to cover npm dist-tags and the in-app installer’s supported selectors, aligning with new semver validation. Adds examples for dist-tags like `beta`/`next`, clarifies support for package name, exact version, and dist-tags only, notes that semver ranges and non-registry specs aren’t supported, explains that the Update button keeps following the original tag, and recommends using exact versions for downgrades.

<sup>Written for commit 56e0e207d079e4fd9014197e63c48d11d76ac255. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

