### PR TITLE
docs: update node linter references to @n8n/eslint-plugin-community-nodes

### DIFF
--- a/_snippets/integrations/submit-community-node.md
+++ b/_snippets/integrations/submit-community-node.md
@@ -20,20 +20,20 @@ Developing with the [`n8n-node` tool](/integrations/creating-nodes/build/n8n-nod
 ## Publishing to npm
 
 /// note | Required for Creator Portal verification
-From May 1st 2026, nodes submitted for verification must be published via GitHub Actions with a [provenance statement](https://docs.npmjs.com/generating-provenance-statements). Direct `npm publish` from a local machine will not be accepted for verified nodes.
+From May 1st 2026, nodes submitted for verification must be published using GitHub Actions with a [provenance statement](https://docs.npmjs.com/generating-provenance-statements). n8n won't accept verified nodes published directly from a local machine.
 ///
 
-If you want to submit your node for verification through the n8n Creator Portal, you must publish using a GitHub Actions workflow with a provenance statement. Provenance lets anyone cryptographically verify that a package was built by a specific workflow, from a specific repository and commit. GitHub Actions signs the provenance statement using its OIDC infrastructure.
+To submit your node for verification through the n8n Creator Portal, publish using a GitHub Actions workflow with a provenance statement. Provenance lets anyone cryptographically verify that a specific workflow built the package, from a specific repository and commit. GitHub Actions signs the provenance statement using its OIDC infrastructure.
 
 ### New nodes
 
-If you scaffold your node with `npm create @n8n/node`, a ready-to-use `publish.yml` workflow is included automatically. Run `npm run release` locally to bump the version, commit, tag, and push — this triggers the workflow to publish to npm.
+If you scaffold your node with `npm create @n8n/node`, the scaffolding includes a ready-to-use `publish.yml` workflow. Run `npm run release` locally to bump the version, commit, tag, and push. This triggers the workflow to publish to npm.
 
 ### Existing nodes
 
 Add the [publish workflow from the n8n-nodes-starter](https://github.com/n8n-io/n8n-nodes-starter/blob/master/.github/workflows/publish.yml) to your repository at `.github/workflows/publish.yml`.
 
-Also make sure your project has `@n8n/node-cli` version `0.23.0` or later installed as a dev dependency, as earlier versions don't support the provenance flag used by the workflow:
+Also make sure your project has `@n8n/node-cli` version `0.23.0` or later as a `devDependency`, as earlier versions don't support the provenance flag used by the workflow:
 
 ```sh
 npm list @n8n/node-cli
@@ -41,23 +41,23 @@ npm list @n8n/node-cli
 
 ### One-time setup
 
-Configure npm to trust your repository's GitHub Actions workflow so it can publish on your behalf — no long-lived token required:
+Configure npm to trust your repository's GitHub Actions workflow so it can publish on your behalf. No long-lived token required:
 
 1. Log in to [npmjs.com](https://www.npmjs.com/) and open your package's settings.
-2. Under **Publish access → Trusted Publishers**, click **Add a publisher**.
+2. Under **Publish access > Trusted Publishers**, click **Add a publisher**.
 3. Select **GitHub Actions** and fill in:
    - **Repository owner**: your GitHub username or organisation
    - **Repository name**: your repository name
    - **Workflow name**: `publish.yml` (the filename, not the workflow `name:` field)
 
-Alternatively, create a Granular Access Token on npmjs.com and store it as `NPM_TOKEN` in your repository's Actions secrets. See the comments in the workflow file for details.
+To use a token instead, create a Granular Access Token on npmjs.com and store it as `NPM_TOKEN` in your repository's Actions secrets. See the comments in the workflow file for details.
 
 ## Submit your node for verification by n8n
 
 n8n vets verified community nodes. Users can discover and install verified community nodes from the nodes panel in n8n. These nodes need to adhere to certain technical and UX standards and constraints.
 
 /// note | GitHub Actions publish required for verification
-From May 1st 2026, nodes submitted for verification through the [n8n Creator Portal](https://creators.n8n.io/nodes) must be published via GitHub Actions with a provenance statement. See [Publishing to npm](#publishing-to-npm) for setup instructions.
+From May 1st 2026, nodes submitted for verification through the [n8n Creator Portal](https://creators.n8n.io/nodes) must be published using GitHub Actions with a provenance statement. See [Publishing to npm](#publishing-to-npm) for setup instructions.
 ///
 
 Before submitting your node for review by n8n, you must:

--- a/_snippets/integrations/submit-community-node.md
+++ b/_snippets/integrations/submit-community-node.md
@@ -15,15 +15,15 @@ Developing with the [`n8n-node` tool](/integrations/creating-nodes/build/n8n-nod
 * Include `n8n-community-node-package` in your package keywords.
 * Make sure that you add your nodes and credentials to the `package.json` file inside the `n8n` attribute.
 * Check your node using the linter (`npm run lint`) and test it locally (`npm run dev`) to ensure it works.
-* Publish the package to npm using a GitHub Actions workflow with a [provenance statement](https://docs.npmjs.com/generating-provenance-statements). This is required from May 1st 2026. See [Publishing to npm](#publishing-to-npm) below.
+* Publish the package to npm. If you plan to submit your node for verification through the [n8n Creator Portal](https://creators.n8n.io/nodes), you must publish using a GitHub Actions workflow with a [provenance statement](https://docs.npmjs.com/generating-provenance-statements). See [Publishing to npm](#publishing-to-npm) below.
 
 ## Publishing to npm
 
-/// warning | Requirement from May 1st 2026
-From May 1st 2026 you must publish **all** community nodes using a GitHub Actions workflow that includes a [provenance statement](https://docs.npmjs.com/generating-provenance-statements). Direct `npm publish` from a local machine will no longer be accepted.
+/// note | Required for Creator Portal verification
+From May 1st 2026, nodes submitted for verification must be published via GitHub Actions with a [provenance statement](https://docs.npmjs.com/generating-provenance-statements). Direct `npm publish` from a local machine will not be accepted for verified nodes.
 ///
 
-Provenance lets anyone cryptographically verify that a package was built by a specific workflow, from a specific repository and commit. GitHub Actions signs the provenance statement using its OIDC infrastructure.
+If you want to submit your node for verification through the n8n Creator Portal, you must publish using a GitHub Actions workflow with a provenance statement. Provenance lets anyone cryptographically verify that a package was built by a specific workflow, from a specific repository and commit. GitHub Actions signs the provenance statement using its OIDC infrastructure.
 
 ### New nodes
 
@@ -55,6 +55,10 @@ Alternatively, create a Granular Access Token on npmjs.com and store it as `NPM_
 ## Submit your node for verification by n8n
 
 n8n vets verified community nodes. Users can discover and install verified community nodes from the nodes panel in n8n. These nodes need to adhere to certain technical and UX standards and constraints.
+
+/// note | GitHub Actions publish required for verification
+From May 1st 2026, nodes submitted for verification through the [n8n Creator Portal](https://creators.n8n.io/nodes) must be published via GitHub Actions with a provenance statement. See [Publishing to npm](#publishing-to-npm) for setup instructions.
+///
 
 Before submitting your node for review by n8n, you must:
 

--- a/_snippets/integrations/submit-community-node.md
+++ b/_snippets/integrations/submit-community-node.md
@@ -15,13 +15,44 @@ Developing with the [`n8n-node` tool](/integrations/creating-nodes/build/n8n-nod
 * Include `n8n-community-node-package` in your package keywords.
 * Make sure that you add your nodes and credentials to the `package.json` file inside the `n8n` attribute.
 * Check your node using the linter (`npm run lint`) and test it locally (`npm run dev`) to ensure it works.
-* Submit the package to the npm registry. Refer to npm's documentation on [Contributing packages to the registry](https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry) for more information.
+* Publish the package to npm using a GitHub Actions workflow with a [provenance statement](https://docs.npmjs.com/generating-provenance-statements). This is required from May 1st 2026. See [Publishing to npm](#publishing-to-npm) below.
+
+## Publishing to npm
+
+/// warning | Requirement from May 1st 2026
+From May 1st 2026 you must publish **all** community nodes using a GitHub Actions workflow that includes a [provenance statement](https://docs.npmjs.com/generating-provenance-statements). Direct `npm publish` from a local machine will no longer be accepted.
+///
+
+Provenance lets anyone cryptographically verify that a package was built by a specific workflow, from a specific repository and commit. GitHub Actions signs the provenance statement using its OIDC infrastructure.
+
+### New nodes
+
+If you scaffold your node with `npm create @n8n/node`, a ready-to-use `publish.yml` workflow is included automatically. Run `npm run release` locally to bump the version, commit, tag, and push — this triggers the workflow to publish to npm.
+
+### Existing nodes
+
+Add the [publish workflow from the n8n-nodes-starter](https://github.com/n8n-io/n8n-nodes-starter/blob/master/.github/workflows/publish.yml) to your repository at `.github/workflows/publish.yml`.
+
+Also make sure your project has `@n8n/node-cli` version `0.23.0` or later installed as a dev dependency, as earlier versions don't support the provenance flag used by the workflow:
+
+```sh
+npm list @n8n/node-cli
+```
+
+### One-time setup
+
+Configure npm to trust your repository's GitHub Actions workflow so it can publish on your behalf — no long-lived token required:
+
+1. Log in to [npmjs.com](https://www.npmjs.com/) and open your package's settings.
+2. Under **Publish access → Trusted Publishers**, click **Add a publisher**.
+3. Select **GitHub Actions** and fill in:
+   - **Repository owner**: your GitHub username or organisation
+   - **Repository name**: your repository name
+   - **Workflow name**: `publish.yml` (the filename, not the workflow `name:` field)
+
+Alternatively, create a Granular Access Token on npmjs.com and store it as `NPM_TOKEN` in your repository's Actions secrets. See the comments in the workflow file for details.
 
 ## Submit your node for verification by n8n
-
-/// note | Upcoming Changes
-From May 1st 2026 you must publish **ALL** community nodes using a GitHub action and include a [provenance statement](https://docs.npmjs.com/generating-provenance-statements)
-///
 
 n8n vets verified community nodes. Users can discover and install verified community nodes from the nodes panel in n8n. These nodes need to adhere to certain technical and UX standards and constraints.
 
@@ -31,7 +62,7 @@ Before submitting your node for review by n8n, you must:
 * Make sure that your node follows the [technical guidelines for verified community nodes](/integrations/creating-nodes/build/reference/verification-guidelines.md) and that all automated checks pass. Specifically, verified community nodes aren't allowed to use any run-time dependencies.
 * Ensure that your node follows the [UX guidelines](/integrations/creating-nodes/build/reference/ux-guidelines.md).
 * Make sure that the node has appropriate documentation in the form of a README in the [npm package](https://docs.npmjs.com/about-package-readme-files) or a related public repository.
-* Submit your node to npm as n8n will fetch it from there for final vetting.
+* Publish your node to npm using a GitHub Actions workflow with provenance, as described in [Publishing to npm](#publishing-to-npm). n8n will fetch it from there for final vetting.
 
 ## Ready to submit?
 If your node meets all the above requirements, sign up or log in to the [n8n Creator Portal](https://creators.n8n.io/nodes) and submit your node for verification. Note that n8n reserves the right to reject nodes that compete with any of n8n's paid features, especially enterprise functionality.

--- a/docs/integrations/creating-nodes/test/node-linter.md
+++ b/docs/integrations/creating-nodes/test/node-linter.md
@@ -4,18 +4,18 @@ contentType: howto
 
 # n8n node linter
 
-n8n's node linter, [`eslint-plugin-n8n-nodes-base`](https://github.com/ivov/eslint-plugin-n8n-nodes-base), statically analyzes ("lints") the source code of n8n nodes and credentials in the official repository and in community packages. The linter detects issues and automatically fixes them to help you follow best practices.
+n8n's node linter, [`@n8n/eslint-plugin-community-nodes`](https://github.com/n8n-io/n8n/tree/master/packages/%40n8n/eslint-plugin-community-nodes), statically analyzes ("lints") the source code of n8n nodes and credentials in community packages. The linter detects issues and automatically fixes them to help you follow best practices.
 
-`eslint-plugin-n8n-nodes-base` contains a [collection of rules](https://github.com/ivov/eslint-plugin-n8n-nodes-base#ruleset) for node files (`*.node.ts`), resource description files (`*Description.ts`), credential files (`*.credentials.ts`), and the `package.json` of a community package.
+`@n8n/eslint-plugin-community-nodes` contains a [collection of rules](https://github.com/n8n-io/n8n/tree/master/packages/%40n8n/eslint-plugin-community-nodes#rules) for node files (`*.node.ts`), credential files (`*.credentials.ts`), and the `package.json` of a community package.
 
 ## Setup
 
-If using the [n8n node starter](https://github.com/n8n-io/n8n-nodes-starter): Run `npm install` in the starter project to install all dependencies. Once the installation finishes, the linter is available to you. 
+If using the [n8n node starter](https://github.com/n8n-io/n8n-nodes-starter): Run `npm install` in the starter project to install all dependencies. Once the installation finishes, the linter is available to you.
 
 If using VS Code, install the [ESLint VS Code extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint). For other IDEs, refer to their ESLint integrations.
 
 /// note | Don't edit the configuration file
-[`.eslintrc.js`](https://github.com/n8n-io/n8n-nodes-starter/blob/master/.eslintrc.js) contains the configuration for `eslint-plugin-n8n-nodes-base`. Don't edit this file.
+[`eslint.config.mjs`](https://github.com/n8n-io/n8n-nodes-starter/blob/master/eslint.config.mjs) contains the ESLint configuration provided by [`@n8n/node-cli`](https://www.npmjs.com/package/@n8n/node-cli). Don't edit this file.
 ///
 
 ## Usage
@@ -30,8 +30,8 @@ In both cases, VS Code lints in the background as you work on your project. Hove
 
 You can also run the linter manually:
 
-* Run `npm run lint` to lint and view detected issues in your console. 
-* Run `npm run lintfix` to lint and automatically fix issues. The linter fixes violations of rules [marked as automatically fixable](https://github.com/ivov/eslint-plugin-n8n-nodes-base#ruleset).
+* Run `npm run lint` to lint and view detected issues in your console.
+* Run `npm run lint:fix` to lint and automatically fix issues. The linter fixes violations of rules [marked as automatically fixable](https://github.com/n8n-io/n8n/tree/master/packages/%40n8n/eslint-plugin-community-nodes#rules).
 
 Both commands can run in the root directory of your community package, or in `/packages/nodes-base/` in the main repository.
 
@@ -39,6 +39,6 @@ Both commands can run in the root directory of your community package, or in `/p
 
 Instead of fixing a rule violation, you can also make an exception for it, so the linter doesn't flag it.
 
-To make a lint exception from VS Code: hover over the issue and click on `Quick fix` (or `cmd+.` in macOS) and select **Disable {rule} for this line**. Only disable rules for a line where you have good reason to. If you think the linter is incorrectly reporting an issue, please [report it in the linter repository](https://github.com/ivov/eslint-plugin-n8n-nodes-base/issues).
+To make a lint exception from VS Code: hover over the issue and click on `Quick fix` (or `cmd+.` in macOS) and select **Disable {rule} for this line**. Only disable rules for a line where you have good reason to. If you think the linter is incorrectly reporting an issue, please [report it in the n8n repository](https://github.com/n8n-io/n8n/issues).
 
-To add a lint exception to a single file, add a code comment. In particular, TSLint rules may not show up in VS Code and may need to be turned off using code comments. Refer to the [TSLint documentation](https://palantir.github.io/tslint/usage/rule-flags/) for more guidance.  
+To add a lint exception to a single file, add a code comment. Refer to the [ESLint documentation](https://eslint.org/docs/latest/use/configure/rules#disabling-rules) for more guidance.


### PR DESCRIPTION
## Summary
- Replace all references to the deprecated `eslint-plugin-n8n-nodes-base` (from `ivov/eslint-plugin-n8n-nodes-base`) with the new `@n8n/eslint-plugin-community-nodes` package in the n8n monorepo
- Update config file reference from `.eslintrc.js` to `eslint.config.mjs` and note it's provided by `@n8n/node-cli`
- Fix lint command from `npm run lintfix` to `npm run lint:fix`
- Replace deprecated TSLint documentation link with current ESLint docs
- Point issue reporting link to `n8n-io/n8n` instead of the old personal repo

## Test plan
- [ ] Verify all links in the updated page resolve correctly
- [ ] Confirm the page renders properly in the docs site