### PR TITLE
docs: update node linter references to @n8n/eslint-plugin-community-nodes

### DIFF
--- a/docs/integrations/creating-nodes/test/node-linter.md
+++ b/docs/integrations/creating-nodes/test/node-linter.md
@@ -4,18 +4,18 @@ contentType: howto
 
 # n8n node linter
 
-n8n's node linter, [`eslint-plugin-n8n-nodes-base`](https://github.com/ivov/eslint-plugin-n8n-nodes-base), statically analyzes ("lints") the source code of n8n nodes and credentials in the official repository and in community packages. The linter detects issues and automatically fixes them to help you follow best practices.
+n8n's node linter, [`@n8n/eslint-plugin-community-nodes`](https://github.com/n8n-io/n8n/tree/master/packages/%40n8n/eslint-plugin-community-nodes), statically analyzes ("lints") the source code of n8n nodes and credentials in community packages. The linter detects issues and automatically fixes them to help you follow best practices.
 
-`eslint-plugin-n8n-nodes-base` contains a [collection of rules](https://github.com/ivov/eslint-plugin-n8n-nodes-base#ruleset) for node files (`*.node.ts`), resource description files (`*Description.ts`), credential files (`*.credentials.ts`), and the `package.json` of a community package.
+`@n8n/eslint-plugin-community-nodes` contains a [collection of rules](https://github.com/n8n-io/n8n/tree/master/packages/%40n8n/eslint-plugin-community-nodes#rules) for node files (`*.node.ts`), credential files (`*.credentials.ts`), and the `package.json` of a community package.
 
 ## Setup
 
-If using the [n8n node starter](https://github.com/n8n-io/n8n-nodes-starter): Run `npm install` in the starter project to install all dependencies. Once the installation finishes, the linter is available to you. 
+If using the [n8n node starter](https://github.com/n8n-io/n8n-nodes-starter): Run `npm install` in the starter project to install all dependencies. Once the installation finishes, the linter is available to you.
 
 If using VS Code, install the [ESLint VS Code extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint). For other IDEs, refer to their ESLint integrations.
 
 /// note | Don't edit the configuration file
-[`.eslintrc.js`](https://github.com/n8n-io/n8n-nodes-starter/blob/master/.eslintrc.js) contains the configuration for `eslint-plugin-n8n-nodes-base`. Don't edit this file.
+[`eslint.config.mjs`](https://github.com/n8n-io/n8n-nodes-starter/blob/master/eslint.config.mjs) contains the ESLint configuration provided by [`@n8n/node-cli`](https://www.npmjs.com/package/@n8n/node-cli). Don't edit this file.
 ///
 
 ## Usage
@@ -30,8 +30,8 @@ In both cases, VS Code lints in the background as you work on your project. Hove
 
 You can also run the linter manually:
 
-* Run `npm run lint` to lint and view detected issues in your console. 
-* Run `npm run lintfix` to lint and automatically fix issues. The linter fixes violations of rules [marked as automatically fixable](https://github.com/ivov/eslint-plugin-n8n-nodes-base#ruleset).
+* Run `npm run lint` to lint and view detected issues in your console.
+* Run `npm run lint:fix` to lint and automatically fix issues. The linter fixes violations of rules [marked as automatically fixable](https://github.com/n8n-io/n8n/tree/master/packages/%40n8n/eslint-plugin-community-nodes#rules).
 
 Both commands can run in the root directory of your community package, or in `/packages/nodes-base/` in the main repository.
 
@@ -39,6 +39,6 @@ Both commands can run in the root directory of your community package, or in `/p
 
 Instead of fixing a rule violation, you can also make an exception for it, so the linter doesn't flag it.
 
-To make a lint exception from VS Code: hover over the issue and click on `Quick fix` (or `cmd+.` in macOS) and select **Disable {rule} for this line**. Only disable rules for a line where you have good reason to. If you think the linter is incorrectly reporting an issue, please [report it in the linter repository](https://github.com/ivov/eslint-plugin-n8n-nodes-base/issues).
+To make a lint exception from VS Code: hover over the issue and click on `Quick fix` (or `cmd+.` in macOS) and select **Disable {rule} for this line**. Only disable rules for a line where you have good reason to. If you think the linter is incorrectly reporting an issue, please [report it in the n8n repository](https://github.com/n8n-io/n8n/issues).
 
-To add a lint exception to a single file, add a code comment. In particular, TSLint rules may not show up in VS Code and may need to be turned off using code comments. Refer to the [TSLint documentation](https://palantir.github.io/tslint/usage/rule-flags/) for more guidance.  
+To add a lint exception to a single file, add a code comment. Refer to the [ESLint documentation](https://eslint.org/docs/latest/use/configure/rules#disabling-rules) for more guidance.


### PR DESCRIPTION
## Summary
- Replace all references to the deprecated `eslint-plugin-n8n-nodes-base` (from `ivov/eslint-plugin-n8n-nodes-base`) with the new `@n8n/eslint-plugin-community-nodes` package in the n8n monorepo
- Update config file reference from `.eslintrc.js` to `eslint.config.mjs` and note it's provided by `@n8n/node-cli`
- Fix lint command from `npm run lintfix` to `npm run lint:fix`
- Replace deprecated TSLint documentation link with current ESLint docs
- Point issue reporting link to `n8n-io/n8n` instead of the old personal repo

## Test plan
- [ ] Verify all links in the updated page resolve correctly
- [ ] Confirm the page renders properly in the docs site