### PR TITLE
fix: clarify protected instance description in setup guide

### DIFF
--- a/docs/source-control-environments/setup.md
+++ b/docs/source-control-environments/setup.md
@@ -65,7 +65,7 @@ Required permissions for your token:
 
 1. In **Settings** > **Environments** in n8n, select **Connect**. n8n connects to your Git repository.
 1. Under **Instance settings**, choose which branch you want to use for the current n8n instance.
-1. **Optional**: select **Protected instance** to prevent users editing workflows in this instance. This is useful for protecting production instances.
+1. **Optional**: select **Protected instance** to prevent users editing source-controlled resources in this instance. This is useful for protecting production instances.
 1. **Optional**: choose a custom color for the instance. This will appear in the menu next to the source control push and pull buttons. It helps users know which instance they're in.
 1. Select **Save settings**.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified the “Protected instance” option in the setup guide to say it blocks edits to source‑controlled resources (not just workflows). This aligns the docs with LIGO-256 and explains why admins can’t create Data Tables or Variables on a git‑protected instance.

<sup>Written for commit 98730c60a0859ea58ba4d768738c06842b191691. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

