### PR TITLE
docs: add Tigris to S3 credentials guide

### DIFF
--- a/docs/integrations/builtin/credentials/s3.md
+++ b/docs/integrations/builtin/credentials/s3.md
@@ -17,6 +17,7 @@ Create an account on an S3-compatible server. Use the S3 node for generic or non
 
 * [DigitalOcean Spaces](https://www.digitalocean.com/products/spaces)
 * [MinIO](https://min.io/)
+* [Tigris](https://www.tigrisdata.com/)
 * [Wasabi](https://wasabi.com/)
 
 ## Supported authentication methods
@@ -38,7 +39,7 @@ To configure this credential, you'll need:
 - **Force Path Style**: When turned on, the connection uses path-style addressing for buckets.
 - **Ignore SSL Issues**: When turned on, n8n will connect even if SSL certificate validation fails.
 
-More detailed instructions for DigitalOcean Spaces and Wasabi follow. If you're using a different provider, refer to their documentation for more information. 
+More detailed instructions for DigitalOcean Spaces, Tigris, and Wasabi follow. If you're using a different provider, refer to their documentation for more information.
 
 ### Using DigitalOcean Spaces
 
@@ -61,6 +62,21 @@ To configure the credential for use with DigitalOcean spaces:
     - To connect even if SSL certificate validation fails, turn on **Ignore SSL Issues**.
 
 Refer to DigitalOcean's [Spaces API Reference Documentation](https://docs.digitalocean.com/reference/api/spaces-api/) for more information.
+
+### Using Tigris
+
+To configure the credential for use with Tigris:
+
+1. For the **S3 Endpoint**, enter `https://t3.storage.dev`.
+2. For the **Region**, enter `auto`.
+3. Log into the [Tigris Dashboard](https://console.tigris.dev/).
+4. Create a new access key pair. Tigris access keys are prefixed with `tid_` and secrets with `tsec_`.
+5. Copy the access key and enter it in n8n as the **Access Key ID**.
+6. Copy the secret key and enter it in n8n as the **Secret Access Key**.
+7. Keep the **Force Path Style** toggle turned off. Tigris uses virtual-hosted-style addressing.
+8. Keep the **Ignore SSL Issues** toggle turned off.
+
+Refer to the [Tigris documentation](https://www.tigrisdata.com/docs/) for more information.
 
 ### Using Wasabi
 


### PR DESCRIPTION
### Summary
Hey! 👋 This PR adds Tigris as an S3-compatible provider to the S3 credentials documentation, following the same step-by-step format used for DigitalOcean Spaces and Wasabi.

1. Adds Tigris to the prerequisites provider list
2. Adds a "Using Tigris" section with endpoint, region, credential setup, and path style guidance
3. Slotted in alphabetically between DigitalOcean and Wasabi

### Why
Outside of AWS, users are looking for S3-compatible alternatives. Tigris is S3-compatible with zero egress fees and a free tier (5 GB). The S3 credentials page already has provider-specific guides — this fills in a gap for a provider that works out of the box with the S3 node.

### Test plan

- [X]  Verified credential fields against `packages/nodes-base/credentials/S3.credentials.ts` in the main n8n repo (`endpoint,` `region`,` forcePathStyle` all match)
- [X]  Follows existing format for DigitalOcean Spaces and Wasabi sections
- [X]  Single file change to `docs/integrations/builtin/credentials/s3.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Tigris as an S3-compatible provider in the S3 credentials docs to help users connect Tigris with the S3 node. Includes a step-by-step setup section (endpoint `https://t3.storage.dev`, region `auto`, `tid_`/`tsec_` keys, virtual-hosted-style addressing, SSL on) and updates the provider list.

<sup>Written for commit bdfeeb1938f57209a36052d3a383aa6568cead2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

