### PR TITLE
Rework Instance-level MCP documentation

### DIFF
--- a/docs/advanced-ai/mcp/accessing-n8n-mcp-server.md
+++ b/docs/advanced-ai/mcp/accessing-n8n-mcp-server.md
@@ -13,7 +13,7 @@ The server allows clients such as Lovable or Claude Desktop to connect securely 
 - Search within workflows marked as available in MCP
 - Retrieve metadata and trigger information for workflows
 - Trigger and run exposed workflows
-- Create and edit workflows
+- Create and edit workflows and data tables
 
 ## Difference between instance-level MCP access and MCP Server Trigger node
 
@@ -24,7 +24,7 @@ In comparison, you configure an MCP Server Trigger node inside a single workflow
 ### Key considerations when using instance-level MCP access
 
 - MCP supports two types of workflow interactions: running existing workflows with the workflow execution tools, and building or editing workflows (v2.13 onward).
-- It doesn’t provide blanket exposure to all workflows in your instance. You must enable MCP at the instance level and then enable each workflow individually.
+- It doesn’t provide blanket exposure to all workflows in your instance. You must enable MCP at the instance level and then enable each workflow individually. The only exception here is the `search_workflows` tool, which is able to access all workflows current user has access to but it will only be able to surface previews, not the full workflow data.
 - It’s not scoped to each MCP client. Any connected client sees all workflows you’ve enabled for MCP access.
 - Most MCP tools work on unpublished workflows. The exception is `execute_workflow`, which defaults to production mode and runs the published version of a workflow. It also supports a `manual` execution mode to run the current (unpublished) version.
 
@@ -158,91 +158,13 @@ To help MCP clients identify workflows, you can add free-text descriptions as fo
 
 	![mcp_workflow_description.png](/_images/advanced-ai/mcp_workflow_description.png)
 
-## Executing workflows through MCP clients
-
-MCP clients can execute workflows that you identify as available in MCP.
-
-When a workflow is triggered or created, it runs as usual in n8n, and you can monitor its execution in the **Executions** list. Once the execution is complete, the MCP client will retrieve the results.
-
-### Providing input data
-
-MCP clients are typically able to assess what inputs are expected by a workflow. If you have a webhook trigger and If you see a client struggling to determine the right inputs, we recommend you provide this information in the workflow description.
-
-### Workflow timeouts
-
-n8n enforces a 5-minute timeout for workflow executions triggered by MCP clients. If a workflow doesn't finish in time, n8n stops the execution and sends an error to the MCP client, ignoring any timeout you set in the workflow settings for MCP-triggered executions.
-
-### Limitations
-
-- If there are multiple supported triggers in a workflow, MCP clients may only be able to use one (first one) of them to trigger the workflow when using workflow execution tools (not applicable to AI Workflow builder workflows).
-- Executing workflows with multi-step forms or any kind of human-in-the-loop interactions isn't supported.
-- Binary input data isn't supported. MCP clients can only provide text-based inputs for your workflows.
-
-## Tools
+## Tools and resources
 
 /// tip
 Consider using coding agents (such as Claude Code or Google ADK agents) instead of chat clients as your MCP clients. Coding agents are optimized for generating and validating TypeScript code, making them ideal for building workflows programmatically.
 ///
 
-The n8n MCP Server exposes the following tools so that you can create and update workflows using an MCP Client.
-
-### SDK and node reference
-
-* `get_sdk_reference`: Retrieve n8n SDK documentation to understand the TypeScript syntax used for building workflows as code. Supports fetching either the full documentation or specific sections. Valid sections: `patterns`, `expressions`, `functions`, `rules`, `import`, `guidelines`, `design`, or `all` (v2.13 onward).
-* `search_nodes`: Search for n8n nodes by service name, trigger type, or utility function. Returns node IDs, discriminators (resource/operation/mode parameters), and related nodes needed for the `get_node_types` tool (v2.13 onward).
-* `get_node_types`: Retrieve TypeScript type definitions for n8n nodes. Returns exact parameter names and structures needed for proper node configuration (v2.13 onward).
-* `get_suggested_nodes`: Get curated node recommendations for workflow technique categories. Returns recommended nodes with pattern hints and configuration guidance (v2.13 onward).
-
-### Workflow creation and validation
-
-* `validate_workflow`: Validate TypeScript workflow code for syntax and structural errors. Returns either a success confirmation or a list of errors that need fixing (v2.13 onward).
-* `create_workflow_from_code`: Create a new workflow in n8n from validated TypeScript workflow code. The tool parses the code into workflow JSON and saves it to your n8n instance. Newly created workflows automatically have descriptions generated from the code and MCP access enabled. Optionally accepts `projectId` and `folderId` parameters to create the workflow inside a project or folder. (v2.14 onward)
-* `update_workflow`: Update an existing workflow in n8n from validated TypeScript workflow code. Parses the code and saves changes to your n8n instance (v2.13 onward).
-* `delete_workflow`: Archive a workflow by ID.
-* `publish_workflow`: Publish a workflow by ID.
-* `unpublish_workflow`: Unpublish a workflow by ID.
-
-### Workflow discovery
-
-* `search_workflows`: Search for workflows enabled for MCP access. Returns workflow IDs, names, descriptions, and trigger information.
-* `get_workflow_details`: Get detailed information about a specific workflow including trigger details.
-
-### Workflow execution
-
-* `execute_workflow`: Execute a workflow by ID. Defaults to `production` mode, which runs the **published** version of the workflow - the workflow must be published for this mode. Supports a `manual` mode to run the current (unpublished) version instead. Returns an execution ID and status; use `get_execution` to retrieve full results.
-
-### Workflow introspection
-
-* `get_execution`: Retrieve workflow execution history and results. Supports filtering parameters to avoid context overflow. (v2.14 onward)
-    * `includeData` (boolean): Include full execution result data. Defaults to `false` (metadata only).
-    * `nodeNames` (array): When `includeData` is true, return data only for the specific node names.
-    * `truncateData` (boolean): When `includeData` is true, limit the number of data items returned per node.
-
-### Testing workflows
-
-* `prepare_test_pin_data`: Look at a workflow and return JSON schemas for any nodes that need simulated data (triggers, credentialed nodes, HTTP requests). Use these schemas to generate realistic test data before running `test_workflow`. (v2.15 onward)
-* `test_workflow`: Run a workflow using generated pin data to simulate external services, while still actually executing logic nodes (Set, If, Code). Return the execution status. (v2.15 onward)
-
-### Projects and folders
-
-* `search_projects`: Search for projects accessible to the current user. (v2.14 onward)
-* `search_folders`: Search for folders within a project. (v2.14 onward)
-
-### Data tables
-
-* `create_data_table`: Create a new data table with the specified columns. Use `search_projects` to find a project ID first. (v2.16 onward)
-* `search_data_tables`: Search for data tables accessible to the current user. Use this to find a data table ID before modifying or adding data to it. (v2.16 onward)
-* `add_data_table_rows`: Insert rows into an existing data table. Each row is an object mapping column names to values. Use `search_data_tables` to find the data table ID first. (v2.16 onward)
-* `add_data_table_column`: Add a new column to an existing data table. (v2.16 onward)
-* `rename_data_table`: Rename an existing data table. (v2.16 onward)
-* `rename_data_table_column`: Rename a column in a data table. (v2.16 onward)
-* `delete_data_table_column`: Delete a column from a data table. This permanently removes the column and all its data. (v2.16 onward)
-
-## Resources
-
-For MCP clients that support resources:
-
-* `workflow-sdk-reference`: Access n8n SDK documentation as an MCP resource, providing comprehensive reference material for building workflows as code.
+The n8n MCP server exposes tools for workflow management, workflow building, and data tables. For a complete list of available tools and their parameters, refer to the [MCP server tools reference](mcp_tools_reference.md).
 
 ## Examples
 
@@ -270,10 +192,6 @@ For MCP clients that support resources:
 5. When prompted, authorize Claude Desktop to access your n8n instance.
 
 ##### Using Access Token
-
-/// info
-This requires the latest version of [Node.js](https://nodejs.org/en/download).
-///
 
 Add the following entry to your `claude_desktop_config.json` file:
 
@@ -380,4 +298,3 @@ If you encounter issues connecting MCP clients to your n8n instance, consider th
 - Check that the workflows you want to access are marked as available in MCP.
 - Confirm that the authentication method (OAuth2 or Access Token) is correctly configured in your MCP client.
 - Review n8n server logs for any error messages related to MCP connections.
-- If you are using desktop MCP clients, make sure you have the latest [Node.js](https://nodejs.org/en/download) version installed.

--- a/docs/advanced-ai/mcp/accessing-n8n-mcp-server.md
+++ b/docs/advanced-ai/mcp/accessing-n8n-mcp-server.md
@@ -10,9 +10,9 @@ Connect supported MCP clients to your n8n workflows through n8n's built-in MCP s
 
 The server allows clients such as Lovable or Claude Desktop to connect securely to an n8n instance. Once connected, these clients can:
 
-- Search within workflows marked as available in MCP
-- Retrieve metadata and trigger information for workflows
-- Trigger and run exposed workflows
+- Search for your workflows
+- Interact with workflows marked as available in MCP
+- Trigger and test exposed workflows
 - Create and edit workflows and data tables
 
 ## Difference between instance-level MCP access and MCP Server Trigger node

--- a/docs/advanced-ai/mcp/accessing-n8n-mcp-server.md
+++ b/docs/advanced-ai/mcp/accessing-n8n-mcp-server.md
@@ -4,7 +4,7 @@ description: Connect, authenticate, and integrate MCP clients to build and execu
 status: beta
 ---
 
-# Accessing n8n MCP server
+# Accessing and using n8n MCP server
 
 Connect supported MCP clients to your n8n workflows through n8n's built-in MCP server.
 

--- a/docs/advanced-ai/mcp/mcp_tools_reference.md
+++ b/docs/advanced-ai/mcp/mcp_tools_reference.md
@@ -1,0 +1,816 @@
+---
+title: n8n MCP server tools reference
+description: Complete reference for all tools exposed by the n8n MCP server, including workflow management, workflow builder, and data table tools.
+---
+
+# n8n MCP server tools reference
+
+This page describes all tools exposed by the instance-level MCP server.
+
+---
+
+## Workflow Management
+
+### search_workflows
+
+Search for workflows with optional filters. Returns a preview of each workflow.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `query` | `string` | No | Filter by name or description |
+| `projectId` | `string` | No | Filter by project ID |
+| `limit` | `integer` | No | Limit the number of results (max 200) |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data` | `array` | List of workflow previews |
+| `data[].id` | `string` | The unique identifier of the workflow |
+| `data[].name` | `string | null` | The name of the workflow |
+| `data[].description` | `string | null` | The description of the workflow |
+| `data[].active` | `boolean | null` | Whether the workflow is active |
+| `data[].createdAt` | `string | null` | ISO timestamp when the workflow was created |
+| `data[].updatedAt` | `string | null` | ISO timestamp when the workflow was last updated |
+| `data[].triggerCount` | `number | null` | The number of triggers associated with the workflow |
+| `data[].scopes` | `string[]` | User permissions for this workflow |
+| `data[].canExecute` | `boolean` | Whether the user has permission to execute this workflow |
+| `data[].availableInMCP` | `boolean` | Whether the workflow is visible to MCP tools |
+| `count` | `integer` | Total number of workflows that match the filters |
+
+#### Notes
+
+- Maximum result limit is 200.
+- Includes user permission scopes for each workflow so MCP clients can get more info about what they can do with the workflow.
+- **IMPORTANT**: This tool is able to list all workflows a user has access to, regardless of their `Available in MCP` setting
+
+---
+
+### get_workflow_details
+
+Get detailed information about a specific workflow including trigger details.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `workflowId` | `string` | Yes | The ID of the workflow to retrieve |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workflow` | `object` | Sanitized workflow data safe for MCP consumption |
+| `workflow.id` | `string` | Workflow ID |
+| `workflow.name` | `string | null` | Workflow name |
+| `workflow.active` | `boolean` | Whether the workflow is active |
+| `workflow.isArchived` | `boolean` | Whether the workflow is archived |
+| `workflow.versionId` | `string` | The current workflow version ID |
+| `workflow.activeVersionId` | `string | null` | The active workflow version ID, if available |
+| `workflow.triggerCount` | `number` | Number of triggers |
+| `workflow.createdAt` | `string | null` | ISO creation timestamp |
+| `workflow.updatedAt` | `string | null` | ISO last-updated timestamp |
+| `workflow.settings` | `object | null` | Workflow settings |
+| `workflow.connections` | `object` | Workflow connections graph |
+| `workflow.nodes` | `array` | List of nodes (credentials stripped) |
+| `workflow.activeVersion` | `object | null` | Active workflow graph (nodes + connections), if available |
+| `workflow.tags` | `array` | Tags with `id` and `name` |
+| `workflow.meta` | `object | null` | Workflow metadata |
+| `workflow.parentFolderId` | `string | null` | Parent folder ID |
+| `workflow.description` | `string` | The description of the workflow |
+| `workflow.scopes` | `string[]` | User permissions for this workflow |
+| `workflow.canExecute` | `boolean` | Whether the user has permission to execute this workflow |
+| `triggerInfo` | `string` | Human-readable instructions describing how to trigger the workflow |
+
+#### Notes
+
+- Sensitive credential data is stripped from nodes before returning.
+- Includes active version details if the workflow is published.
+
+---
+
+### execute_workflow
+
+Execute a workflow by ID by mapping data from user prompt to trigger inputs. Returns execution ID and status. This will perform 'full' workflow execution, without mocking or skipping any nodes.
+
+#### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `workflowId` | `string` | Yes | | The ID of the workflow to execute |
+| `executionMode` | `"manual" | "production"` | No | `"production"` | `"manual"` tests the current version, `"production"` executes the published (active) version |
+| `inputs` | `object` | No | | Inputs to provide to the workflow (discriminated union, see below) |
+
+**`inputs` variants (discriminated by `type`):**
+
+| Type | Fields | Description |
+|------|--------|-------------|
+| `chat` | `chatInput: string` | Input for chat-based workflows |
+| `form` | `formData: Record<string, unknown>` | Input data for form-based workflows |
+| `webhook` | `webhookData: { method?, query?, body?, headers? }` | Input data for webhook-based workflows |
+
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `executionId` | `string | null` | The execution ID |
+| `status` | `string` | The status of the execution. One of: `"success"`, `"error"`, `"running"`, `"waiting"`, `"canceled"`, `"crashed"`, `"new"`, `"unknown"` |
+| `error` | `string` | Error message if the execution failed |
+
+#### Notes
+
+- Only supports workflows with specific trigger node types: Webhook, Chat Trigger, Form Trigger, Manual Trigger, Schedule Trigger.
+- When `executionMode` is `"production"`, the workflow must have a published (active) version.
+- If there are multiple supported triggers in a workflow, MCP clients may only be able to use one (first one) of them to trigger the workflow when using workflow execution tools (not applicable to AI Workflow builder workflows).
+- Executing workflows with multi-step forms or any kind of human-in-the-loop interactions isn't supported.
+
+---
+
+### get_execution
+
+/// info | Available from n8n v2.12.0
+///
+
+Get execution details by execution ID and workflow ID. By default returns metadata only.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `workflowId` | `string` | Yes | The ID of the workflow the execution belongs to |
+| `executionId` | `string` | Yes | The ID of the execution to retrieve |
+| `includeData` | `boolean` | No | Whether to include full execution result data. Defaults to false (metadata only). |
+| `nodeNames` | `string[]` | No | When `includeData` is true, return data only for these nodes. If omitted, data for all nodes is included. |
+| `truncateData` | `integer` | No | When `includeData` is true, limit the number of data items returned per node output. |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `execution` | `object | null` | Execution metadata, or null if an error occurred |
+| `execution.id` | `string` | Execution ID |
+| `execution.workflowId` | `string` | Workflow ID |
+| `execution.mode` | `string` | Execution mode |
+| `execution.status` | `string` | Execution status |
+| `execution.startedAt` | `string | null` | ISO timestamp when the execution started |
+| `execution.stoppedAt` | `string | null` | ISO timestamp when the execution stopped |
+| `execution.retryOf` | `string | null` | ID of the execution this is a retry of |
+| `execution.retrySuccessId` | `string | null` | ID of the successful retry execution |
+| `execution.waitTill` | `string | null` | ISO timestamp the execution is waiting until |
+| `data` | `unknown` | Execution result data (only present when `includeData` is true) |
+| `error` | `string` | Error message if the request failed |
+
+#### Notes
+
+- Use lightweight metadata queries (default) when full execution data isn't needed.
+- Filtering by `nodeNames` and truncating via `truncateData` helps manage large result sets.
+
+---
+
+### test_workflow
+
+/// info | Available from n8n v2.15.0
+///
+
+Test a workflow using pin data to bypass external services. Trigger nodes, nodes with credentials, and HTTP Request nodes are pinned (use simulated data). Other nodes (Set, If, Code, etc.) execute normally, including credential-free I/O nodes like Execute Command or file read/write nodes.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `workflowId` | `string` | Yes | The ID of the workflow to test |
+| `pinData` | `Record<string, array>` | Yes | Pin data for all workflow nodes. |
+| `triggerNodeName` | `string` | No | Optional name of the trigger node to start execution from. Defaults to the first trigger node. |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `executionId` | `string | null` | The test execution ID |
+| `status` | `string` | The status of the test execution. One of: `"success"`, `"error"`, `"running"`, `"waiting"`, `"canceled"`, `"crashed"`, `"new"`, `"unknown"` |
+| `error` | `string` | Error message if the execution failed |
+
+#### Notes
+
+- Can be used to test workflow logic without setting up credentials or hitting external services
+- This tool executes workflows synchronously (waits for execution to finish)
+- Has an enforced MCP execution timeout (5 minutes).
+
+---
+
+### prepare_test_pin_data
+
+/// info | Available from n8n v2.15.0
+///
+
+Prepare test pin data for a workflow. Trigger nodes, nodes with credentials, and HTTP Request nodes need pin data. Logic nodes (Set, If, Code, etc.) and credential-free I/O nodes (Execute Command, file read/write) execute normally without pin data. Returns JSON Schemas describing the expected output shape for each node that needs pin data.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `workflowId` | `string` | Yes | The ID of the workflow to generate test pin data for |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `nodeSchemasToGenerate` | `Record<string, JsonSchema>` | Nodes that need pin data. Keys are node names, values are JSON Schema objects describing the expected output shape. |
+| `nodesWithoutSchema` | `string[]` | Node names that need pin data but have no output schema. Use empty defaults `[{"json": {}}]` for each. |
+| `nodesSkipped` | `string[]` | Nodes that don't need pin data and will execute normally during the test. |
+| `coverage` | `object` | Coverage statistics |
+| `coverage.withSchemaFromExecution` | `number` | Nodes with schemas inferred from last successful execution output |
+| `coverage.withSchemaFromDefinition` | `number` | Nodes with schemas from node type definitions |
+| `coverage.withoutSchema` | `number` | Nodes with no data or schema |
+| `coverage.skipped` | `number` | Nodes that will execute normally (no pin data needed) |
+| `coverage.total` | `number` | Total number of enabled nodes |
+
+#### Notes
+
+- Schemas should be used to generate realistic sample data for `test_workflow`.
+
+---
+
+### publish_workflow
+
+/// info | Available from n8n v2.12.0
+///
+
+Publish (activate) a workflow to make it available for production execution. This creates an active version from the current draft.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `workflowId` | `string` | Yes | The ID of the workflow to publish |
+| `versionId` | `string` | No | Optional version ID to publish. If not provided, publishes the current draft version. |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `boolean` | Whether publishing succeeded |
+| `workflowId` | `string` | The workflow ID |
+| `activeVersionId` | `string | null` | The active version ID after publishing |
+| `error` | `string` | Error message if publishing failed |
+
+
+---
+
+### unpublish_workflow
+
+/// info | Available from n8n v2.12.0
+///
+
+Unpublish (deactivate) a workflow to stop it from being available for production execution.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `workflowId` | `string` | Yes | The ID of the workflow to unpublish |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `boolean` | Whether unpublishing succeeded |
+| `workflowId` | `string` | The workflow ID |
+| `error` | `string` | Error message if unpublishing failed |
+
+
+---
+
+### search_projects
+
+/// info | Available from n8n v2.14.0
+///
+
+Search for projects accessible to the current user.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `query` | `string` | No | Filter projects by name (case-insensitive partial match) |
+| `type` | `"personal" | "team"` | No | Filter by project type |
+| `limit` | `integer` | No | Limit the number of results (max 100) |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data` | `array` | List of matching projects |
+| `data[].id` | `string` | The unique identifier of the project |
+| `data[].name` | `string` | The name of the project |
+| `data[].type` | `"personal" | "team"` | The project type |
+| `count` | `integer` | Total number of matching projects |
+
+#### Notes
+
+- Maximum result limit is 100.
+- This tool enables MCP clients to create workflows and data tables in a specific project
+
+---
+
+### search_folders
+
+/// info | Available from n8n v2.14.0
+///
+
+Search for folders within a project.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectId` | `string` | Yes | The ID of the project to search folders in |
+| `query` | `string` | No | Filter folders by name (case-insensitive partial match) |
+| `limit` | `integer` | No | Limit the number of results (max 100) |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data` | `array` | List of matching folders |
+| `data[].id` | `string` | The unique identifier of the folder |
+| `data[].name` | `string` | The name of the folder |
+| `data[].parentFolderId` | `string | null` | The ID of the parent folder, or null if at project root |
+| `count` | `integer` | Total number of matching folders |
+
+#### Notes
+
+- Maximum result limit is 100.
+- This tool enables MCP clients to create workflows and data tables in a specific folder
+
+---
+
+## Workflow Builder
+
+### get_sdk_reference
+
+/// info | Available from n8n v2.12.0
+///
+
+Get the n8n Workflow SDK reference documentation including patterns, expression syntax, and functions.
+
+#### Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `section` | `string` | No | `"all"` | Documentation section to retrieve. One of: `"patterns"`, `"expressions"`, `"functions"`, `"rules"`, `"import"`, `"guidelines"`, `"design"`, `"all"` |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `reference` | `string` | SDK reference documentation content for the requested section |
+
+#### Notes
+
+- Should be called first before building any workflows.
+- Sections cover patterns, expression syntax, built-in functions, coding rules, import syntax, naming guidelines, and design guidance.
+
+---
+
+### search_nodes
+
+/// info | Available from n8n v2.12.0
+///
+
+Search for n8n nodes by service name, trigger type, or utility function. Returns node IDs, discriminators (resource/operation/mode), and related nodes needed for `get_node_types` tool.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `queries` | `string[]` | Yes (min 1) | Search queries -- service names (for example `"gmail"`, `"slack"`), trigger types (for example `"schedule trigger"`, `"webhook"`), or utility nodes (for example `"set"`, `"if"`, `"merge"`, `"code"`) |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `results` | `string` | Search results with matching node IDs, discriminators, and related nodes |
+
+
+---
+
+### get_node_types
+
+/// info | Available from n8n v2.12.0
+///
+
+Get TypeScript type definitions for n8n nodes. Returns exact parameter names and structures.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `nodeIds` | `array` | Yes (min 1) | Array of node IDs. Each element can be a plain string (for example `"n8n-nodes-base.gmail"`) or an object with discriminators (see below). |
+
+**Node ID object format:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `nodeId` | `string` | Yes | The node type ID (for example `"n8n-nodes-base.gmail"`) |
+| `version` | `string` | No | Specific version (for example `"2.1"`) |
+| `resource` | `string` | No | Resource discriminator (for example `"message"`) |
+| `operation` | `string` | No | Operation discriminator (for example `"send"`) |
+| `mode` | `string` | No | Mode discriminator |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `definitions` | `string` | TypeScript type definitions for the requested nodes |
+
+#### Notes
+
+- Critical for correct node configuration -- MCP clients should always call before writing workflow code.
+- Supports both simple string node IDs and objects with discriminators for multi-variant nodes.
+
+---
+
+### get_suggested_nodes
+
+/// info | Available from n8n v2.12.0
+///
+
+Get curated node recommendations for workflow technique categories. Returns recommended nodes with pattern hints and configuration guidance. Use after analyzing what kind of workflow to build.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `categories` | `string[]` | Yes (min 1) | Workflow technique categories. Available values: `chatbot`, `notification`, `scheduling`, `data_transformation`, `data_persistence`, `data_extraction`, `document_processing`, `form_input`, `content_generation`, `triage`, `find_research` |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `suggestions` | `string` | Curated node recommendations with pattern hints and configuration guidance |
+
+---
+
+### validate_workflow
+
+/// info | Available from n8n v2.12.0
+///
+
+Validate n8n Workflow SDK code. Parses the code into a workflow and checks for errors. Returns the workflow JSON if valid, or detailed error messages to fix. Always validate before creating a workflow.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `code` | `string` | Yes | Full TypeScript/JavaScript workflow code using the n8n Workflow SDK. Must include the workflow export. |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `valid` | `boolean` | Whether the workflow code is valid |
+| `nodeCount` | `number` | The number of nodes in the workflow (if valid) |
+| `warnings` | `array` | Validation warnings (if any) |
+| `warnings[].code` | `string` | The warning code identifying the type of warning |
+| `warnings[].message` | `string` | The warning message |
+| `warnings[].nodeName` | `string` | The node that triggered the warning |
+| `warnings[].parameterPath` | `string` | The parameter path that triggered the warning |
+| `errors` | `string[]` | Validation errors (if invalid) |
+
+#### Notes
+
+- Must be called before `create_workflow_from_code` or `update_workflow`.
+- Warnings may be present even when the code is valid.
+
+---
+
+### create_workflow_from_code
+
+/// info | Available from n8n v2.12.0
+///
+
+Create a workflow in n8n from validated SDK code. Parses the code into a workflow and saves it.
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `code` | `string` | Yes | Full TypeScript/JavaScript workflow code using the n8n Workflow SDK. Must be validated first with `validate_workflow`. |
+| `name` | `string` | No | Optional workflow name (max 128 chars). If not provided, uses the name from the code. |
+| `description` | `string` | No | Short workflow description (max 255 chars, 1-2 sentences). |
+| `projectId` | `string` | No | Project ID to create the workflow in. Defaults to the user's personal project. |
+| `folderId` | `string` | No | Folder ID to create the workflow in. Requires `projectId` to be set. |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workflowId` | `string` | The ID of the created workflow |
+| `name` | `string` | The name of the created workflow |
+| `nodeCount` | `number` | The number of nodes in the workflow |
+| `url` | `string` | The URL to open the workflow in n8n |
+| `autoAssignedCredentials` | `array` | List of credentials that were automatically assigned to nodes |
+| `autoAssignedCredentials[].nodeName` | `string` | The name of the node that had credentials auto-assigned |
+| `autoAssignedCredentials[].credentialName` | `string` | The name of the credential that was auto-assigned |
+| `note` | `string` | Additional notes about the workflow creation (for example nodes skipped during credential auto-assignment) |
+
+#### Notes
+
+- Automatically assigns available credentials to nodes.
+- HTTP Request nodes are skipped during credential auto-assignment and must be configured manually.
+- Sets `availableInMCP` flag to true on the created workflow.
+- Marks the workflow with `aiBuilderAssisted` metadata.
+- Resolves webhook node IDs automatically.
+- `folderId` requires `projectId` to also be provided.
+
+---
+
+### update_workflow
+
+/// info | Available from n8n v2.12.0
+///
+
+Update an existing workflow in n8n from validated SDK code. Parses the code into a workflow and saves the changes.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `workflowId` | `string` | Yes | The ID of the workflow to update |
+| `code` | `string` | Yes | Full TypeScript/JavaScript workflow code using the n8n Workflow SDK. Must be validated first with `validate_workflow`. |
+| `name` | `string` | No | Optional workflow name (max 128 chars). If not provided, uses the name from the code. |
+| `description` | `string` | No | Short workflow description (max 255 chars, 1-2 sentences). |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workflowId` | `string` | The ID of the updated workflow |
+| `name` | `string` | The name of the updated workflow |
+| `nodeCount` | `number` | The number of nodes in the workflow |
+| `url` | `string` | The URL to open the workflow in n8n |
+| `autoAssignedCredentials` | `array` | List of credentials that were automatically assigned to nodes |
+| `autoAssignedCredentials[].nodeName` | `string` | The name of the node that had credentials auto-assigned |
+| `autoAssignedCredentials[].credentialName` | `string` | The name of the credential that was auto-assigned |
+| `note` | `string` | Additional notes about the workflow update (for example nodes skipped during credential auto-assignment) |
+
+#### Notes
+
+- Preserves user-configured credentials from the existing workflow by matching nodes by name and type.
+- Marks the workflow with `aiBuilderAssisted` metadata.
+
+---
+
+### archive_workflow
+
+/// info | Available from n8n v2.12.0
+///
+
+Archive a workflow in n8n by its ID.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `workflowId` | `string` | Yes | The ID of the workflow to archive |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `archived` | `boolean` | Whether the workflow was archived |
+| `workflowId` | `string` | The ID of the archived workflow |
+| `name` | `string` | The name of the archived workflow |
+
+#### Notes
+
+- Idempotent -- skips already-archived workflows.
+
+---
+
+## Data Tables
+
+### search_data_tables
+
+/// info | Available from n8n v2.16.0
+///
+
+Search for data tables accessible to the current user. Use this to find a data table ID before modifying or adding data to it.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `query` | `string` | No | Filter data tables by name (case-insensitive partial match) |
+| `projectId` | `string` | No | Filter by project ID |
+| `limit` | `integer` | No | Limit the number of results (max 100) |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data` | `array` | List of data tables matching the query |
+| `data[].id` | `string` | Unique identifier of the data table |
+| `data[].name` | `string` | The name of the data table |
+| `data[].projectId` | `string` | The project this data table belongs to |
+| `data[].createdAt` | `string` | ISO timestamp when the data table was created |
+| `data[].updatedAt` | `string` | ISO timestamp when the data table was last updated |
+| `data[].columns` | `array` | The columns defined in this data table |
+| `data[].columns[].id` | `string` | Column unique identifier |
+| `data[].columns[].name` | `string` | Column name |
+| `data[].columns[].type` | `string` | Column data type. One of: `"string"`, `"number"`, `"boolean"`, `"date"` |
+| `data[].columns[].index` | `integer` | Column position in the table |
+| `count` | `integer` | Total number of matching data tables |
+
+#### Notes
+
+- Maximum result limit is 100.
+
+---
+
+### create_data_table
+
+/// info | Available from n8n v2.16.0
+///
+
+Create a new data table with the specified columns.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectId` | `string` | Yes | The project ID where the data table will be created |
+| `name` | `string` | Yes | The name of the data table (min 1, max 128 chars, must be unique within the project) |
+| `columns` | `array` | Yes (min 1) | The columns to create in the data table |
+| `columns[].name` | `string` | Yes | Column name. Must start with a letter, contain only letters, numbers, and underscores (max 63 chars). |
+| `columns[].type` | `string` | Yes | The data type of the column. One of: `"string"`, `"number"`, `"boolean"`, `"date"` |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | The unique identifier of the created data table |
+| `name` | `string` | The name of the created data table |
+| `projectId` | `string` | The project ID of the created data table |
+
+#### Notes
+
+- At least one column is required.
+- Table name must be unique within the project.
+- Column names must match the pattern: `^[a-zA-Z][a-zA-Z0-9_]*$` (max 63 chars).
+
+---
+
+### add_data_table_column
+
+/// info | Available from n8n v2.16.0
+///
+
+Add a new column to an existing data table.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `dataTableId` | `string` | Yes | The ID of the data table to add a column to |
+| `projectId` | `string` | Yes | The project ID the data table belongs to |
+| `name` | `string` | Yes | Column name. Must start with a letter, contain only letters, numbers, and underscores (max 63 chars). |
+| `type` | `string` | Yes | The data type of the new column. One of: `"string"`, `"number"`, `"boolean"`, `"date"` |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `boolean` | Whether the operation succeeded |
+| `message` | `string` | Description of the result |
+| `column` | `object` | The created column |
+| `column.id` | `string` | Column unique identifier |
+| `column.name` | `string` | Column name |
+| `column.type` | `string` | Column data type |
+
+#### Notes
+
+- Column names must match the pattern: `^[a-zA-Z][a-zA-Z0-9_]*$` (max 63 chars).
+- Column type is immutable (trough MCP) after creation.
+
+---
+
+### rename_data_table_column
+
+/// info | Available from n8n v2.16.0
+///
+
+Rename a column in a data table.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `dataTableId` | `string` | Yes | The ID of the data table containing the column |
+| `projectId` | `string` | Yes | The project ID the data table belongs to |
+| `columnId` | `string` | Yes | The ID of the column to rename |
+| `name` | `string` | Yes | The new column name. Must follow column naming rules. |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `boolean` | Whether the operation succeeded |
+| `message` | `string` | Description of the result |
+| `column` | `object` | The renamed column |
+| `column.id` | `string` | Column unique identifier |
+| `column.name` | `string` | New column name |
+| `column.type` | `string` | Column data type |
+
+#### Notes
+
+- New name must follow column naming rules: `^[a-zA-Z][a-zA-Z0-9_]*$` (max 63 chars).
+
+---
+
+### delete_data_table_column
+
+/// info | Available from n8n v2.16.0
+///
+
+Delete a column from a data table. This permanently removes the column and all its data.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `dataTableId` | `string` | Yes | The ID of the data table containing the column |
+| `projectId` | `string` | Yes | The project ID the data table belongs to |
+| `columnId` | `string` | Yes | The ID of the column to delete |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `boolean` | Whether the operation succeeded |
+| `message` | `string` | Description of the result |
+
+#### Notes
+
+- Deleting Data table trough MCP can't be undone.
+
+---
+
+### rename_data_table
+
+/// info | Available from n8n v2.16.0
+///
+
+Rename an existing data table.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `dataTableId` | `string` | Yes | The ID of the data table to rename |
+| `projectId` | `string` | Yes | The project ID the data table belongs to |
+| `name` | `string` | Yes | The new name for the data table (min 1, max 128 chars) |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `boolean` | Whether the operation succeeded |
+| `message` | `string` | Description of the result |
+
+#### Notes
+
+- Name must be unique within the project.
+
+---
+
+### add_data_table_rows
+
+/// info | Available from n8n v2.16.0
+///
+
+Insert rows into an existing data table. Each row is an object mapping column names to values.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `dataTableId` | `string` | Yes | The ID of the data table to insert rows into |
+| `projectId` | `string` | Yes | The project ID the data table belongs to |
+| `rows` | `array` | Yes (min 1, max 1000) | Array of row objects. Each object maps column names to values (`string`, `number`, `boolean`, or `null`). |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `boolean` | Whether the insert operation succeeded |
+| `insertedCount` | `integer` | Number of rows successfully inserted |
+
+#### Notes
+
+- Maximum 1000 rows per call.
+- Row values must be `string`, `number`, `boolean`, or `null`.
+- Column names in row objects must match existing column names in the data table.

--- a/docs/advanced-ai/mcp/mcp_tools_reference.md
+++ b/docs/advanced-ai/mcp/mcp_tools_reference.md
@@ -344,7 +344,7 @@ Search for folders within a project.
 #### Notes
 
 - Maximum result limit is 100.
-- This tool enables MCP clients to create workflows and data tables in a specific folder
+- This tool enables MCP clients to create workflows in a specific folder
 
 ---
 

--- a/docs/advanced-ai/mcp/mcp_tools_reference.md
+++ b/docs/advanced-ai/mcp/mcp_tools_reference.md
@@ -9,7 +9,7 @@ This page describes all tools exposed by the instance-level MCP server.
 
 ---
 
-## Workflow Management
+## Workflow management
 
 ### search_workflows
 
@@ -348,7 +348,7 @@ Search for folders within a project.
 
 ---
 
-## Workflow Builder
+## Workflow builder
 
 ### get_sdk_reference
 
@@ -591,7 +591,7 @@ Archive a workflow in n8n by its ID.
 
 ---
 
-## Data Tables
+## Data tables
 
 ### search_data_tables
 

--- a/docs/advanced-ai/mcp/mcp_tools_reference.md
+++ b/docs/advanced-ai/mcp/mcp_tools_reference.md
@@ -755,7 +755,7 @@ Delete a column from a data table. This permanently removes the column and all i
 
 #### Notes
 
-- Deleting Data table trough MCP can't be undone.
+- Deleting a column through MCP can't be undone.
 
 ---
 

--- a/docs/release-notes/1-x.md
+++ b/docs/release-notes/1-x.md
@@ -521,7 +521,7 @@ To enable workflows through an instance-level MCP connection, both your instance
 - All platforms connected to your instance MCP will have access to each of the workflows you have enabled. At this time, you cannot limit access of individual workflows to particular platforms.
 
 <br><br>
-This feature simplifies integration and improves visibility across AI platforms that support MCP, helping you use your n8n workflows directly in the tools where you already work and experiment. [Learn more in documentation.](/advanced-ai/accessing-n8n-mcp-server.md)
+This feature simplifies integration and improves visibility across AI platforms that support MCP, helping you use your n8n workflows directly in the tools where you already work and experiment. [Learn more in documentation.](/advanced-ai/mcp/accessing-n8n-mcp-server.md)
 <br> 
 <figure markdown="span">
     ![Instance MCP](/_images/release-notes/instance_mcp_settings.png)

--- a/nav.yml
+++ b/nav.yml
@@ -1,1323 +1,1323 @@
 nav:
   - Using n8n:
-      - Welcome: index.md
-      - Getting started:
-          - Learning path: learning-path.md
-          - Choose your n8n: choose-n8n.md
-          - Quickstarts:
-              - try-it-out/index.md
-              - A very quick quickstart: try-it-out/quickstart.md
-              - A longer introduction: try-it-out/tutorial-first-workflow.md
-          - Video courses: video-courses.md
-          - Text courses:
-              - courses/index.md
-              - Level one:
-                  - courses/level-one/index.md
-                  - Navigating the editor UI: courses/level-one/chapter-1.md
-                  - Building a mini-workflow: courses/level-one/chapter-2.md
-                  - Automating a (real-world) use case: courses/level-one/chapter-3.md
-                  - Designing the workflow: courses/level-one/chapter-4.md
-                  - Building the workflow:
-                      - Getting data from the data warehouse: courses/level-one/chapter-5/chapter-5.1.md
-                      - Inserting data into airtable: courses/level-one/chapter-5/chapter-5.2.md
-                      - Filtering orders: courses/level-one/chapter-5/chapter-5.3.md
-                      - Setting values for processing orders: courses/level-one/chapter-5/chapter-5.4.md
-                      - Calculating booked orders: courses/level-one/chapter-5/chapter-5.5.md
-                      - Notifying the team: courses/level-one/chapter-5/chapter-5.6.md
-                      - Scheduling the workflow: courses/level-one/chapter-5/chapter-5.7.md
-                      - Activating and examining the workflow: courses/level-one/chapter-5/chapter-5.8.md
-                  - Exporting and importing workflows: courses/level-one/chapter-6.md
-                  - Test your knowledge: courses/level-one/chapter-7.md
-              - Level two:
-                  - courses/level-two/index.md
-                  - Understanding the data structure: courses/level-two/chapter-1.md
-                  - Processing different data types: courses/level-two/chapter-2.md
-                  - Merging and splitting data: courses/level-two/chapter-3.md
-                  - Dealing with errors in workflows: courses/level-two/chapter-4.md
-                  - Automating a business workflow:
-                      - Use case: courses/level-two/chapter-5/chapter-5.0.md
-                      - Workflow 1: courses/level-two/chapter-5/chapter-5.1.md
-                      - Workflow 2: courses/level-two/chapter-5/chapter-5.2.md
-                      - Workflow 3: courses/level-two/chapter-5/chapter-5.3.md
-                  - Test your knowledge: courses/level-two/chapter-6.md
-      - Using the app:
-          - Understand workflows:
-              - workflows/index.md
-              - Create and run: workflows/create.md
-              - Save and publish: workflows/publish.md
-              - Components:
-                  - workflows/components/index.md
-                  - Nodes: workflows/components/nodes.md
-                  - Connections: workflows/components/connections.md
-                  - Sticky Notes: workflows/components/sticky-notes.md
-              - Executions:
-                  - workflows/executions/index.md
-                  - Manual, partial, and production executions: workflows/executions/manual-partial-and-production-executions.md
-                  - Dirty nodes: workflows/executions/dirty-nodes.md
-                  - Workflow-level executions: workflows/executions/single-workflow-executions.md
-                  - All executions: workflows/executions/all-executions.md
-                  - Custom executions data: workflows/executions/custom-executions-data.md
-                  - Debug executions: workflows/executions/debug.md
-                  - Redact execution data: workflows/executions/execution-data-redaction.md
-              - Tags: workflows/tags.md
-              - Export and import: workflows/export-import.md
-              - Templates: workflows/templates.md
-              - Sharing: workflows/sharing.md
-              - Settings: workflows/settings.md
-              - Streaming responses: workflows/streaming.md
-              - Workflow history: workflows/history.md
-              - Workflow ID: workflows/workflow-id.md
-              - Sub-workflow conversion: workflows/subworkflow-conversion.md
-          - Manage credentials:
-              - credentials/index.md
-              - Create and edit: credentials/add-edit-credentials.md
-              - Credential sharing: credentials/credential-sharing.md
-          - Manage users and access:
-              - user-management/index.md
-              - Cloud setup: user-management/cloud-setup.md
-              - Manage users: user-management/manage-users.md
-              - Account types: user-management/account-types.md
-              - Role-based access control:
-                  - user-management/rbac/index.md
-                  - Role types: user-management/rbac/role-types.md
-                  - Projects: user-management/rbac/projects.md
-                  - Custom roles: user-management/rbac/custom-roles.md
-              - Best practices: user-management/best-practices.md
-              - 2FA: user-management/two-factor-auth.md
-              - LDAP: user-management/ldap.md
-              - OIDC:
-                  - user-management/oidc/index.md
-                  - Set up OIDC: user-management/oidc/setup.md
-                  - Troubleshooting: user-management/oidc/troubleshooting.md
-              - SAML:
-                  - user-management/saml/index.md
-                  - Set up SAML: user-management/saml/setup.md
-                  - Okta Workforce Identity SAML setup: user-management/saml/okta.md
-                  - Azure AD SAML setup: user-management/saml/azuread.md
-                  - Manage users with SAML: user-management/saml/managing.md
-                  - Troubleshooting: user-management/saml/troubleshooting.md
-          - Keyboard shortcuts: keyboard-shortcuts.md
-      - Key concepts:
-          - Flow logic:
-              - flow-logic/index.md
-              - Splitting with conditionals: flow-logic/splitting.md
-              - Merging data: flow-logic/merging.md
-              - Looping: flow-logic/looping.md
-              - Waiting: flow-logic/waiting.md
-              - Sub-workflows: flow-logic/subworkflows.md
-              - Error handling: flow-logic/error-handling.md
-              - Execution order in multi-branch workflows: flow-logic/execution-order.md
-          - Working with data:
-              - Overview: data/index.md
-              - How n8n structures data: data/data-structure.md
-              - Expressions versus data nodes: data/expressions.md
-              - Referencing data:
-                  - data/data-mapping/index.md
-                  - Referencing data in the UI: data/data-mapping/data-mapping-ui.md
-                  - Referencing previous nodes: data/data-mapping/referencing-other-nodes.md
-                  - Linking data items:
-                      - data/data-mapping/data-item-linking/index.md
-                      - How items link through workflows: data/data-mapping/data-item-linking/item-linking-concepts.md
-                      - Accessing linked items in the Code node: data/data-mapping/itemmatching.md
-                      - Preserving linking in the Code node: data/data-mapping/data-item-linking/item-linking-code-node.md
-                      - Item linking errors: data/data-mapping/data-item-linking/item-linking-errors.md
-                      - Item linking for node creators: data/data-mapping/data-item-linking/item-linking-node-building.md
-              - Transforming data:
-                  - Approaches for transforming data: data/transforming-data.md
-                  - Expressions for data transformation: data/expressions-for-transformation.md
-                  - Expression reference:
-                      - data/expression-reference/index.md
-                      - data/expression-reference/array.md
-                      - data/expression-reference/binaryfile.md
-                      - data/expression-reference/boolean.md
-                      - data/expression-reference/customdata.md
-                      - data/expression-reference/date.md
-                      - data/expression-reference/datetime.md
-                      - data/expression-reference/execdata.md
-                      - data/expression-reference/httpresponse.md
-                      - data/expression-reference/item.md
-                      - data/expression-reference/nodeinputdata.md
-                      - data/expression-reference/nodeoutputdata.md
-                      - data/expression-reference/number.md
-                      - data/expression-reference/object.md
-                      - data/expression-reference/prevnodedata.md
-                      - data/expression-reference/root.md
-                      - data/expression-reference/string.md
-                      - data/expression-reference/workflowdata.md
-              - Filtering data: data/data-filtering.md
-              - Pinning and mocking data: data/data-pinning.md
-              - Specific data types:
-                  - Binary data: data/specific-data-types/binary-data.md
-                  - Date and time with Luxon: data/specific-data-types/luxon.md
-                  - Query JSON with JMESPath: data/specific-data-types/jmespath.md
-              - Data tables: data/data-tables.md
-          - Glossary: glossary.md
-      - n8n Cloud:
-          - Overview: manage-cloud/overview.md
-          - Cloud free trial: manage-cloud/cloud-free-trial.md
-          - Access the Cloud admin dashboard: manage-cloud/cloud-admin-dashboard.md
-          - Update your n8n Cloud version: manage-cloud/update-cloud-version.md
-          - Set the timezone: manage-cloud/set-cloud-timezone.md
-          - Cloud IP addresses: manage-cloud/cloud-ip.md
-          - Cloud data management: manage-cloud/cloud-data-management.md
-          - Change ownership or username: manage-cloud/change-ownership-or-username.md
-          - Concurrency: manage-cloud/concurrency.md
-          - Download workflows: manage-cloud/download-workflows.md
-          - AI Assistant: manage-cloud/ai-assistant.md
-      - Enterprise features:
-          - Source control and environments:
-              - source-control-environments/index.md
-              - Understand:
-                  - source-control-environments/understand/index.md
-                  - Environments: source-control-environments/understand/environments.md
-                  - Git in n8n: source-control-environments/understand/git.md
-                  - Branch patterns: source-control-environments/understand/patterns.md
-              - Set up: source-control-environments/setup.md
-              - Using:
-                  - source-control-environments/using/index.md
-                  - Push and pull: source-control-environments/using/push-pull.md
-                  - Compare workflow changes: source-control-environments/using/compare-changes.md
-                  - Copy work between environments: source-control-environments/using/copy-work.md
-              - "Tutorial: Create environments with source control": source-control-environments/create-environments.md
-          - External secrets: external-secrets.md
-          - Log streaming: log-streaming.md
-          - Security settings: security-settings.md
-          - Insights: insights.md
-          - License key: license-key.md
-      - Releases:
-          - Release notes:
-              - 2.x: release-notes.md
-              - 1.x: release-notes/1-x.md
-              - 0.x: release-notes/0-x.md
-          - v2.0 breaking changes: 2-0-breaking-changes.md
-          - v2.0 Migration tool: migration-tool-v2.md
-          - v1.0 migration guide: 1-0-migration-checklist.md
-      - Help and community:
-          - Where to get help: help-community/help.md
-          - Contributing: help-community/contributing.md
-      - Licenses and privacy:
-          - Privacy and security:
-              - privacy-security/index.md
-              - Privacy: privacy-security/privacy.md
-              - Security: https://n8n.io/legal/#security
-              - Incident response: privacy-security/incident-response.md
-              - What you can do: privacy-security/what-you-can-do.md
-          - Sustainable use license: sustainable-use-license.md
+    - Welcome: index.md
+    - Getting started:
+      - Learning path: learning-path.md
+      - Choose your n8n: choose-n8n.md
+      - Quickstarts:
+        - try-it-out/index.md
+        - A very quick quickstart: try-it-out/quickstart.md
+        - A longer introduction: try-it-out/tutorial-first-workflow.md
+      - Video courses: video-courses.md
+      - Text courses:
+        - courses/index.md
+        - Level one:
+          - courses/level-one/index.md
+          - Navigating the editor UI: courses/level-one/chapter-1.md
+          - Building a mini-workflow: courses/level-one/chapter-2.md
+          - Automating a (real-world) use case: courses/level-one/chapter-3.md
+          - Designing the workflow: courses/level-one/chapter-4.md
+          - Building the workflow:
+            - Getting data from the data warehouse: courses/level-one/chapter-5/chapter-5.1.md
+            - Inserting data into airtable: courses/level-one/chapter-5/chapter-5.2.md
+            - Filtering orders: courses/level-one/chapter-5/chapter-5.3.md
+            - Setting values for processing orders: courses/level-one/chapter-5/chapter-5.4.md
+            - Calculating booked orders: courses/level-one/chapter-5/chapter-5.5.md
+            - Notifying the team: courses/level-one/chapter-5/chapter-5.6.md
+            - Scheduling the workflow: courses/level-one/chapter-5/chapter-5.7.md
+            - Activating and examining the workflow: courses/level-one/chapter-5/chapter-5.8.md
+          - Exporting and importing workflows: courses/level-one/chapter-6.md
+          - Test your knowledge: courses/level-one/chapter-7.md
+        - Level two:
+          - courses/level-two/index.md
+          - Understanding the data structure: courses/level-two/chapter-1.md
+          - Processing different data types: courses/level-two/chapter-2.md
+          - Merging and splitting data: courses/level-two/chapter-3.md
+          - Dealing with errors in workflows: courses/level-two/chapter-4.md
+          - Automating a business workflow:
+            - Use case: courses/level-two/chapter-5/chapter-5.0.md
+            - Workflow 1: courses/level-two/chapter-5/chapter-5.1.md
+            - Workflow 2: courses/level-two/chapter-5/chapter-5.2.md
+            - Workflow 3: courses/level-two/chapter-5/chapter-5.3.md
+          - Test your knowledge: courses/level-two/chapter-6.md
+    - Using the app:
+      - Understand workflows:
+        - workflows/index.md
+        - Create and run: workflows/create.md
+        - Save and publish: workflows/publish.md
+        - Components:
+          - workflows/components/index.md
+          - Nodes: workflows/components/nodes.md
+          - Connections: workflows/components/connections.md
+          - Sticky Notes: workflows/components/sticky-notes.md
+        - Executions:
+          - workflows/executions/index.md
+          - Manual, partial, and production executions: workflows/executions/manual-partial-and-production-executions.md
+          - Dirty nodes: workflows/executions/dirty-nodes.md
+          - Workflow-level executions: workflows/executions/single-workflow-executions.md
+          - All executions: workflows/executions/all-executions.md
+          - Custom executions data: workflows/executions/custom-executions-data.md
+          - Debug executions: workflows/executions/debug.md
+          - Redact execution data: workflows/executions/execution-data-redaction.md
+        - Tags: workflows/tags.md
+        - Export and import: workflows/export-import.md
+        - Templates: workflows/templates.md
+        - Sharing: workflows/sharing.md
+        - Settings: workflows/settings.md
+        - Streaming responses: workflows/streaming.md
+        - Workflow history: workflows/history.md
+        - Workflow ID: workflows/workflow-id.md
+        - Sub-workflow conversion: workflows/subworkflow-conversion.md
+      - Manage credentials:
+        - credentials/index.md
+        - Create and edit: credentials/add-edit-credentials.md
+        - Credential sharing: credentials/credential-sharing.md
+      - Manage users and access:
+        - user-management/index.md
+        - Cloud setup: user-management/cloud-setup.md
+        - Manage users: user-management/manage-users.md
+        - Account types: user-management/account-types.md
+        - Role-based access control:
+          - user-management/rbac/index.md
+          - Role types: user-management/rbac/role-types.md
+          - Projects: user-management/rbac/projects.md
+          - Custom roles: user-management/rbac/custom-roles.md
+        - Best practices: user-management/best-practices.md
+        - 2FA: user-management/two-factor-auth.md
+        - LDAP: user-management/ldap.md
+        - OIDC:
+          - user-management/oidc/index.md
+          - Set up OIDC: user-management/oidc/setup.md
+          - Troubleshooting: user-management/oidc/troubleshooting.md
+        - SAML:
+          - user-management/saml/index.md
+          - Set up SAML: user-management/saml/setup.md
+          - Okta Workforce Identity SAML setup: user-management/saml/okta.md
+          - Azure AD SAML setup: user-management/saml/azuread.md
+          - Manage users with SAML: user-management/saml/managing.md
+          - Troubleshooting: user-management/saml/troubleshooting.md
+      - Keyboard shortcuts: keyboard-shortcuts.md
+    - Key concepts:
+      - Flow logic:
+        - flow-logic/index.md
+        - Splitting with conditionals: flow-logic/splitting.md
+        - Merging data: flow-logic/merging.md
+        - Looping: flow-logic/looping.md
+        - Waiting: flow-logic/waiting.md
+        - Sub-workflows: flow-logic/subworkflows.md
+        - Error handling: flow-logic/error-handling.md
+        - Execution order in multi-branch workflows: flow-logic/execution-order.md
+      - Working with data:
+        - Overview: data/index.md
+        - How n8n structures data: data/data-structure.md
+        - Expressions versus data nodes: data/expressions.md
+        - Referencing data:
+          - data/data-mapping/index.md
+          - Referencing data in the UI: data/data-mapping/data-mapping-ui.md
+          - Referencing previous nodes: data/data-mapping/referencing-other-nodes.md
+          - Linking data items:
+            - data/data-mapping/data-item-linking/index.md
+            - How items link through workflows: data/data-mapping/data-item-linking/item-linking-concepts.md
+            - Accessing linked items in the Code node: data/data-mapping/itemmatching.md
+            - Preserving linking in the Code node: data/data-mapping/data-item-linking/item-linking-code-node.md
+            - Item linking errors: data/data-mapping/data-item-linking/item-linking-errors.md
+            - Item linking for node creators: data/data-mapping/data-item-linking/item-linking-node-building.md
+        - Transforming data:
+          - Approaches for transforming data: data/transforming-data.md
+          - Expressions for data transformation: data/expressions-for-transformation.md
+          - Expression reference: 
+            - data/expression-reference/index.md
+            - data/expression-reference/array.md
+            - data/expression-reference/binaryfile.md
+            - data/expression-reference/boolean.md
+            - data/expression-reference/customdata.md
+            - data/expression-reference/date.md
+            - data/expression-reference/datetime.md
+            - data/expression-reference/execdata.md
+            - data/expression-reference/httpresponse.md
+            - data/expression-reference/item.md
+            - data/expression-reference/nodeinputdata.md
+            - data/expression-reference/nodeoutputdata.md
+            - data/expression-reference/number.md
+            - data/expression-reference/object.md
+            - data/expression-reference/prevnodedata.md
+            - data/expression-reference/root.md
+            - data/expression-reference/string.md
+            - data/expression-reference/workflowdata.md
+        - Filtering data: data/data-filtering.md
+        - Pinning and mocking data: data/data-pinning.md
+        - Specific data types:
+          - Binary data: data/specific-data-types/binary-data.md
+          - Date and time with Luxon: data/specific-data-types/luxon.md
+          - Query JSON with JMESPath: data/specific-data-types/jmespath.md
+        - Data tables: data/data-tables.md
+      - Glossary: glossary.md
+    - n8n Cloud:
+      - Overview: manage-cloud/overview.md
+      - Cloud free trial: manage-cloud/cloud-free-trial.md
+      - Access the Cloud admin dashboard: manage-cloud/cloud-admin-dashboard.md
+      - Update your n8n Cloud version: manage-cloud/update-cloud-version.md
+      - Set the timezone: manage-cloud/set-cloud-timezone.md
+      - Cloud IP addresses: manage-cloud/cloud-ip.md
+      - Cloud data management: manage-cloud/cloud-data-management.md
+      - Change ownership or username: manage-cloud/change-ownership-or-username.md
+      - Concurrency: manage-cloud/concurrency.md
+      - Download workflows: manage-cloud/download-workflows.md
+      - AI Assistant: manage-cloud/ai-assistant.md
+    - Enterprise features:
+      - Source control and environments:
+        - source-control-environments/index.md
+        - Understand:
+          - source-control-environments/understand/index.md
+          - Environments: source-control-environments/understand/environments.md
+          - Git in n8n: source-control-environments/understand/git.md
+          - Branch patterns: source-control-environments/understand/patterns.md
+        - Set up: source-control-environments/setup.md
+        - Using:
+          - source-control-environments/using/index.md
+          - Push and pull: source-control-environments/using/push-pull.md
+          - Compare workflow changes: source-control-environments/using/compare-changes.md
+          - Copy work between environments: source-control-environments/using/copy-work.md
+        - "Tutorial: Create environments with source control": source-control-environments/create-environments.md
+      - External secrets: external-secrets.md
+      - Log streaming: log-streaming.md
+      - Security settings: security-settings.md
+      - Insights: insights.md
+      - License key: license-key.md
+    - Releases:
+      - Release notes:
+        - 2.x: release-notes.md
+        - 1.x: release-notes/1-x.md
+        - 0.x: release-notes/0-x.md
+      - v2.0 breaking changes: 2-0-breaking-changes.md
+      - v2.0 Migration tool: migration-tool-v2.md
+      - v1.0 migration guide: 1-0-migration-checklist.md
+    - Help and community:
+      - Where to get help: help-community/help.md
+      - Contributing: help-community/contributing.md
+    - Licenses and privacy:
+      - Privacy and security:
+          - privacy-security/index.md
+          - Privacy: privacy-security/privacy.md
+          - Security: https://n8n.io/legal/#security
+          - Incident response: privacy-security/incident-response.md
+          - What you can do: privacy-security/what-you-can-do.md
+      - Sustainable use license: sustainable-use-license.md
   - Integrations:
-      - integrations/index.md
-      - Built-in nodes:
-          - Node types: integrations/builtin/node-types.md
-          - Core nodes:
-              - integrations/builtin/core-nodes/index.md
-              - Activation Trigger: integrations/builtin/core-nodes/n8n-nodes-base.activationtrigger.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.aggregate.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.aitransform.md
-              - Code:
-                  - Code: integrations/builtin/core-nodes/n8n-nodes-base.code/index.md
-                  - Keyboard shortcuts: integrations/builtin/core-nodes/n8n-nodes-base.code/keyboard-shortcuts.md
-                  - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.code/common-issues.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.comparedatasets.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.compression.md
-              - Chat Trigger:
-                  - Chat Trigger: integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/index.md
-                  - Common issues: integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/common-issues.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.converttofile.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.crypto.md
-              - Data Table:
-                  - Data Table: integrations/builtin/core-nodes/n8n-nodes-base.datatable/index.md
-                  - Row operations: integrations/builtin/core-nodes/n8n-nodes-base.datatable/rows.md
-                  - Table operations: integrations/builtin/core-nodes/n8n-nodes-base.datatable/tables.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.datetime.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.debughelper.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.set.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.editimage.md
-              - Email Trigger (IMAP): integrations/builtin/core-nodes/n8n-nodes-base.emailimap.md
-              - Error Trigger: integrations/builtin/core-nodes/n8n-nodes-base.errortrigger.md
-              - Evaluation: integrations/builtin/core-nodes/n8n-nodes-base.evaluation.md
-              - Evaluation Trigger: integrations/builtin/core-nodes/n8n-nodes-base.evaluationtrigger.md
-              - Execute Command:
-                  - Execute Command: integrations/builtin/core-nodes/n8n-nodes-base.executecommand/index.md
-                  - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.executecommand/common-issues.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.executeworkflow.md
-              - Execute Sub-workflow Trigger: integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.executiondata.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.extractfromfile.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.filter.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.ftp.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.git.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.graphql.md
-              - Guardrails: integrations/builtin/core-nodes/n8n-nodes-langchain.guardrails.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.html.md
-              - HTTP Request:
-                  - HTTP Request: integrations/builtin/core-nodes/n8n-nodes-base.httprequest/index.md
-                  - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.httprequest/common-issues.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.if.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.jwt.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.ldap.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.limit.md
-              - Local File Trigger: integrations/builtin/core-nodes/n8n-nodes-base.localfiletrigger.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches.md
-              - Manual Trigger: integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.markdown.md
-              - MCP Client: integrations/builtin/core-nodes/n8n-nodes-langchain.mcpClient.md
-              - MCP Server Trigger: integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.merge.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.n8n.md
-              - n8n Form: integrations/builtin/core-nodes/n8n-nodes-base.form.md
-              - n8n Form Trigger: integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
-              - n8n Trigger: integrations/builtin/core-nodes/n8n-nodes-base.n8ntrigger.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.noop.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.readwritefile.md
-              - Remove Duplicates:
-                  - integrations/builtin/core-nodes/n8n-nodes-base.removeduplicates/index.md
-                  - Templates and examples: integrations/builtin/core-nodes/n8n-nodes-base.removeduplicates/templates-and-examples.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.renamekeys.md
-              - Chat: integrations/builtin/core-nodes/n8n-nodes-langchain.chat.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.respondtowebhook.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.rssfeedread.md
-              - RSS Feed Trigger: integrations/builtin/core-nodes/n8n-nodes-base.rssfeedreadtrigger.md
-              - Schedule Trigger:
-                  - Schedule Trigger: integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/index.md
-                  - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/common-issues.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.sendemail.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.sort.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.splitout.md
-              - SSE Trigger: integrations/builtin/core-nodes/n8n-nodes-base.ssetrigger.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.ssh.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.stopanderror.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.summarize.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.switch.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.totp.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.wait.md
-              - Webhook:
-                  - integrations/builtin/core-nodes/n8n-nodes-base.webhook/index.md
-                  - Workflow development: integrations/builtin/core-nodes/n8n-nodes-base.webhook/workflow-development.md
-                  - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.webhook/common-issues.md
-              - Workflow Trigger: integrations/builtin/core-nodes/n8n-nodes-base.workflowtrigger.md
-              - integrations/builtin/core-nodes/n8n-nodes-base.xml.md
-          - Actions:
-              - integrations/builtin/app-nodes/index.md
-              - Action Network: integrations/builtin/app-nodes/n8n-nodes-base.actionnetwork.md
-              - ActiveCampaign: integrations/builtin/app-nodes/n8n-nodes-base.activecampaign.md
-              - Adalo: integrations/builtin/app-nodes/n8n-nodes-base.adalo.md
-              - Affinity: integrations/builtin/app-nodes/n8n-nodes-base.affinity.md
-              - Agile CRM: integrations/builtin/app-nodes/n8n-nodes-base.agilecrm.md
-              - Airtable:
-                  - Airtable: integrations/builtin/app-nodes/n8n-nodes-base.airtable/index.md
-                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.airtable/common-issues.md
-              - Airtop: integrations/builtin/app-nodes/n8n-nodes-base.airtop.md
-              - AMQP Sender: integrations/builtin/app-nodes/n8n-nodes-base.amqp.md
-              - Anthropic: integrations/builtin/app-nodes/n8n-nodes-langchain.anthropic.md
-              - APITemplate.io: integrations/builtin/app-nodes/n8n-nodes-base.apitemplateio.md
-              - Asana: integrations/builtin/app-nodes/n8n-nodes-base.asana.md
-              - Autopilot: integrations/builtin/app-nodes/n8n-nodes-base.autopilot.md
-              - AWS Certificate Manager: integrations/builtin/app-nodes/n8n-nodes-base.awscertificatemanager.md
-              - AWS Cognito: integrations/builtin/app-nodes/n8n-nodes-base.awscognito.md
-              - AWS Comprehend: integrations/builtin/app-nodes/n8n-nodes-base.awscomprehend.md
-              - AWS DynamoDB: integrations/builtin/app-nodes/n8n-nodes-base.awsdynamodb.md
-              - AWS Elastic Load Balancing: integrations/builtin/app-nodes/n8n-nodes-base.awselb.md
-              - AWS IAM: integrations/builtin/app-nodes/n8n-nodes-base.awsiam.md
-              - AWS Lambda: integrations/builtin/app-nodes/n8n-nodes-base.awslambda.md
-              - AWS Rekognition: integrations/builtin/app-nodes/n8n-nodes-base.awsrekognition.md
-              - AWS S3: integrations/builtin/app-nodes/n8n-nodes-base.awss3.md
-              - AWS SES: integrations/builtin/app-nodes/n8n-nodes-base.awsses.md
-              - AWS SNS: integrations/builtin/app-nodes/n8n-nodes-base.awssns.md
-              - AWS SQS: integrations/builtin/app-nodes/n8n-nodes-base.awssqs.md
-              - AWS Textract: integrations/builtin/app-nodes/n8n-nodes-base.awstextract.md
-              - AWS Transcribe: integrations/builtin/app-nodes/n8n-nodes-base.awstranscribe.md
-              - Azure Cosmos DB: integrations/builtin/app-nodes/n8n-nodes-base.azurecosmosdb.md
-              - Azure Storage: integrations/builtin/app-nodes/n8n-nodes-base.azurestorage.md
-              - BambooHR: integrations/builtin/app-nodes/n8n-nodes-base.bamboohr.md
-              - Bannerbear: integrations/builtin/app-nodes/n8n-nodes-base.bannerbear.md
-              - Baserow: integrations/builtin/app-nodes/n8n-nodes-base.baserow.md
-              - Beeminder: integrations/builtin/app-nodes/n8n-nodes-base.beeminder.md
-              - Bitly: integrations/builtin/app-nodes/n8n-nodes-base.bitly.md
-              - Bitwarden: integrations/builtin/app-nodes/n8n-nodes-base.bitwarden.md
-              - Box: integrations/builtin/app-nodes/n8n-nodes-base.box.md
-              - Brandfetch: integrations/builtin/app-nodes/n8n-nodes-base.brandfetch.md
-              - Brevo: integrations/builtin/app-nodes/n8n-nodes-base.brevo.md
-              - Bubble: integrations/builtin/app-nodes/n8n-nodes-base.bubble.md
-              - Chargebee: integrations/builtin/app-nodes/n8n-nodes-base.chargebee.md
-              - CircleCI: integrations/builtin/app-nodes/n8n-nodes-base.circleci.md
-              - Webex by Cisco: integrations/builtin/app-nodes/n8n-nodes-base.ciscowebex.md
-              - Clearbit: integrations/builtin/app-nodes/n8n-nodes-base.clearbit.md
-              - ClickUp: integrations/builtin/app-nodes/n8n-nodes-base.clickup.md
-              - Clockify: integrations/builtin/app-nodes/n8n-nodes-base.clockify.md
-              - Cloudflare: integrations/builtin/app-nodes/n8n-nodes-base.cloudflare.md
-              - Cockpit: integrations/builtin/app-nodes/n8n-nodes-base.cockpit.md
-              - Coda: integrations/builtin/app-nodes/n8n-nodes-base.coda.md
-              - CoinGecko: integrations/builtin/app-nodes/n8n-nodes-base.coingecko.md
-              - Contentful: integrations/builtin/app-nodes/n8n-nodes-base.contentful.md
-              - ConvertKit: integrations/builtin/app-nodes/n8n-nodes-base.convertkit.md
-              - Copper: integrations/builtin/app-nodes/n8n-nodes-base.copper.md
-              - Cortex: integrations/builtin/app-nodes/n8n-nodes-base.cortex.md
-              - CrateDB: integrations/builtin/app-nodes/n8n-nodes-base.cratedb.md
-              - crowd.dev: integrations/builtin/app-nodes/n8n-nodes-base.crowddev.md
-              - Customer.io: integrations/builtin/app-nodes/n8n-nodes-base.customerio.md
-              - Databricks: integrations/builtin/app-nodes/n8n-nodes-base.databricks.md
-              - DeepL: integrations/builtin/app-nodes/n8n-nodes-base.deepl.md
-              - Demio: integrations/builtin/app-nodes/n8n-nodes-base.demio.md
-              - DHL: integrations/builtin/app-nodes/n8n-nodes-base.dhl.md
-              - Discord:
-                  - Discord: integrations/builtin/app-nodes/n8n-nodes-base.discord/index.md
-                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.discord/common-issues.md
-              - Discourse: integrations/builtin/app-nodes/n8n-nodes-base.discourse.md
-              - Disqus: integrations/builtin/app-nodes/n8n-nodes-base.disqus.md
-              - Drift: integrations/builtin/app-nodes/n8n-nodes-base.drift.md
-              - Dropbox: integrations/builtin/app-nodes/n8n-nodes-base.dropbox.md
-              - Dropcontact: integrations/builtin/app-nodes/n8n-nodes-base.dropcontact.md
-              - E-goi: integrations/builtin/app-nodes/n8n-nodes-base.egoi.md
-              - Elasticsearch: integrations/builtin/app-nodes/n8n-nodes-base.elasticsearch.md
-              - Elastic Security: integrations/builtin/app-nodes/n8n-nodes-base.elasticsecurity.md
-              - Emelia: integrations/builtin/app-nodes/n8n-nodes-base.emelia.md
-              - ERPNext: integrations/builtin/app-nodes/n8n-nodes-base.erpnext.md
-              - Facebook Graph API: integrations/builtin/app-nodes/n8n-nodes-base.facebookgraphapi.md
-              - FileMaker: integrations/builtin/app-nodes/n8n-nodes-base.filemaker.md
-              - Flow: integrations/builtin/app-nodes/n8n-nodes-base.flow.md
-              - Freshdesk: integrations/builtin/app-nodes/n8n-nodes-base.freshdesk.md
-              - Freshservice: integrations/builtin/app-nodes/n8n-nodes-base.freshservice.md
-              - Freshworks CRM: integrations/builtin/app-nodes/n8n-nodes-base.freshworkscrm.md
-              - GetResponse: integrations/builtin/app-nodes/n8n-nodes-base.getresponse.md
-              - Ghost: integrations/builtin/app-nodes/n8n-nodes-base.ghost.md
-              - GitHub: integrations/builtin/app-nodes/n8n-nodes-base.github.md
-              - GitLab: integrations/builtin/app-nodes/n8n-nodes-base.gitlab.md
-              - Gmail:
-                  - Gmail: integrations/builtin/app-nodes/n8n-nodes-base.gmail/index.md
-                  - Draft operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/draft-operations.md
-                  - Label operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/label-operations.md
-                  - Message operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/message-operations.md
-                  - Thread operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/thread-operations.md
-                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.gmail/common-issues.md
-              - Gong: integrations/builtin/app-nodes/n8n-nodes-base.gong.md
-              - Google Ads: integrations/builtin/app-nodes/n8n-nodes-base.googleads.md
-              - Google Analytics: integrations/builtin/app-nodes/n8n-nodes-base.googleanalytics.md
-              - Google BigQuery: integrations/builtin/app-nodes/n8n-nodes-base.googlebigquery.md
-              - Google Books: integrations/builtin/app-nodes/n8n-nodes-base.googlebooks.md
-              - Google Business Profile: integrations/builtin/app-nodes/n8n-nodes-base.googlebusinessprofile.md
-              - Google Calendar:
-                  - Google Calendar: integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/index.md
-                  - Calendar operations: integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/calendar-operations.md
-                  - Event operations: integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/event-operations.md
-              - Google Chat: integrations/builtin/app-nodes/n8n-nodes-base.googlechat.md
-              - Google Cloud Firestore: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudfirestore.md
-              - Google Cloud Natural Language: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudnaturallanguage.md
-              - Google Cloud Realtime Database: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudrealtimedatabase.md
-              - Google Cloud Storage: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudstorage.md
-              - Google Contacts: integrations/builtin/app-nodes/n8n-nodes-base.googlecontacts.md
-              - Google Docs: integrations/builtin/app-nodes/n8n-nodes-base.googledocs.md
-              - Google Drive:
-                  - Google Drive: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/index.md
-                  - File operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/file-operations.md
-                  - File and folder operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/file-folder-operations.md
-                  - Folder operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/folder-operations.md
-                  - Shared drive operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/shared-drive-operations.md
-                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/common-issues.md
-              - Google Gemini: integrations/builtin/app-nodes/n8n-nodes-langchain.googlegemini.md
-              - Google Perspective: integrations/builtin/app-nodes/n8n-nodes-base.googleperspective.md
-              - Google Sheets:
-                  - Google Sheets: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/index.md
-                  - Document operations: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/document-operations.md
-                  - Sheet within Document operations: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/sheet-operations.md
-                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/common-issues.md
-              - Google Slides: integrations/builtin/app-nodes/n8n-nodes-base.googleslides.md
-              - Google Tasks: integrations/builtin/app-nodes/n8n-nodes-base.googletasks.md
-              - Google Translate: integrations/builtin/app-nodes/n8n-nodes-base.googletranslate.md
-              - Google Workspace Admin: integrations/builtin/app-nodes/n8n-nodes-base.gsuiteadmin.md
-              - Gotify: integrations/builtin/app-nodes/n8n-nodes-base.gotify.md
-              - GoToWebinar: integrations/builtin/app-nodes/n8n-nodes-base.gotowebinar.md
-              - Grafana: integrations/builtin/app-nodes/n8n-nodes-base.grafana.md
-              - Grist: integrations/builtin/app-nodes/n8n-nodes-base.grist.md
-              - Hacker News: integrations/builtin/app-nodes/n8n-nodes-base.hackernews.md
-              - HaloPSA: integrations/builtin/app-nodes/n8n-nodes-base.halopsa.md
-              - Harvest: integrations/builtin/app-nodes/n8n-nodes-base.harvest.md
-              - Help Scout: integrations/builtin/app-nodes/n8n-nodes-base.helpscout.md
-              - HighLevel: integrations/builtin/app-nodes/n8n-nodes-base.highlevel.md
-              - Home Assistant: integrations/builtin/app-nodes/n8n-nodes-base.homeassistant.md
-              - HubSpot: integrations/builtin/app-nodes/n8n-nodes-base.hubspot.md
-              - Humantic AI: integrations/builtin/app-nodes/n8n-nodes-base.humanticai.md
-              - Hunter: integrations/builtin/app-nodes/n8n-nodes-base.hunter.md
-              - Intercom: integrations/builtin/app-nodes/n8n-nodes-base.intercom.md
-              - Invoice Ninja: integrations/builtin/app-nodes/n8n-nodes-base.invoiceninja.md
-              - Iterable: integrations/builtin/app-nodes/n8n-nodes-base.iterable.md
-              - Jenkins: integrations/builtin/app-nodes/n8n-nodes-base.jenkins.md
-              - Jina AI: integrations/builtin/app-nodes/n8n-nodes-base.jinaai.md
-              - Jira Software: integrations/builtin/app-nodes/n8n-nodes-base.jira.md
-              - Kafka: integrations/builtin/app-nodes/n8n-nodes-base.kafka.md
-              - Keap: integrations/builtin/app-nodes/n8n-nodes-base.keap.md
-              - Kitemaker: integrations/builtin/app-nodes/n8n-nodes-base.kitemaker.md
-              - KoboToolbox: integrations/builtin/app-nodes/n8n-nodes-base.kobotoolbox.md
-              - Lemlist: integrations/builtin/app-nodes/n8n-nodes-base.lemlist.md
-              - Line: integrations/builtin/app-nodes/n8n-nodes-base.line.md
-              - Linear: integrations/builtin/app-nodes/n8n-nodes-base.linear.md
-              - LingvaNex: integrations/builtin/app-nodes/n8n-nodes-base.lingvanex.md
-              - LinkedIn: integrations/builtin/app-nodes/n8n-nodes-base.linkedin.md
-              - LoneScale: integrations/builtin/app-nodes/n8n-nodes-base.lonescale.md
-              - Magento 2: integrations/builtin/app-nodes/n8n-nodes-base.magento2.md
-              - Mailcheck: integrations/builtin/app-nodes/n8n-nodes-base.mailcheck.md
-              - Mailchimp: integrations/builtin/app-nodes/n8n-nodes-base.mailchimp.md
-              - MailerLite: integrations/builtin/app-nodes/n8n-nodes-base.mailerlite.md
-              - Mailgun: integrations/builtin/app-nodes/n8n-nodes-base.mailgun.md
-              - Mailjet: integrations/builtin/app-nodes/n8n-nodes-base.mailjet.md
-              - Mandrill: integrations/builtin/app-nodes/n8n-nodes-base.mandrill.md
-              - marketstack: integrations/builtin/app-nodes/n8n-nodes-base.marketstack.md
-              - Matrix: integrations/builtin/app-nodes/n8n-nodes-base.matrix.md
-              - Mattermost: integrations/builtin/app-nodes/n8n-nodes-base.mattermost.md
-              - Mautic: integrations/builtin/app-nodes/n8n-nodes-base.mautic.md
-              - Medium: integrations/builtin/app-nodes/n8n-nodes-base.medium.md
-              - MessageBird: integrations/builtin/app-nodes/n8n-nodes-base.messagebird.md
-              - Metabase: integrations/builtin/app-nodes/n8n-nodes-base.metabase.md
-              - Microsoft Dynamics CRM: integrations/builtin/app-nodes/n8n-nodes-base.microsoftdynamicscrm.md
-              - Microsoft Entra ID: integrations/builtin/app-nodes/n8n-nodes-base.microsoftentra.md
-              - Microsoft Excel 365: integrations/builtin/app-nodes/n8n-nodes-base.microsoftexcel.md
-              - Microsoft Graph Security: integrations/builtin/app-nodes/n8n-nodes-base.microsoftgraphsecurity.md
-              - Microsoft OneDrive: integrations/builtin/app-nodes/n8n-nodes-base.microsoftonedrive.md
-              - Microsoft Outlook: integrations/builtin/app-nodes/n8n-nodes-base.microsoftoutlook.md
-              - Microsoft SharePoint: integrations/builtin/app-nodes/n8n-nodes-base.microsoftsharepoint.md
-              - Microsoft SQL: integrations/builtin/app-nodes/n8n-nodes-base.microsoftsql.md
-              - Microsoft Teams: integrations/builtin/app-nodes/n8n-nodes-base.microsoftteams.md
-              - Microsoft To Do: integrations/builtin/app-nodes/n8n-nodes-base.microsofttodo.md
-              - Mindee: integrations/builtin/app-nodes/n8n-nodes-base.mindee.md
-              - MISP: integrations/builtin/app-nodes/n8n-nodes-base.misp.md
-              - Mistral AI: integrations/builtin/app-nodes/n8n-nodes-base.mistralai.md
-              - Mocean: integrations/builtin/app-nodes/n8n-nodes-base.mocean.md
-              - monday.com: integrations/builtin/app-nodes/n8n-nodes-base.mondaycom.md
-              - MongoDB: integrations/builtin/app-nodes/n8n-nodes-base.mongodb.md
-              - Monica CRM: integrations/builtin/app-nodes/n8n-nodes-base.monicacrm.md
-              - MQTT: integrations/builtin/app-nodes/n8n-nodes-base.mqtt.md
-              - MSG91: integrations/builtin/app-nodes/n8n-nodes-base.msg91.md
-              - MySQL:
-                  - MySQL: integrations/builtin/app-nodes/n8n-nodes-base.mysql/index.md
-                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.mysql/common-issues.md
-              - Customer Datastore (n8n Training): integrations/builtin/app-nodes/n8n-nodes-base.n8ntrainingcustomerdatastore.md
-              - Customer Messenger (n8n Training): integrations/builtin/app-nodes/n8n-nodes-base.n8ntrainingcustomermessenger.md
-              - NASA: integrations/builtin/app-nodes/n8n-nodes-base.nasa.md
-              - Netlify: integrations/builtin/app-nodes/n8n-nodes-base.netlify.md
-              - Netscaler ADC: integrations/builtin/app-nodes/n8n-nodes-base.netscaleradc.md
-              - Nextcloud: integrations/builtin/app-nodes/n8n-nodes-base.nextcloud.md
-              - NocoDB: integrations/builtin/app-nodes/n8n-nodes-base.nocodb.md
-              - Notion:
-                  - Notion: integrations/builtin/app-nodes/n8n-nodes-base.notion/index.md
-                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.notion/common-issues.md
-              - npm: integrations/builtin/app-nodes/n8n-nodes-base.npm.md
-              - Odoo: integrations/builtin/app-nodes/n8n-nodes-base.odoo.md
-              - Okta: integrations/builtin/app-nodes/n8n-nodes-base.okta.md
-              - One Simple API: integrations/builtin/app-nodes/n8n-nodes-base.onesimpleapi.md
-              - Onfleet: integrations/builtin/app-nodes/n8n-nodes-base.onfleet.md
-              - OpenAI:
-                  - OpenAI: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/index.md
-                  - Assistant operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/assistant-operations.md
-                  - Audio operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/audio-operations.md
-                  - Conversation operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/conversation-operations.md
-                  - File operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/file-operations.md
-                  - Image operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/image-operations.md
-                  - Text operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/text-operations.md
-                  - Video operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/video-operations.md
-                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
-              - OpenThesaurus: integrations/builtin/app-nodes/n8n-nodes-base.openthesaurus.md
-              - OpenWeatherMap: integrations/builtin/app-nodes/n8n-nodes-base.openweathermap.md
-              - Oracle Database:
-                  - Oracle Database: integrations/builtin/app-nodes/n8n-nodes-base.oracledb/index.md
-              - Oura: integrations/builtin/app-nodes/n8n-nodes-base.oura.md
-              - Paddle: integrations/builtin/app-nodes/n8n-nodes-base.paddle.md
-              - PagerDuty: integrations/builtin/app-nodes/n8n-nodes-base.pagerduty.md
-              - PayPal: integrations/builtin/app-nodes/n8n-nodes-base.paypal.md
-              - Peekalink: integrations/builtin/app-nodes/n8n-nodes-base.peekalink.md
-              - Perplexity: integrations/builtin/app-nodes/n8n-nodes-langchain.perplexity.md
-              - PhantomBuster: integrations/builtin/app-nodes/n8n-nodes-base.phantombuster.md
-              - Philips Hue: integrations/builtin/app-nodes/n8n-nodes-base.philipshue.md
-              - Pipedrive: integrations/builtin/app-nodes/n8n-nodes-base.pipedrive.md
-              - Plivo: integrations/builtin/app-nodes/n8n-nodes-base.plivo.md
-              - PostBin: integrations/builtin/app-nodes/n8n-nodes-base.postbin.md
-              - Postgres:
-                  - Postgres: integrations/builtin/app-nodes/n8n-nodes-base.postgres/index.md
-                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.postgres/common-issues.md
-              - PostHog: integrations/builtin/app-nodes/n8n-nodes-base.posthog.md
-              - ProfitWell: integrations/builtin/app-nodes/n8n-nodes-base.profitwell.md
-              - Pushbullet: integrations/builtin/app-nodes/n8n-nodes-base.pushbullet.md
-              - Pushcut: integrations/builtin/app-nodes/n8n-nodes-base.pushcut.md
-              - Pushover: integrations/builtin/app-nodes/n8n-nodes-base.pushover.md
-              - QuestDB: integrations/builtin/app-nodes/n8n-nodes-base.questdb.md
-              - Quick Base: integrations/builtin/app-nodes/n8n-nodes-base.quickbase.md
-              - QuickBooks Online: integrations/builtin/app-nodes/n8n-nodes-base.quickbooks.md
-              - QuickChart: integrations/builtin/app-nodes/n8n-nodes-base.quickchart.md
-              - RabbitMQ: integrations/builtin/app-nodes/n8n-nodes-base.rabbitmq.md
-              - Raindrop: integrations/builtin/app-nodes/n8n-nodes-base.raindrop.md
-              - Reddit: integrations/builtin/app-nodes/n8n-nodes-base.reddit.md
-              - Redis: integrations/builtin/app-nodes/n8n-nodes-base.redis.md
-              - Rocket.Chat: integrations/builtin/app-nodes/n8n-nodes-base.rocketchat.md
-              - Rundeck: integrations/builtin/app-nodes/n8n-nodes-base.rundeck.md
-              - S3: integrations/builtin/app-nodes/n8n-nodes-base.s3.md
-              - Salesforce: integrations/builtin/app-nodes/n8n-nodes-base.salesforce.md
-              - Salesmate: integrations/builtin/app-nodes/n8n-nodes-base.salesmate.md
-              - SeaTable: integrations/builtin/app-nodes/n8n-nodes-base.seatable.md
-              - SecurityScorecard: integrations/builtin/app-nodes/n8n-nodes-base.securityscorecard.md
-              - Segment: integrations/builtin/app-nodes/n8n-nodes-base.segment.md
-              - SendGrid: integrations/builtin/app-nodes/n8n-nodes-base.sendgrid.md
-              - Sendy: integrations/builtin/app-nodes/n8n-nodes-base.sendy.md
-              - Sentry.io: integrations/builtin/app-nodes/n8n-nodes-base.sentryio.md
-              - ServiceNow: integrations/builtin/app-nodes/n8n-nodes-base.servicenow.md
-              - seven: integrations/builtin/app-nodes/n8n-nodes-base.sms77.md
-              - Shopify: integrations/builtin/app-nodes/n8n-nodes-base.shopify.md
-              - SIGNL4: integrations/builtin/app-nodes/n8n-nodes-base.signl4.md
-              - Slack: integrations/builtin/app-nodes/n8n-nodes-base.slack.md
-              - Snowflake: integrations/builtin/app-nodes/n8n-nodes-base.snowflake.md
-              - Splunk: integrations/builtin/app-nodes/n8n-nodes-base.splunk.md
-              - Spotify: integrations/builtin/app-nodes/n8n-nodes-base.spotify.md
-              - Stackby: integrations/builtin/app-nodes/n8n-nodes-base.stackby.md
-              - Storyblok: integrations/builtin/app-nodes/n8n-nodes-base.storyblok.md
-              - Strapi: integrations/builtin/app-nodes/n8n-nodes-base.strapi.md
-              - Strava: integrations/builtin/app-nodes/n8n-nodes-base.strava.md
-              - Stripe: integrations/builtin/app-nodes/n8n-nodes-base.stripe.md
-              - Supabase:
-                  - Supabase: integrations/builtin/app-nodes/n8n-nodes-base.supabase/index.md
-                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.supabase/common-issues.md
-              - SyncroMSP: integrations/builtin/app-nodes/n8n-nodes-base.syncromsp.md
-              - Taiga: integrations/builtin/app-nodes/n8n-nodes-base.taiga.md
-              - Tapfiliate: integrations/builtin/app-nodes/n8n-nodes-base.tapfiliate.md
-              - Telegram:
-                  - integrations/builtin/app-nodes/n8n-nodes-base.telegram/index.md
-                  - Chat operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/chat-operations.md
-                  - Callback operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/callback-operations.md
-                  - File operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/file-operations.md
-                  - Message operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/message-operations.md
-                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.telegram/common-issues.md
-              - TheHive: integrations/builtin/app-nodes/n8n-nodes-base.thehive.md
-              - TheHive 5: integrations/builtin/app-nodes/n8n-nodes-base.thehive5.md
-              - TimescaleDB: integrations/builtin/app-nodes/n8n-nodes-base.timescaledb.md
-              - Todoist: integrations/builtin/app-nodes/n8n-nodes-base.todoist.md
-              - Travis CI: integrations/builtin/app-nodes/n8n-nodes-base.travisci.md
-              - Trello: integrations/builtin/app-nodes/n8n-nodes-base.trello.md
-              - Twake: integrations/builtin/app-nodes/n8n-nodes-base.twake.md
-              - Twilio: integrations/builtin/app-nodes/n8n-nodes-base.twilio.md
-              - Twist: integrations/builtin/app-nodes/n8n-nodes-base.twist.md
-              - Unleashed Software: integrations/builtin/app-nodes/n8n-nodes-base.unleashedsoftware.md
-              - UpLead: integrations/builtin/app-nodes/n8n-nodes-base.uplead.md
-              - uProc: integrations/builtin/app-nodes/n8n-nodes-base.uproc.md
-              - UptimeRobot: integrations/builtin/app-nodes/n8n-nodes-base.uptimerobot.md
-              - urlscan.io: integrations/builtin/app-nodes/n8n-nodes-base.urlscanio.md
-              - Venafi TLS Protect Cloud: integrations/builtin/app-nodes/n8n-nodes-base.venafitlsprotectcloud.md
-              - Venafi TLS Protect Datacenter: integrations/builtin/app-nodes/n8n-nodes-base.venafitlsprotectdatacenter.md
-              - Vero: integrations/builtin/app-nodes/n8n-nodes-base.vero.md
-              - Vonage: integrations/builtin/app-nodes/n8n-nodes-base.vonage.md
-              - Webflow: integrations/builtin/app-nodes/n8n-nodes-base.webflow.md
-              - Wekan: integrations/builtin/app-nodes/n8n-nodes-base.wekan.md
-              - WhatsApp Business Cloud:
-                  - WhatsApp Business Cloud: integrations/builtin/app-nodes/n8n-nodes-base.whatsapp/index.md
-                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.whatsapp/common-issues.md
-              - Wise: integrations/builtin/app-nodes/n8n-nodes-base.wise.md
-              - WooCommerce: integrations/builtin/app-nodes/n8n-nodes-base.woocommerce.md
-              - WordPress: integrations/builtin/app-nodes/n8n-nodes-base.wordpress.md
-              - X (Formerly Twitter): integrations/builtin/app-nodes/n8n-nodes-base.twitter.md
-              - Xero: integrations/builtin/app-nodes/n8n-nodes-base.xero.md
-              - Yourls: integrations/builtin/app-nodes/n8n-nodes-base.yourls.md
-              - YouTube: integrations/builtin/app-nodes/n8n-nodes-base.youtube.md
-              - Zammad: integrations/builtin/app-nodes/n8n-nodes-base.zammad.md
-              - Zendesk: integrations/builtin/app-nodes/n8n-nodes-base.zendesk.md
-              - Zoho CRM: integrations/builtin/app-nodes/n8n-nodes-base.zohocrm.md
-              - Zoom: integrations/builtin/app-nodes/n8n-nodes-base.zoom.md
-              - Zulip: integrations/builtin/app-nodes/n8n-nodes-base.zulip.md
-          - Triggers:
-              - integrations/builtin/trigger-nodes/index.md
-              - ActiveCampaign Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.activecampaigntrigger.md
-              - Acuity Scheduling Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.acuityschedulingtrigger.md
-              - Affinity Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.affinitytrigger.md
-              - Airtable Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.airtabletrigger.md
-              - AMQP Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.amqptrigger.md
-              - Asana Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.asanatrigger.md
-              - Autopilot Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.autopilottrigger.md
-              - AWS SNS Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.awssnstrigger.md
-              - Bitbucket Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.bitbuckettrigger.md
-              - Box Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.boxtrigger.md
-              - Brevo Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.brevotrigger.md
-              - Calendly Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.calendlytrigger.md
-              - Cal Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.caltrigger.md
-              - Chargebee Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.chargebeetrigger.md
-              - ClickUp Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.clickuptrigger.md
-              - Clockify Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.clockifytrigger.md
-              - ConvertKit Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.convertkittrigger.md
-              - Copper Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.coppertrigger.md
-              - crowd.dev Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.crowddevtrigger.md
-              - Customer.io Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.customeriotrigger.md
-              - Emelia Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.emeliatrigger.md
-              - Eventbrite Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.eventbritetrigger.md
-              - Facebook Lead Ads Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.facebookleadadstrigger.md
-              - Facebook Trigger:
-                  - Facebook Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/index.md
-                  - Ad Account: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/ad-account.md
-                  - Application: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/application.md
-                  - Certificate Transparency: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/certificate-transparency.md
-                  - Group: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/group.md
-                  - Instagram: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/instagram.md
-                  - Link: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/link.md
-                  - Page: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/page.md
-                  - Permissions: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/permissions.md
-                  - User: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/user.md
-                  - WhatsApp Business Account: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/whatsapp.md
-                  - Workplace Security: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/workplace-security.md
-              - Figma Trigger (Beta): integrations/builtin/trigger-nodes/n8n-nodes-base.figmatrigger.md
-              - Flow Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.flowtrigger.md
-              - Form.io Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.formiotrigger.md
-              - Formstack Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.formstacktrigger.md
-              - GetResponse Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.getresponsetrigger.md
-              - GitHub Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.githubtrigger.md
-              - GitLab Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.gitlabtrigger.md
-              - Gmail Trigger:
-                  - integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/index.md
-                  - Poll Mode options: integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/poll-mode-options.md
-                  - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/common-issues.md
-              - Google Calendar Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googlecalendartrigger.md
-              - Google Drive Trigger:
-                  - Google Drive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googledrivetrigger/index.md
-                  - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.googledrivetrigger/common-issues.md
-              - Google Business Profile Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googlebusinessprofiletrigger.md
-              - Google Sheets Trigger:
-                  - Google Sheets Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googlesheetstrigger/index.md
-                  - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.googlesheetstrigger/common-issues.md
-              - Gumroad Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.gumroadtrigger.md
-              - Help Scout Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.helpscouttrigger.md
-              - Hubspot Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.hubspottrigger.md
-              - Invoice Ninja Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.invoiceninjatrigger.md
-              - Jira Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.jiratrigger.md
-              - Jotform Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.jotformtrigger.md
-              - Kafka Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.kafkatrigger.md
-              - Keap Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.keaptrigger.md
-              - KoboToolbox Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.kobotoolboxtrigger.md
-              - Lemlist Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.lemlisttrigger.md
-              - Linear Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.lineartrigger.md
-              - LoneScale Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.lonescaletrigger.md
-              - Mailchimp Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mailchimptrigger.md
-              - MailerLite Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mailerlitetrigger.md
-              - Mailjet Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mailjettrigger.md
-              - Mautic Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mautictrigger.md
-              - Microsoft OneDrive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftonedrivetrigger.md
-              - Microsoft Outlook Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftoutlooktrigger.md
-              - Microsoft Teams Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftteamstrigger.md
-              - MQTT Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mqtttrigger.md
-              - Netlify Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.netlifytrigger.md
-              - Notion Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.notiontrigger.md
-              - Onfleet Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.onfleettrigger.md
-              - PayPal Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.paypaltrigger.md
-              - Pipedrive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.pipedrivetrigger.md
-              - Postgres Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.postgrestrigger.md
-              - Postmark Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.postmarktrigger.md
-              - Pushcut Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.pushcuttrigger.md
-              - RabbitMQ Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.rabbitmqtrigger.md
-              - Redis Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.redistrigger.md
-              - Salesforce Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.salesforcetrigger.md
-              - SeaTable Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.seatabletrigger.md
-              - Shopify Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.shopifytrigger.md
-              - Slack Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
-              - Strava Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.stravatrigger.md
-              - Stripe Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.stripetrigger.md
-              - SurveyMonkey Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.surveymonkeytrigger.md
-              - Taiga Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.taigatrigger.md
-              - Telegram Trigger:
-                  - Telegram Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.telegramtrigger/index.md
-                  - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.telegramtrigger/common-issues.md
-              - TheHive 5 Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.thehive5trigger.md
-              - TheHive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.thehivetrigger.md
-              - Toggl Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.toggltrigger.md
-              - Trello Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.trellotrigger.md
-              - Twilio Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.twiliotrigger.md
-              - Typeform Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.typeformtrigger.md
-              - Venafi TLS Protect Cloud Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.venafitlsprotectcloudtrigger.md
-              - Webex by Cisco Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.ciscowebextrigger.md
-              - Webflow Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.webflowtrigger.md
-              - WhatsApp Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.whatsapptrigger.md
-              - Wise Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.wisetrigger.md
-              - WooCommerce Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.woocommercetrigger.md
-              - Workable Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.workabletrigger.md
-              - Wufoo Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.wufootrigger.md
-              - Zendesk Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.zendesktrigger.md
-          - Cluster nodes:
-              - integrations/builtin/cluster-nodes/index.md
-              - Root nodes:
-                  - integrations/builtin/cluster-nodes/root-nodes/index.md
-                  - AI Agent:
-                      - AI Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/index.md
-                      - Conversational Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/conversational-agent.md
-                      - OpenAI Functions Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/openai-functions-agent.md
-                      - Plan and Execute Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/plan-execute-agent.md
-                      - ReAct Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/react-agent.md
-                      - SQL Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/sql-agent.md
-                      - Tools Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
-                      - Common issues: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/common-issues.md
-                  - Basic LLM Chain: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainllm.md
-                  - Question and Answer Chain:
-                      - Question and Answer Chain: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainretrievalqa/index.md
-                      - Common issues: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainretrievalqa/common-issues.md
-                  - Summarization Chain: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainsummarization.md
-                  - Information Extractor: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.information-extractor.md
-                  - Text Classifier: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.text-classifier.md
-                  - Sentiment Analysis: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.sentimentanalysis.md
-                  - LangChain Code: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.code.md
-                  - Microsoft Agent 365 Trigger: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.microsoftagent365trigger/index.md
-                  - Azure AI Search Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreazureaisearch.md
-                  - Simple Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreinmemory.md
-                  - Milvus Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremilvus.md
-                  - MongoDB Atlas Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md
-                  - PGVector Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepgvector.md
-                  - Chroma Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorechroma.md
-                  - Pinecone Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepinecone.md
-                  - Qdrant Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreqdrant.md
-                  - Redis Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreredis.md
-                  - Supabase Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoresupabase.md
-                  - Weaviate Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreweaviate.md
-                  - Zep Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorezep.md
-              - Sub-nodes:
-                  - integrations/builtin/cluster-nodes/sub-nodes/index.md
-                  - Default Data Loader: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentdefaultdataloader.md
-                  - GitHub Document Loader: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentgithubloader.md
-                  - Embeddings AWS Bedrock: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsawsbedrock.md
-                  - Embeddings Azure OpenAI: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsazureopenai.md
-                  - Embeddings Cohere: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingscohere.md
-                  - Embeddings Google Gemini: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsgooglegemini.md
-                  - Embeddings Google PaLM: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsgooglepalm.md
-                  - Embeddings Google Vertex: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsgooglevertex.md
-                  - Embeddings HuggingFace Inference: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingshuggingfaceinference.md
-                  - Embeddings Lemonade: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingslemonade.md
-                  - Embeddings Mistral Cloud: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsmistralcloud.md
-                  - Embeddings Ollama: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsollama.md
-                  - Embeddings OpenAI: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsopenai.md
-                  - Anthropic Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatanthropic.md
-                  - AWS Bedrock Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatawsbedrock.md
-                  - Azure OpenAI Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatazureopenai.md
-                  - Cohere Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatcohere.md
-                  - DeepSeek Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatdeepseek.md
-                  - Google Gemini Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgooglegemini.md
-                  - Google Vertex Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgooglevertex.md
-                  - Groq Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgroq.md
-                  - Lemonade Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatlemonade.md
-                  - Mistral Cloud Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatmistralcloud.md
-                  - Ollama Chat Model:
-                      - Ollama Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatollama/index.md
-                      - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatollama/common-issues.md
-                  - OpenAI Chat Model:
-                      - OpenAI Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai/index.md
-                      - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai/common-issues.md
-                  - OpenRouter Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenrouter.md
-                  - Vercel AI Gateway Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatvercel.md
-                  - xAI Grok Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatxaigrok.md
-                  - Cohere Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmcohere.md
-                  - Lemonade Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmlemonade.md
-                  - Ollama Model:
-                      - Ollama Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmollama/index.md
-                      - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmollama/common-issues.md
-                  - Hugging Face Inference Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmopenhuggingfaceinference.md
-                  - Chat Memory Manager: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorymanager.md
-                  - Simple Memory:
-                      - integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorybufferwindow/index.md
-                      - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorybufferwindow/common-issues.md
-                  - Motorhead: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorymotorhead.md
-                  - MongoDB Chat Memory: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorymongochat.md
-                  - Redis Chat Memory: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memoryredischat.md
-                  - Postgres Chat Memory: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorypostgreschat.md
-                  - Xata: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memoryxata.md
-                  - Zep: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memoryzep.md
-                  - Auto-fixing Output Parser: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparserautofixing.md
-                  - Item List Output Parser: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparseritemlist.md
-                  - Structured Output Parser:
-                      - Structured Output Parser: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparserstructured/index.md
-                      - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparserstructured/common-issues.md
-                  - Contextual Compression Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrievercontextualcompression.md
-                  - MultiQuery Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrievermultiquery.md
-                  - Vector Store Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrievervectorstore.md
-                  - Workflow Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrieverworkflow.md
-                  - Character Text Splitter: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.textsplittercharactertextsplitter.md
-                  - Recursive Character Text Splitter: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.textsplitterrecursivecharactertextsplitter.md
-                  - Token Splitter: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.textsplittertokensplitter.md
-                  - AI Agent Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolaiagent.md
-                  - Calculator: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcalculator.md
-                  - Custom Code Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcode.md
-                  - MCP Client Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md
-                  - SearXNG Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolsearxng.md
-                  - SerpApi (Google Search): integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolserpapi.md
-                  - Think Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolthink.md
-                  - Vector Store Question Answer Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolvectorstore.md
-                  - Wikipedia: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolwikipedia.md
-                  - Wolfram|Alpha: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolwolframalpha.md
-                  - Call n8n Workflow Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md
-                  - Reranker Cohere: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.rerankercohere.md
-                  - Model Selector: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.modelselector.md
-          - Credentials:
-              - integrations/builtin/credentials/index.md
-              - integrations/builtin/credentials/actionnetwork.md
-              - integrations/builtin/credentials/activecampaign.md
-              - integrations/builtin/credentials/acuityscheduling.md
-              - integrations/builtin/credentials/adalo.md
-              - integrations/builtin/credentials/affinity.md
-              - integrations/builtin/credentials/agilecrm.md
-              - integrations/builtin/credentials/airtable.md
-              - integrations/builtin/credentials/airtop.md
-              - integrations/builtin/credentials/alienvault.md
-              - integrations/builtin/credentials/amqp.md
-              - integrations/builtin/credentials/anthropic.md
-              - integrations/builtin/credentials/apitemplateio.md
-              - integrations/builtin/credentials/asana.md
-              - integrations/builtin/credentials/auth0management.md
-              - integrations/builtin/credentials/autopilot.md
-              - integrations/builtin/credentials/aws.md
-              - integrations/builtin/credentials/azureopenai.md
-              - integrations/builtin/credentials/azurecosmosdb.md
-              - integrations/builtin/credentials/azureaisearch.md
-              - integrations/builtin/credentials/azurestorage.md
-              - integrations/builtin/credentials/bamboohr.md
-              - integrations/builtin/credentials/bannerbear.md
-              - integrations/builtin/credentials/baserow.md
-              - integrations/builtin/credentials/beeminder.md
-              - integrations/builtin/credentials/bitbucket.md
-              - integrations/builtin/credentials/bitly.md
-              - integrations/builtin/credentials/bitwarden.md
-              - integrations/builtin/credentials/box.md
-              - integrations/builtin/credentials/brandfetch.md
-              - integrations/builtin/credentials/brevo.md
-              - integrations/builtin/credentials/bubble.md
-              - integrations/builtin/credentials/cal.md
-              - integrations/builtin/credentials/calendly.md
-              - integrations/builtin/credentials/carbonblack.md
-              - integrations/builtin/credentials/chargebee.md
-              - integrations/builtin/credentials/circleci.md
-              - integrations/builtin/credentials/ciscomeraki.md
-              - integrations/builtin/credentials/ciscosecureendpoint.md
-              - integrations/builtin/credentials/ciscoumbrella.md
-              - integrations/builtin/credentials/clearbit.md
-              - integrations/builtin/credentials/clickup.md
-              - integrations/builtin/credentials/clockify.md
-              - integrations/builtin/credentials/cloudflare.md
-              - integrations/builtin/credentials/cockpit.md
-              - integrations/builtin/credentials/coda.md
-              - integrations/builtin/credentials/cohere.md
-              - integrations/builtin/credentials/contentful.md
-              - integrations/builtin/credentials/convertapi.md
-              - integrations/builtin/credentials/convertkit.md
-              - integrations/builtin/credentials/copper.md
-              - integrations/builtin/credentials/cortex.md
-              - integrations/builtin/credentials/cratedb.md
-              - integrations/builtin/credentials/crowddev.md
-              - integrations/builtin/credentials/crowdstrike.md
-              - integrations/builtin/credentials/customerio.md
-              - integrations/builtin/credentials/databricks.md
-              - integrations/builtin/credentials/datadog.md
-              - integrations/builtin/credentials/deepl.md
-              - integrations/builtin/credentials/deepseek.md
-              - integrations/builtin/credentials/demio.md
-              - integrations/builtin/credentials/dfiriris.md
-              - integrations/builtin/credentials/dhl.md
-              - integrations/builtin/credentials/discord.md
-              - integrations/builtin/credentials/discourse.md
-              - integrations/builtin/credentials/disqus.md
-              - integrations/builtin/credentials/drift.md
-              - integrations/builtin/credentials/dropbox.md
-              - integrations/builtin/credentials/dropcontact.md
-              - integrations/builtin/credentials/dynatrace.md
-              - integrations/builtin/credentials/egoi.md
-              - integrations/builtin/credentials/elasticsearch.md
-              - integrations/builtin/credentials/elasticsecurity.md
-              - integrations/builtin/credentials/emelia.md
-              - integrations/builtin/credentials/erpnext.md
-              - integrations/builtin/credentials/eventbrite.md
-              - integrations/builtin/credentials/f5bigip.md
-              - integrations/builtin/credentials/facebookapp.md
-              - integrations/builtin/credentials/facebookgraph.md
-              - integrations/builtin/credentials/facebookleadads.md
-              - integrations/builtin/credentials/figma.md
-              - integrations/builtin/credentials/filemaker.md
-              - integrations/builtin/credentials/filescan.md
-              - integrations/builtin/credentials/flow.md
-              - integrations/builtin/credentials/formiotrigger.md
-              - integrations/builtin/credentials/formstacktrigger.md
-              - integrations/builtin/credentials/fortigate.md
-              - integrations/builtin/credentials/freshdesk.md
-              - integrations/builtin/credentials/freshservice.md
-              - integrations/builtin/credentials/freshworkscrm.md
-              - integrations/builtin/credentials/ftp.md
-              - integrations/builtin/credentials/getresponse.md
-              - integrations/builtin/credentials/ghost.md
-              - integrations/builtin/credentials/git.md
-              - integrations/builtin/credentials/github.md
-              - integrations/builtin/credentials/gitlab.md
-              - integrations/builtin/credentials/gong.md
-              - Google:
-                  - integrations/builtin/credentials/google/index.md
-                  - integrations/builtin/credentials/google/oauth-single-service.md
-                  - integrations/builtin/credentials/google/oauth-generic.md
-                  - integrations/builtin/credentials/google/service-account.md
-              - integrations/builtin/credentials/googleai.md
-              - integrations/builtin/credentials/gotify.md
-              - integrations/builtin/credentials/gotowebinar.md
-              - integrations/builtin/credentials/grafana.md
-              - integrations/builtin/credentials/grist.md
-              - integrations/builtin/credentials/groq.md
-              - integrations/builtin/credentials/gumroad.md
-              - integrations/builtin/credentials/halopsa.md
-              - integrations/builtin/credentials/harvest.md
-              - integrations/builtin/credentials/helpscout.md
-              - integrations/builtin/credentials/highlevel.md
-              - integrations/builtin/credentials/homeassistant.md
-              - integrations/builtin/credentials/httprequest.md
-              - integrations/builtin/credentials/hubspot.md
-              - integrations/builtin/credentials/huggingface.md
-              - integrations/builtin/credentials/humanticai.md
-              - integrations/builtin/credentials/hunter.md
-              - integrations/builtin/credentials/hybridanalysis.md
-              - IMAP:
-                  - integrations/builtin/credentials/imap/index.md
-                  - integrations/builtin/credentials/imap/gmail.md
-                  - integrations/builtin/credentials/imap/outlook.md
-                  - integrations/builtin/credentials/imap/yahoo.md
-              - integrations/builtin/credentials/impervawaf.md
-              - integrations/builtin/credentials/intercom.md
-              - integrations/builtin/credentials/invoiceninja.md
-              - integrations/builtin/credentials/iterable.md
-              - integrations/builtin/credentials/jenkins.md
-              - integrations/builtin/credentials/jinaai.md
-              - integrations/builtin/credentials/jira.md
-              - integrations/builtin/credentials/jotform.md
-              - integrations/builtin/credentials/jwt.md
-              - integrations/builtin/credentials/kafka.md
-              - integrations/builtin/credentials/keap.md
-              - integrations/builtin/credentials/kibana.md
-              - integrations/builtin/credentials/kitemaker.md
-              - integrations/builtin/credentials/kobotoolbox.md
-              - integrations/builtin/credentials/ldap.md
-              - integrations/builtin/credentials/lemlist.md
-              - integrations/builtin/credentials/lemonade.md
-              - integrations/builtin/credentials/line.md
-              - integrations/builtin/credentials/linear.md
-              - integrations/builtin/credentials/lingvanex.md
-              - integrations/builtin/credentials/linkedin.md
-              - integrations/builtin/credentials/lonescale.md
-              - integrations/builtin/credentials/magento2.md
-              - integrations/builtin/credentials/mailcheck.md
-              - integrations/builtin/credentials/mailchimp.md
-              - integrations/builtin/credentials/mailerlite.md
-              - integrations/builtin/credentials/mailgun.md
-              - integrations/builtin/credentials/mailjet.md
-              - integrations/builtin/credentials/malcore.md
-              - integrations/builtin/credentials/mandrill.md
-              - integrations/builtin/credentials/marketstack.md
-              - integrations/builtin/credentials/matrix.md
-              - integrations/builtin/credentials/mattermost.md
-              - integrations/builtin/credentials/mautic.md
-              - integrations/builtin/credentials/medium.md
-              - integrations/builtin/credentials/messagebird.md
-              - integrations/builtin/credentials/metabase.md
-              - integrations/builtin/credentials/microsoft.md
-              - integrations/builtin/credentials/microsoftazuremonitor.md
-              - integrations/builtin/credentials/microsoftentra.md
-              - integrations/builtin/credentials/microsoftsql.md
-              - integrations/builtin/credentials/microsoftagent365.md
-              - integrations/builtin/credentials/milvus.md
-              - integrations/builtin/credentials/mindee.md
-              - integrations/builtin/credentials/miro.md
-              - integrations/builtin/credentials/misp.md
-              - integrations/builtin/credentials/mist.md
-              - integrations/builtin/credentials/mistral.md
-              - integrations/builtin/credentials/mocean.md
-              - integrations/builtin/credentials/mondaycom.md
-              - integrations/builtin/credentials/mongodb.md
-              - integrations/builtin/credentials/monicacrm.md
-              - integrations/builtin/credentials/motorhead.md
-              - integrations/builtin/credentials/mqtt.md
-              - integrations/builtin/credentials/msg91.md
-              - integrations/builtin/credentials/mysql.md
-              - integrations/builtin/credentials/nasa.md
-              - integrations/builtin/credentials/netlify.md
-              - integrations/builtin/credentials/netscaleradc.md
-              - integrations/builtin/credentials/nextcloud.md
-              - integrations/builtin/credentials/nocodb.md
-              - integrations/builtin/credentials/notion.md
-              - integrations/builtin/credentials/npm.md
-              - integrations/builtin/credentials/odoo.md
-              - integrations/builtin/credentials/okta.md
-              - integrations/builtin/credentials/ollama.md
-              - integrations/builtin/credentials/onesimpleapi.md
-              - integrations/builtin/credentials/onfleet.md
-              - integrations/builtin/credentials/openai.md
-              - integrations/builtin/credentials/opencti.md
-              - integrations/builtin/credentials/openrouter.md
-              - integrations/builtin/credentials/openweathermap.md
-              - integrations/builtin/credentials/oracledb.md
-              - integrations/builtin/credentials/oura.md
-              - integrations/builtin/credentials/paddle.md
-              - integrations/builtin/credentials/pagerduty.md
-              - integrations/builtin/credentials/paypal.md
-              - integrations/builtin/credentials/peekalink.md
-              - integrations/builtin/credentials/perplexity.md
-              - integrations/builtin/credentials/phantombuster.md
-              - integrations/builtin/credentials/philipshue.md
-              - integrations/builtin/credentials/chroma.md
-              - integrations/builtin/credentials/pinecone.md
-              - integrations/builtin/credentials/pipedrive.md
-              - integrations/builtin/credentials/plivo.md
-              - integrations/builtin/credentials/postgres.md
-              - integrations/builtin/credentials/posthog.md
-              - integrations/builtin/credentials/postmark.md
-              - integrations/builtin/credentials/profitwell.md
-              - integrations/builtin/credentials/pushbullet.md
-              - integrations/builtin/credentials/pushcut.md
-              - integrations/builtin/credentials/pushover.md
-              - integrations/builtin/credentials/qradar.md
-              - integrations/builtin/credentials/qdrant.md
-              - integrations/builtin/credentials/qualys.md
-              - integrations/builtin/credentials/questdb.md
-              - integrations/builtin/credentials/quickbase.md
-              - integrations/builtin/credentials/quickbooks.md
-              - integrations/builtin/credentials/rabbitmq.md
-              - integrations/builtin/credentials/raindrop.md
-              - integrations/builtin/credentials/rapid7insightvm.md
-              - integrations/builtin/credentials/recordedfuture.md
-              - integrations/builtin/credentials/reddit.md
-              - integrations/builtin/credentials/redis.md
-              - integrations/builtin/credentials/rocketchat.md
-              - integrations/builtin/credentials/rundeck.md
-              - integrations/builtin/credentials/s3.md
-              - integrations/builtin/credentials/salesforce.md
-              - integrations/builtin/credentials/salesmate.md
-              - integrations/builtin/credentials/searxng.md
-              - integrations/builtin/credentials/seatable.md
-              - integrations/builtin/credentials/securityscorecard.md
-              - integrations/builtin/credentials/segment.md
-              - integrations/builtin/credentials/sekoia.md
-              - Send Email:
-                  - integrations/builtin/credentials/sendemail/index.md
-                  - integrations/builtin/credentials/sendemail/gmail.md
-                  - integrations/builtin/credentials/sendemail/outlook.md
-                  - integrations/builtin/credentials/sendemail/yahoo.md
-              - integrations/builtin/credentials/sendgrid.md
-              - integrations/builtin/credentials/sendy.md
-              - integrations/builtin/credentials/sentryio.md
-              - integrations/builtin/credentials/serp.md
-              - integrations/builtin/credentials/servicenow.md
-              - integrations/builtin/credentials/sms77.md
-              - integrations/builtin/credentials/shopify.md
-              - integrations/builtin/credentials/shuffler.md
-              - integrations/builtin/credentials/signl4.md
-              - integrations/builtin/credentials/slack.md
-              - integrations/builtin/credentials/snowflake.md
-              - integrations/builtin/credentials/solarwindsipam.md
-              - integrations/builtin/credentials/solarwindsobservability.md
-              - integrations/builtin/credentials/splunk.md
-              - integrations/builtin/credentials/spotify.md
-              - integrations/builtin/credentials/ssh.md
-              - integrations/builtin/credentials/stackby.md
-              - integrations/builtin/credentials/storyblok.md
-              - integrations/builtin/credentials/strapi.md
-              - integrations/builtin/credentials/strava.md
-              - integrations/builtin/credentials/stripe.md
-              - integrations/builtin/credentials/supabase.md
-              - integrations/builtin/credentials/surveymonkey.md
-              - integrations/builtin/credentials/syncromsp.md
-              - integrations/builtin/credentials/sysdig.md
-              - integrations/builtin/credentials/taiga.md
-              - integrations/builtin/credentials/tapfiliate.md
-              - integrations/builtin/credentials/telegram.md
-              - integrations/builtin/credentials/thehive.md
-              - integrations/builtin/credentials/thehive5.md
-              - integrations/builtin/credentials/timescaledb.md
-              - integrations/builtin/credentials/todoist.md
-              - integrations/builtin/credentials/toggl.md
-              - integrations/builtin/credentials/totp.md
-              - integrations/builtin/credentials/travisci.md
-              - integrations/builtin/credentials/trellixepo.md
-              - integrations/builtin/credentials/trello.md
-              - integrations/builtin/credentials/twake.md
-              - integrations/builtin/credentials/twilio.md
-              - integrations/builtin/credentials/twist.md
-              - integrations/builtin/credentials/typeform.md
-              - integrations/builtin/credentials/unleashedsoftware.md
-              - integrations/builtin/credentials/uplead.md
-              - integrations/builtin/credentials/uproc.md
-              - integrations/builtin/credentials/uptimerobot.md
-              - integrations/builtin/credentials/urlscanio.md
-              - integrations/builtin/credentials/venafitlsprotectcloud.md
-              - integrations/builtin/credentials/venafitlsprotectdatacenter.md
-              - integrations/builtin/credentials/vercel.md
-              - integrations/builtin/credentials/vero.md
-              - integrations/builtin/credentials/virustotal.md
-              - integrations/builtin/credentials/vonage.md
-              - integrations/builtin/credentials/weaviate.md
-              - integrations/builtin/credentials/ciscowebex.md
-              - integrations/builtin/credentials/webflow.md
-              - integrations/builtin/credentials/webhook.md
-              - integrations/builtin/credentials/wekan.md
-              - integrations/builtin/credentials/whatsapp.md
-              - integrations/builtin/credentials/wise.md
-              - integrations/builtin/credentials/wolframalpha.md
-              - integrations/builtin/credentials/woocommerce.md
-              - integrations/builtin/credentials/wordpress.md
-              - integrations/builtin/credentials/workable.md
-              - integrations/builtin/credentials/wufoo.md
-              - integrations/builtin/credentials/twitter.md
-              - integrations/builtin/credentials/xai.md
-              - integrations/builtin/credentials/xata.md
-              - integrations/builtin/credentials/xero.md
-              - integrations/builtin/credentials/yourls.md
-              - integrations/builtin/credentials/zabbix.md
-              - integrations/builtin/credentials/zammad.md
-              - integrations/builtin/credentials/zendesk.md
-              - integrations/builtin/credentials/zep.md
-              - integrations/builtin/credentials/zoho.md
-              - integrations/builtin/credentials/zoom.md
-              - integrations/builtin/credentials/zscalerzia.md
-              - integrations/builtin/credentials/zulip.md
-          - Custom API actions for existing nodes: integrations/custom-operations.md
-          - Handle rate limits: integrations/builtin/rate-limits.md
-      - Community nodes:
-          - Installation and management:
-              - integrations/community-nodes/installation/index.md
-              - Install verified community nodes: integrations/community-nodes/installation/verified-install.md
-              - GUI installation: integrations/community-nodes/installation/gui-install.md
-              - Manual installation: integrations/community-nodes/installation/manual-install.md
-          - Risks: integrations/community-nodes/risks.md
-          - Blocklist: integrations/community-nodes/blocklist.md
-          - Using community nodes: integrations/community-nodes/usage.md
-          - Troubleshooting: integrations/community-nodes/troubleshooting.md
-          - Building community nodes: integrations/community-nodes/build-community-nodes.md
-      - Creating nodes:
-          - Overview: integrations/creating-nodes/overview.md
-          - Plan your node:
-              - integrations/creating-nodes/plan/index.md
-              - Choose a node type: integrations/creating-nodes/plan/node-types.md
-              - Choose a node building style: integrations/creating-nodes/plan/choose-node-method.md
-              - Node UI design: integrations/creating-nodes/plan/node-ui-design.md
-              - Choose node file structure: integrations/creating-nodes/build/reference/node-file-structure.md
-          - Build your node:
-              - integrations/creating-nodes/build/index.md
-              - Set up your development environment: integrations/creating-nodes/build/node-development-environment.md
-              - Using the n8n-node tool: integrations/creating-nodes/build/n8n-node.md
-              - "Tutorial: Build a declarative-style node": integrations/creating-nodes/build/declarative-style-node.md
-              - "Tutorial: Build a programmatic-style node": integrations/creating-nodes/build/programmatic-style-node.md
-              - Reference:
-                  - integrations/creating-nodes/build/reference/index.md
-                  - Node UI elements: integrations/creating-nodes/build/reference/ui-elements.md
-                  - Code standards: integrations/creating-nodes/build/reference/code-standards.md
-                  - Error handling: integrations/creating-nodes/build/reference/error-handling.md
-                  - Versioning: integrations/creating-nodes/build/reference/node-versioning.md
-                  - File structure: integrations/creating-nodes/build/reference/node-file-structure.md
-                  - Base files:
-                      - integrations/creating-nodes/build/reference/node-base-files/index.md
-                      - Structure: integrations/creating-nodes/build/reference/node-base-files/structure.md
-                      - Standard parameters: integrations/creating-nodes/build/reference/node-base-files/standard-parameters.md
-                      - Declarative-style parameters: integrations/creating-nodes/build/reference/node-base-files/declarative-style-parameters.md
-                      - Programmatic-style parameters: integrations/creating-nodes/build/reference/node-base-files/programmatic-style-parameters.md
-                      - Programmatic-style execute method: integrations/creating-nodes/build/reference/node-base-files/programmatic-style-execute-method.md
-                  - Codex files: integrations/creating-nodes/build/reference/node-codex-files.md
-                  - Credentials files: integrations/creating-nodes/build/reference/credentials-files.md
-                  - HTTP request helpers: integrations/creating-nodes/build/reference/http-helpers.md
-                  - Item linking: integrations/creating-nodes/build/reference/paired-items.md
-                  - UX guidelines: integrations/creating-nodes/build/reference/ux-guidelines.md
-                  - Verification guidelines: integrations/creating-nodes/build/reference/verification-guidelines.md
-          - Test your node:
-              - integrations/creating-nodes/test/index.md
-              - Run your node locally: integrations/creating-nodes/test/run-node-locally.md
-              - Node linter: integrations/creating-nodes/test/node-linter.md
-              - Troubleshooting: integrations/creating-nodes/test/troubleshooting-node-development.md
-          - Deploy your node:
-              - integrations/creating-nodes/deploy/index.md
-              - Submit community nodes: integrations/creating-nodes/deploy/submit-community-nodes.md
-              - Install private nodes: integrations/creating-nodes/deploy/install-private-nodes.md
+    - integrations/index.md
+    - Built-in nodes:
+      - Node types: integrations/builtin/node-types.md
+      - Core nodes:
+        - integrations/builtin/core-nodes/index.md
+        - Activation Trigger: integrations/builtin/core-nodes/n8n-nodes-base.activationtrigger.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.aggregate.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.aitransform.md
+        - Code:
+          - Code: integrations/builtin/core-nodes/n8n-nodes-base.code/index.md
+          - Keyboard shortcuts: integrations/builtin/core-nodes/n8n-nodes-base.code/keyboard-shortcuts.md
+          - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.code/common-issues.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.comparedatasets.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.compression.md
+        - Chat Trigger:
+          - Chat Trigger: integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/index.md
+          - Common issues: integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/common-issues.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.converttofile.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.crypto.md
+        - Data Table:
+          - Data Table: integrations/builtin/core-nodes/n8n-nodes-base.datatable/index.md
+          - Row operations: integrations/builtin/core-nodes/n8n-nodes-base.datatable/rows.md
+          - Table operations: integrations/builtin/core-nodes/n8n-nodes-base.datatable/tables.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.datetime.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.debughelper.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.set.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.editimage.md
+        - Email Trigger (IMAP): integrations/builtin/core-nodes/n8n-nodes-base.emailimap.md
+        - Error Trigger: integrations/builtin/core-nodes/n8n-nodes-base.errortrigger.md
+        - Evaluation: integrations/builtin/core-nodes/n8n-nodes-base.evaluation.md
+        - Evaluation Trigger: integrations/builtin/core-nodes/n8n-nodes-base.evaluationtrigger.md
+        - Execute Command:
+          - Execute Command: integrations/builtin/core-nodes/n8n-nodes-base.executecommand/index.md
+          - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.executecommand/common-issues.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.executeworkflow.md
+        - Execute Sub-workflow Trigger: integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.executiondata.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.extractfromfile.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.filter.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.ftp.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.git.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.graphql.md
+        - Guardrails: integrations/builtin/core-nodes/n8n-nodes-langchain.guardrails.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.html.md
+        - HTTP Request:
+          - HTTP Request: integrations/builtin/core-nodes/n8n-nodes-base.httprequest/index.md
+          - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.httprequest/common-issues.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.if.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.jwt.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.ldap.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.limit.md
+        - Local File Trigger: integrations/builtin/core-nodes/n8n-nodes-base.localfiletrigger.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches.md
+        - Manual Trigger: integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.markdown.md
+        - MCP Client: integrations/builtin/core-nodes/n8n-nodes-langchain.mcpClient.md
+        - MCP Server Trigger: integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.merge.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.n8n.md
+        - n8n Form: integrations/builtin/core-nodes/n8n-nodes-base.form.md
+        - n8n Form Trigger: integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
+        - n8n Trigger: integrations/builtin/core-nodes/n8n-nodes-base.n8ntrigger.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.noop.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.readwritefile.md
+        - Remove Duplicates:
+          - integrations/builtin/core-nodes/n8n-nodes-base.removeduplicates/index.md
+          - Templates and examples: integrations/builtin/core-nodes/n8n-nodes-base.removeduplicates/templates-and-examples.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.renamekeys.md
+        - Chat: integrations/builtin/core-nodes/n8n-nodes-langchain.chat.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.respondtowebhook.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.rssfeedread.md
+        - RSS Feed Trigger: integrations/builtin/core-nodes/n8n-nodes-base.rssfeedreadtrigger.md
+        - Schedule Trigger:
+          - Schedule Trigger: integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/index.md
+          - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/common-issues.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.sendemail.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.sort.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.splitout.md
+        - SSE Trigger: integrations/builtin/core-nodes/n8n-nodes-base.ssetrigger.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.ssh.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.stopanderror.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.summarize.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.switch.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.totp.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.wait.md
+        - Webhook:
+          - integrations/builtin/core-nodes/n8n-nodes-base.webhook/index.md
+          - Workflow development: integrations/builtin/core-nodes/n8n-nodes-base.webhook/workflow-development.md
+          - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.webhook/common-issues.md
+        - Workflow Trigger: integrations/builtin/core-nodes/n8n-nodes-base.workflowtrigger.md
+        - integrations/builtin/core-nodes/n8n-nodes-base.xml.md
+      - Actions:
+        - integrations/builtin/app-nodes/index.md
+        - Action Network: integrations/builtin/app-nodes/n8n-nodes-base.actionnetwork.md
+        - ActiveCampaign: integrations/builtin/app-nodes/n8n-nodes-base.activecampaign.md
+        - Adalo: integrations/builtin/app-nodes/n8n-nodes-base.adalo.md
+        - Affinity: integrations/builtin/app-nodes/n8n-nodes-base.affinity.md
+        - Agile CRM: integrations/builtin/app-nodes/n8n-nodes-base.agilecrm.md
+        - Airtable:
+          - Airtable: integrations/builtin/app-nodes/n8n-nodes-base.airtable/index.md
+          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.airtable/common-issues.md
+        - Airtop: integrations/builtin/app-nodes/n8n-nodes-base.airtop.md
+        - AMQP Sender: integrations/builtin/app-nodes/n8n-nodes-base.amqp.md
+        - Anthropic: integrations/builtin/app-nodes/n8n-nodes-langchain.anthropic.md
+        - APITemplate.io: integrations/builtin/app-nodes/n8n-nodes-base.apitemplateio.md
+        - Asana: integrations/builtin/app-nodes/n8n-nodes-base.asana.md
+        - Autopilot: integrations/builtin/app-nodes/n8n-nodes-base.autopilot.md
+        - AWS Certificate Manager: integrations/builtin/app-nodes/n8n-nodes-base.awscertificatemanager.md
+        - AWS Cognito: integrations/builtin/app-nodes/n8n-nodes-base.awscognito.md
+        - AWS Comprehend: integrations/builtin/app-nodes/n8n-nodes-base.awscomprehend.md
+        - AWS DynamoDB: integrations/builtin/app-nodes/n8n-nodes-base.awsdynamodb.md
+        - AWS Elastic Load Balancing: integrations/builtin/app-nodes/n8n-nodes-base.awselb.md
+        - AWS IAM: integrations/builtin/app-nodes/n8n-nodes-base.awsiam.md
+        - AWS Lambda: integrations/builtin/app-nodes/n8n-nodes-base.awslambda.md
+        - AWS Rekognition: integrations/builtin/app-nodes/n8n-nodes-base.awsrekognition.md
+        - AWS S3: integrations/builtin/app-nodes/n8n-nodes-base.awss3.md
+        - AWS SES: integrations/builtin/app-nodes/n8n-nodes-base.awsses.md
+        - AWS SNS: integrations/builtin/app-nodes/n8n-nodes-base.awssns.md
+        - AWS SQS: integrations/builtin/app-nodes/n8n-nodes-base.awssqs.md
+        - AWS Textract: integrations/builtin/app-nodes/n8n-nodes-base.awstextract.md
+        - AWS Transcribe: integrations/builtin/app-nodes/n8n-nodes-base.awstranscribe.md
+        - Azure Cosmos DB: integrations/builtin/app-nodes/n8n-nodes-base.azurecosmosdb.md
+        - Azure Storage: integrations/builtin/app-nodes/n8n-nodes-base.azurestorage.md
+        - BambooHR: integrations/builtin/app-nodes/n8n-nodes-base.bamboohr.md
+        - Bannerbear: integrations/builtin/app-nodes/n8n-nodes-base.bannerbear.md
+        - Baserow: integrations/builtin/app-nodes/n8n-nodes-base.baserow.md
+        - Beeminder: integrations/builtin/app-nodes/n8n-nodes-base.beeminder.md
+        - Bitly: integrations/builtin/app-nodes/n8n-nodes-base.bitly.md
+        - Bitwarden: integrations/builtin/app-nodes/n8n-nodes-base.bitwarden.md
+        - Box: integrations/builtin/app-nodes/n8n-nodes-base.box.md
+        - Brandfetch: integrations/builtin/app-nodes/n8n-nodes-base.brandfetch.md
+        - Brevo: integrations/builtin/app-nodes/n8n-nodes-base.brevo.md
+        - Bubble: integrations/builtin/app-nodes/n8n-nodes-base.bubble.md
+        - Chargebee: integrations/builtin/app-nodes/n8n-nodes-base.chargebee.md
+        - CircleCI: integrations/builtin/app-nodes/n8n-nodes-base.circleci.md
+        - Webex by Cisco: integrations/builtin/app-nodes/n8n-nodes-base.ciscowebex.md
+        - Clearbit: integrations/builtin/app-nodes/n8n-nodes-base.clearbit.md
+        - ClickUp: integrations/builtin/app-nodes/n8n-nodes-base.clickup.md
+        - Clockify: integrations/builtin/app-nodes/n8n-nodes-base.clockify.md
+        - Cloudflare: integrations/builtin/app-nodes/n8n-nodes-base.cloudflare.md
+        - Cockpit: integrations/builtin/app-nodes/n8n-nodes-base.cockpit.md
+        - Coda: integrations/builtin/app-nodes/n8n-nodes-base.coda.md
+        - CoinGecko: integrations/builtin/app-nodes/n8n-nodes-base.coingecko.md
+        - Contentful: integrations/builtin/app-nodes/n8n-nodes-base.contentful.md
+        - ConvertKit: integrations/builtin/app-nodes/n8n-nodes-base.convertkit.md
+        - Copper: integrations/builtin/app-nodes/n8n-nodes-base.copper.md
+        - Cortex: integrations/builtin/app-nodes/n8n-nodes-base.cortex.md
+        - CrateDB: integrations/builtin/app-nodes/n8n-nodes-base.cratedb.md
+        - crowd.dev: integrations/builtin/app-nodes/n8n-nodes-base.crowddev.md
+        - Customer.io: integrations/builtin/app-nodes/n8n-nodes-base.customerio.md
+        - Databricks: integrations/builtin/app-nodes/n8n-nodes-base.databricks.md
+        - DeepL: integrations/builtin/app-nodes/n8n-nodes-base.deepl.md
+        - Demio: integrations/builtin/app-nodes/n8n-nodes-base.demio.md
+        - DHL: integrations/builtin/app-nodes/n8n-nodes-base.dhl.md
+        - Discord:
+          - Discord: integrations/builtin/app-nodes/n8n-nodes-base.discord/index.md
+          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.discord/common-issues.md
+        - Discourse: integrations/builtin/app-nodes/n8n-nodes-base.discourse.md
+        - Disqus: integrations/builtin/app-nodes/n8n-nodes-base.disqus.md
+        - Drift: integrations/builtin/app-nodes/n8n-nodes-base.drift.md
+        - Dropbox: integrations/builtin/app-nodes/n8n-nodes-base.dropbox.md
+        - Dropcontact: integrations/builtin/app-nodes/n8n-nodes-base.dropcontact.md
+        - E-goi: integrations/builtin/app-nodes/n8n-nodes-base.egoi.md
+        - Elasticsearch: integrations/builtin/app-nodes/n8n-nodes-base.elasticsearch.md
+        - Elastic Security: integrations/builtin/app-nodes/n8n-nodes-base.elasticsecurity.md
+        - Emelia: integrations/builtin/app-nodes/n8n-nodes-base.emelia.md
+        - ERPNext: integrations/builtin/app-nodes/n8n-nodes-base.erpnext.md
+        - Facebook Graph API: integrations/builtin/app-nodes/n8n-nodes-base.facebookgraphapi.md
+        - FileMaker: integrations/builtin/app-nodes/n8n-nodes-base.filemaker.md
+        - Flow: integrations/builtin/app-nodes/n8n-nodes-base.flow.md
+        - Freshdesk: integrations/builtin/app-nodes/n8n-nodes-base.freshdesk.md
+        - Freshservice: integrations/builtin/app-nodes/n8n-nodes-base.freshservice.md
+        - Freshworks CRM: integrations/builtin/app-nodes/n8n-nodes-base.freshworkscrm.md
+        - GetResponse: integrations/builtin/app-nodes/n8n-nodes-base.getresponse.md
+        - Ghost: integrations/builtin/app-nodes/n8n-nodes-base.ghost.md
+        - GitHub: integrations/builtin/app-nodes/n8n-nodes-base.github.md
+        - GitLab: integrations/builtin/app-nodes/n8n-nodes-base.gitlab.md
+        - Gmail:
+          - Gmail: integrations/builtin/app-nodes/n8n-nodes-base.gmail/index.md
+          - Draft operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/draft-operations.md
+          - Label operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/label-operations.md
+          - Message operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/message-operations.md
+          - Thread operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/thread-operations.md
+          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.gmail/common-issues.md
+        - Gong: integrations/builtin/app-nodes/n8n-nodes-base.gong.md
+        - Google Ads: integrations/builtin/app-nodes/n8n-nodes-base.googleads.md
+        - Google Analytics: integrations/builtin/app-nodes/n8n-nodes-base.googleanalytics.md
+        - Google BigQuery: integrations/builtin/app-nodes/n8n-nodes-base.googlebigquery.md
+        - Google Books: integrations/builtin/app-nodes/n8n-nodes-base.googlebooks.md
+        - Google Business Profile: integrations/builtin/app-nodes/n8n-nodes-base.googlebusinessprofile.md
+        - Google Calendar:
+          - Google Calendar: integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/index.md
+          - Calendar operations: integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/calendar-operations.md
+          - Event operations: integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/event-operations.md
+        - Google Chat: integrations/builtin/app-nodes/n8n-nodes-base.googlechat.md
+        - Google Cloud Firestore: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudfirestore.md
+        - Google Cloud Natural Language: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudnaturallanguage.md
+        - Google Cloud Realtime Database: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudrealtimedatabase.md
+        - Google Cloud Storage: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudstorage.md
+        - Google Contacts: integrations/builtin/app-nodes/n8n-nodes-base.googlecontacts.md
+        - Google Docs: integrations/builtin/app-nodes/n8n-nodes-base.googledocs.md
+        - Google Drive:
+          - Google Drive: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/index.md
+          - File operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/file-operations.md
+          - File and folder operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/file-folder-operations.md
+          - Folder operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/folder-operations.md
+          - Shared drive operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/shared-drive-operations.md
+          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/common-issues.md
+        - Google Gemini: integrations/builtin/app-nodes/n8n-nodes-langchain.googlegemini.md
+        - Google Perspective: integrations/builtin/app-nodes/n8n-nodes-base.googleperspective.md
+        - Google Sheets:
+          - Google Sheets: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/index.md
+          - Document operations: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/document-operations.md
+          - Sheet within Document operations: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/sheet-operations.md
+          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/common-issues.md
+        - Google Slides: integrations/builtin/app-nodes/n8n-nodes-base.googleslides.md
+        - Google Tasks: integrations/builtin/app-nodes/n8n-nodes-base.googletasks.md
+        - Google Translate: integrations/builtin/app-nodes/n8n-nodes-base.googletranslate.md
+        - Google Workspace Admin: integrations/builtin/app-nodes/n8n-nodes-base.gsuiteadmin.md
+        - Gotify: integrations/builtin/app-nodes/n8n-nodes-base.gotify.md
+        - GoToWebinar: integrations/builtin/app-nodes/n8n-nodes-base.gotowebinar.md
+        - Grafana: integrations/builtin/app-nodes/n8n-nodes-base.grafana.md
+        - Grist: integrations/builtin/app-nodes/n8n-nodes-base.grist.md
+        - Hacker News: integrations/builtin/app-nodes/n8n-nodes-base.hackernews.md
+        - HaloPSA: integrations/builtin/app-nodes/n8n-nodes-base.halopsa.md
+        - Harvest: integrations/builtin/app-nodes/n8n-nodes-base.harvest.md
+        - Help Scout: integrations/builtin/app-nodes/n8n-nodes-base.helpscout.md
+        - HighLevel: integrations/builtin/app-nodes/n8n-nodes-base.highlevel.md
+        - Home Assistant: integrations/builtin/app-nodes/n8n-nodes-base.homeassistant.md
+        - HubSpot: integrations/builtin/app-nodes/n8n-nodes-base.hubspot.md
+        - Humantic AI: integrations/builtin/app-nodes/n8n-nodes-base.humanticai.md
+        - Hunter: integrations/builtin/app-nodes/n8n-nodes-base.hunter.md
+        - Intercom: integrations/builtin/app-nodes/n8n-nodes-base.intercom.md
+        - Invoice Ninja: integrations/builtin/app-nodes/n8n-nodes-base.invoiceninja.md
+        - Iterable: integrations/builtin/app-nodes/n8n-nodes-base.iterable.md
+        - Jenkins: integrations/builtin/app-nodes/n8n-nodes-base.jenkins.md
+        - Jina AI: integrations/builtin/app-nodes/n8n-nodes-base.jinaai.md
+        - Jira Software: integrations/builtin/app-nodes/n8n-nodes-base.jira.md
+        - Kafka: integrations/builtin/app-nodes/n8n-nodes-base.kafka.md
+        - Keap: integrations/builtin/app-nodes/n8n-nodes-base.keap.md
+        - Kitemaker: integrations/builtin/app-nodes/n8n-nodes-base.kitemaker.md
+        - KoboToolbox: integrations/builtin/app-nodes/n8n-nodes-base.kobotoolbox.md
+        - Lemlist: integrations/builtin/app-nodes/n8n-nodes-base.lemlist.md
+        - Line: integrations/builtin/app-nodes/n8n-nodes-base.line.md
+        - Linear: integrations/builtin/app-nodes/n8n-nodes-base.linear.md
+        - LingvaNex: integrations/builtin/app-nodes/n8n-nodes-base.lingvanex.md
+        - LinkedIn: integrations/builtin/app-nodes/n8n-nodes-base.linkedin.md
+        - LoneScale: integrations/builtin/app-nodes/n8n-nodes-base.lonescale.md
+        - Magento 2: integrations/builtin/app-nodes/n8n-nodes-base.magento2.md
+        - Mailcheck: integrations/builtin/app-nodes/n8n-nodes-base.mailcheck.md
+        - Mailchimp: integrations/builtin/app-nodes/n8n-nodes-base.mailchimp.md
+        - MailerLite: integrations/builtin/app-nodes/n8n-nodes-base.mailerlite.md
+        - Mailgun: integrations/builtin/app-nodes/n8n-nodes-base.mailgun.md
+        - Mailjet: integrations/builtin/app-nodes/n8n-nodes-base.mailjet.md
+        - Mandrill: integrations/builtin/app-nodes/n8n-nodes-base.mandrill.md
+        - marketstack: integrations/builtin/app-nodes/n8n-nodes-base.marketstack.md
+        - Matrix: integrations/builtin/app-nodes/n8n-nodes-base.matrix.md
+        - Mattermost: integrations/builtin/app-nodes/n8n-nodes-base.mattermost.md
+        - Mautic: integrations/builtin/app-nodes/n8n-nodes-base.mautic.md
+        - Medium: integrations/builtin/app-nodes/n8n-nodes-base.medium.md
+        - MessageBird: integrations/builtin/app-nodes/n8n-nodes-base.messagebird.md
+        - Metabase: integrations/builtin/app-nodes/n8n-nodes-base.metabase.md
+        - Microsoft Dynamics CRM: integrations/builtin/app-nodes/n8n-nodes-base.microsoftdynamicscrm.md
+        - Microsoft Entra ID: integrations/builtin/app-nodes/n8n-nodes-base.microsoftentra.md
+        - Microsoft Excel 365: integrations/builtin/app-nodes/n8n-nodes-base.microsoftexcel.md
+        - Microsoft Graph Security: integrations/builtin/app-nodes/n8n-nodes-base.microsoftgraphsecurity.md
+        - Microsoft OneDrive: integrations/builtin/app-nodes/n8n-nodes-base.microsoftonedrive.md
+        - Microsoft Outlook: integrations/builtin/app-nodes/n8n-nodes-base.microsoftoutlook.md
+        - Microsoft SharePoint: integrations/builtin/app-nodes/n8n-nodes-base.microsoftsharepoint.md
+        - Microsoft SQL: integrations/builtin/app-nodes/n8n-nodes-base.microsoftsql.md
+        - Microsoft Teams: integrations/builtin/app-nodes/n8n-nodes-base.microsoftteams.md
+        - Microsoft To Do: integrations/builtin/app-nodes/n8n-nodes-base.microsofttodo.md
+        - Mindee: integrations/builtin/app-nodes/n8n-nodes-base.mindee.md
+        - MISP: integrations/builtin/app-nodes/n8n-nodes-base.misp.md
+        - Mistral AI: integrations/builtin/app-nodes/n8n-nodes-base.mistralai.md
+        - Mocean: integrations/builtin/app-nodes/n8n-nodes-base.mocean.md
+        - monday.com: integrations/builtin/app-nodes/n8n-nodes-base.mondaycom.md
+        - MongoDB: integrations/builtin/app-nodes/n8n-nodes-base.mongodb.md
+        - Monica CRM: integrations/builtin/app-nodes/n8n-nodes-base.monicacrm.md
+        - MQTT: integrations/builtin/app-nodes/n8n-nodes-base.mqtt.md
+        - MSG91: integrations/builtin/app-nodes/n8n-nodes-base.msg91.md
+        - MySQL:
+          - MySQL: integrations/builtin/app-nodes/n8n-nodes-base.mysql/index.md
+          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.mysql/common-issues.md
+        - Customer Datastore (n8n Training): integrations/builtin/app-nodes/n8n-nodes-base.n8ntrainingcustomerdatastore.md
+        - Customer Messenger (n8n Training): integrations/builtin/app-nodes/n8n-nodes-base.n8ntrainingcustomermessenger.md
+        - NASA: integrations/builtin/app-nodes/n8n-nodes-base.nasa.md
+        - Netlify: integrations/builtin/app-nodes/n8n-nodes-base.netlify.md
+        - Netscaler ADC: integrations/builtin/app-nodes/n8n-nodes-base.netscaleradc.md
+        - Nextcloud: integrations/builtin/app-nodes/n8n-nodes-base.nextcloud.md
+        - NocoDB: integrations/builtin/app-nodes/n8n-nodes-base.nocodb.md
+        - Notion:
+          - Notion: integrations/builtin/app-nodes/n8n-nodes-base.notion/index.md
+          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.notion/common-issues.md
+        - npm: integrations/builtin/app-nodes/n8n-nodes-base.npm.md
+        - Odoo: integrations/builtin/app-nodes/n8n-nodes-base.odoo.md
+        - Okta: integrations/builtin/app-nodes/n8n-nodes-base.okta.md
+        - One Simple API: integrations/builtin/app-nodes/n8n-nodes-base.onesimpleapi.md
+        - Onfleet: integrations/builtin/app-nodes/n8n-nodes-base.onfleet.md
+        - OpenAI:
+          - OpenAI: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/index.md
+          - Assistant operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/assistant-operations.md
+          - Audio operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/audio-operations.md
+          - Conversation operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/conversation-operations.md
+          - File operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/file-operations.md
+          - Image operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/image-operations.md
+          - Text operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/text-operations.md
+          - Video operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/video-operations.md
+          - Common issues: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
+        - OpenThesaurus: integrations/builtin/app-nodes/n8n-nodes-base.openthesaurus.md
+        - OpenWeatherMap: integrations/builtin/app-nodes/n8n-nodes-base.openweathermap.md
+        - Oracle Database:
+          - Oracle Database: integrations/builtin/app-nodes/n8n-nodes-base.oracledb/index.md
+        - Oura: integrations/builtin/app-nodes/n8n-nodes-base.oura.md
+        - Paddle: integrations/builtin/app-nodes/n8n-nodes-base.paddle.md
+        - PagerDuty: integrations/builtin/app-nodes/n8n-nodes-base.pagerduty.md
+        - PayPal: integrations/builtin/app-nodes/n8n-nodes-base.paypal.md
+        - Peekalink: integrations/builtin/app-nodes/n8n-nodes-base.peekalink.md
+        - Perplexity: integrations/builtin/app-nodes/n8n-nodes-langchain.perplexity.md
+        - PhantomBuster: integrations/builtin/app-nodes/n8n-nodes-base.phantombuster.md
+        - Philips Hue: integrations/builtin/app-nodes/n8n-nodes-base.philipshue.md
+        - Pipedrive: integrations/builtin/app-nodes/n8n-nodes-base.pipedrive.md
+        - Plivo: integrations/builtin/app-nodes/n8n-nodes-base.plivo.md
+        - PostBin: integrations/builtin/app-nodes/n8n-nodes-base.postbin.md
+        - Postgres:
+          - Postgres: integrations/builtin/app-nodes/n8n-nodes-base.postgres/index.md
+          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.postgres/common-issues.md
+        - PostHog: integrations/builtin/app-nodes/n8n-nodes-base.posthog.md
+        - ProfitWell: integrations/builtin/app-nodes/n8n-nodes-base.profitwell.md
+        - Pushbullet: integrations/builtin/app-nodes/n8n-nodes-base.pushbullet.md
+        - Pushcut: integrations/builtin/app-nodes/n8n-nodes-base.pushcut.md
+        - Pushover: integrations/builtin/app-nodes/n8n-nodes-base.pushover.md
+        - QuestDB: integrations/builtin/app-nodes/n8n-nodes-base.questdb.md
+        - Quick Base: integrations/builtin/app-nodes/n8n-nodes-base.quickbase.md
+        - QuickBooks Online: integrations/builtin/app-nodes/n8n-nodes-base.quickbooks.md
+        - QuickChart: integrations/builtin/app-nodes/n8n-nodes-base.quickchart.md
+        - RabbitMQ: integrations/builtin/app-nodes/n8n-nodes-base.rabbitmq.md
+        - Raindrop: integrations/builtin/app-nodes/n8n-nodes-base.raindrop.md
+        - Reddit: integrations/builtin/app-nodes/n8n-nodes-base.reddit.md
+        - Redis: integrations/builtin/app-nodes/n8n-nodes-base.redis.md
+        - Rocket.Chat: integrations/builtin/app-nodes/n8n-nodes-base.rocketchat.md
+        - Rundeck: integrations/builtin/app-nodes/n8n-nodes-base.rundeck.md
+        - S3: integrations/builtin/app-nodes/n8n-nodes-base.s3.md
+        - Salesforce: integrations/builtin/app-nodes/n8n-nodes-base.salesforce.md
+        - Salesmate: integrations/builtin/app-nodes/n8n-nodes-base.salesmate.md
+        - SeaTable: integrations/builtin/app-nodes/n8n-nodes-base.seatable.md
+        - SecurityScorecard: integrations/builtin/app-nodes/n8n-nodes-base.securityscorecard.md
+        - Segment: integrations/builtin/app-nodes/n8n-nodes-base.segment.md
+        - SendGrid: integrations/builtin/app-nodes/n8n-nodes-base.sendgrid.md
+        - Sendy: integrations/builtin/app-nodes/n8n-nodes-base.sendy.md
+        - Sentry.io: integrations/builtin/app-nodes/n8n-nodes-base.sentryio.md
+        - ServiceNow: integrations/builtin/app-nodes/n8n-nodes-base.servicenow.md
+        - seven: integrations/builtin/app-nodes/n8n-nodes-base.sms77.md
+        - Shopify: integrations/builtin/app-nodes/n8n-nodes-base.shopify.md
+        - SIGNL4: integrations/builtin/app-nodes/n8n-nodes-base.signl4.md
+        - Slack: integrations/builtin/app-nodes/n8n-nodes-base.slack.md
+        - Snowflake: integrations/builtin/app-nodes/n8n-nodes-base.snowflake.md
+        - Splunk: integrations/builtin/app-nodes/n8n-nodes-base.splunk.md
+        - Spotify: integrations/builtin/app-nodes/n8n-nodes-base.spotify.md
+        - Stackby: integrations/builtin/app-nodes/n8n-nodes-base.stackby.md
+        - Storyblok: integrations/builtin/app-nodes/n8n-nodes-base.storyblok.md
+        - Strapi: integrations/builtin/app-nodes/n8n-nodes-base.strapi.md
+        - Strava: integrations/builtin/app-nodes/n8n-nodes-base.strava.md
+        - Stripe: integrations/builtin/app-nodes/n8n-nodes-base.stripe.md
+        - Supabase:
+          - Supabase: integrations/builtin/app-nodes/n8n-nodes-base.supabase/index.md
+          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.supabase/common-issues.md
+        - SyncroMSP: integrations/builtin/app-nodes/n8n-nodes-base.syncromsp.md
+        - Taiga: integrations/builtin/app-nodes/n8n-nodes-base.taiga.md
+        - Tapfiliate: integrations/builtin/app-nodes/n8n-nodes-base.tapfiliate.md
+        - Telegram:
+          - integrations/builtin/app-nodes/n8n-nodes-base.telegram/index.md
+          - Chat operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/chat-operations.md
+          - Callback operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/callback-operations.md
+          - File operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/file-operations.md
+          - Message operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/message-operations.md
+          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.telegram/common-issues.md
+        - TheHive: integrations/builtin/app-nodes/n8n-nodes-base.thehive.md
+        - TheHive 5: integrations/builtin/app-nodes/n8n-nodes-base.thehive5.md
+        - TimescaleDB: integrations/builtin/app-nodes/n8n-nodes-base.timescaledb.md
+        - Todoist: integrations/builtin/app-nodes/n8n-nodes-base.todoist.md
+        - Travis CI: integrations/builtin/app-nodes/n8n-nodes-base.travisci.md
+        - Trello: integrations/builtin/app-nodes/n8n-nodes-base.trello.md
+        - Twake: integrations/builtin/app-nodes/n8n-nodes-base.twake.md
+        - Twilio: integrations/builtin/app-nodes/n8n-nodes-base.twilio.md
+        - Twist: integrations/builtin/app-nodes/n8n-nodes-base.twist.md
+        - Unleashed Software: integrations/builtin/app-nodes/n8n-nodes-base.unleashedsoftware.md
+        - UpLead: integrations/builtin/app-nodes/n8n-nodes-base.uplead.md
+        - uProc: integrations/builtin/app-nodes/n8n-nodes-base.uproc.md
+        - UptimeRobot: integrations/builtin/app-nodes/n8n-nodes-base.uptimerobot.md
+        - urlscan.io: integrations/builtin/app-nodes/n8n-nodes-base.urlscanio.md
+        - Venafi TLS Protect Cloud: integrations/builtin/app-nodes/n8n-nodes-base.venafitlsprotectcloud.md
+        - Venafi TLS Protect Datacenter: integrations/builtin/app-nodes/n8n-nodes-base.venafitlsprotectdatacenter.md
+        - Vero: integrations/builtin/app-nodes/n8n-nodes-base.vero.md
+        - Vonage: integrations/builtin/app-nodes/n8n-nodes-base.vonage.md
+        - Webflow: integrations/builtin/app-nodes/n8n-nodes-base.webflow.md
+        - Wekan: integrations/builtin/app-nodes/n8n-nodes-base.wekan.md
+        - WhatsApp Business Cloud:
+          - WhatsApp Business Cloud: integrations/builtin/app-nodes/n8n-nodes-base.whatsapp/index.md
+          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.whatsapp/common-issues.md
+        - Wise: integrations/builtin/app-nodes/n8n-nodes-base.wise.md
+        - WooCommerce: integrations/builtin/app-nodes/n8n-nodes-base.woocommerce.md
+        - WordPress: integrations/builtin/app-nodes/n8n-nodes-base.wordpress.md
+        - X (Formerly Twitter): integrations/builtin/app-nodes/n8n-nodes-base.twitter.md
+        - Xero: integrations/builtin/app-nodes/n8n-nodes-base.xero.md
+        - Yourls: integrations/builtin/app-nodes/n8n-nodes-base.yourls.md
+        - YouTube: integrations/builtin/app-nodes/n8n-nodes-base.youtube.md
+        - Zammad: integrations/builtin/app-nodes/n8n-nodes-base.zammad.md
+        - Zendesk: integrations/builtin/app-nodes/n8n-nodes-base.zendesk.md
+        - Zoho CRM: integrations/builtin/app-nodes/n8n-nodes-base.zohocrm.md
+        - Zoom: integrations/builtin/app-nodes/n8n-nodes-base.zoom.md
+        - Zulip: integrations/builtin/app-nodes/n8n-nodes-base.zulip.md
+      - Triggers:
+        - integrations/builtin/trigger-nodes/index.md
+        - ActiveCampaign Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.activecampaigntrigger.md
+        - Acuity Scheduling Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.acuityschedulingtrigger.md
+        - Affinity Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.affinitytrigger.md
+        - Airtable Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.airtabletrigger.md
+        - AMQP Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.amqptrigger.md
+        - Asana Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.asanatrigger.md
+        - Autopilot Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.autopilottrigger.md
+        - AWS SNS Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.awssnstrigger.md
+        - Bitbucket Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.bitbuckettrigger.md
+        - Box Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.boxtrigger.md
+        - Brevo Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.brevotrigger.md
+        - Calendly Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.calendlytrigger.md
+        - Cal Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.caltrigger.md
+        - Chargebee Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.chargebeetrigger.md
+        - ClickUp Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.clickuptrigger.md
+        - Clockify Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.clockifytrigger.md
+        - ConvertKit Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.convertkittrigger.md
+        - Copper Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.coppertrigger.md
+        - crowd.dev Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.crowddevtrigger.md
+        - Customer.io Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.customeriotrigger.md
+        - Emelia Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.emeliatrigger.md
+        - Eventbrite Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.eventbritetrigger.md
+        - Facebook Lead Ads Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.facebookleadadstrigger.md
+        - Facebook Trigger:
+          - Facebook Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/index.md
+          - Ad Account: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/ad-account.md
+          - Application: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/application.md
+          - Certificate Transparency: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/certificate-transparency.md
+          - Group: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/group.md
+          - Instagram: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/instagram.md
+          - Link: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/link.md
+          - Page: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/page.md
+          - Permissions: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/permissions.md
+          - User: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/user.md
+          - WhatsApp Business Account: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/whatsapp.md
+          - Workplace Security: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/workplace-security.md
+        - Figma Trigger (Beta): integrations/builtin/trigger-nodes/n8n-nodes-base.figmatrigger.md
+        - Flow Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.flowtrigger.md
+        - Form.io Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.formiotrigger.md
+        - Formstack Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.formstacktrigger.md
+        - GetResponse Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.getresponsetrigger.md
+        - GitHub Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.githubtrigger.md
+        - GitLab Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.gitlabtrigger.md
+        - Gmail Trigger:
+          - integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/index.md
+          - Poll Mode options: integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/poll-mode-options.md
+          - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/common-issues.md
+        - Google Calendar Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googlecalendartrigger.md
+        - Google Drive Trigger:
+          - Google Drive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googledrivetrigger/index.md
+          - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.googledrivetrigger/common-issues.md
+        - Google Business Profile Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googlebusinessprofiletrigger.md
+        - Google Sheets Trigger:
+          - Google Sheets Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googlesheetstrigger/index.md
+          - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.googlesheetstrigger/common-issues.md
+        - Gumroad Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.gumroadtrigger.md
+        - Help Scout Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.helpscouttrigger.md
+        - Hubspot Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.hubspottrigger.md
+        - Invoice Ninja Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.invoiceninjatrigger.md
+        - Jira Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.jiratrigger.md
+        - Jotform Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.jotformtrigger.md
+        - Kafka Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.kafkatrigger.md
+        - Keap Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.keaptrigger.md
+        - KoboToolbox Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.kobotoolboxtrigger.md
+        - Lemlist Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.lemlisttrigger.md
+        - Linear Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.lineartrigger.md
+        - LoneScale Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.lonescaletrigger.md
+        - Mailchimp Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mailchimptrigger.md
+        - MailerLite Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mailerlitetrigger.md
+        - Mailjet Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mailjettrigger.md
+        - Mautic Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mautictrigger.md
+        - Microsoft OneDrive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftonedrivetrigger.md
+        - Microsoft Outlook Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftoutlooktrigger.md
+        - Microsoft Teams Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftteamstrigger.md
+        - MQTT Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mqtttrigger.md
+        - Netlify Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.netlifytrigger.md
+        - Notion Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.notiontrigger.md
+        - Onfleet Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.onfleettrigger.md
+        - PayPal Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.paypaltrigger.md
+        - Pipedrive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.pipedrivetrigger.md
+        - Postgres Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.postgrestrigger.md
+        - Postmark Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.postmarktrigger.md
+        - Pushcut Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.pushcuttrigger.md
+        - RabbitMQ Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.rabbitmqtrigger.md
+        - Redis Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.redistrigger.md
+        - Salesforce Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.salesforcetrigger.md
+        - SeaTable Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.seatabletrigger.md
+        - Shopify Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.shopifytrigger.md
+        - Slack Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
+        - Strava Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.stravatrigger.md
+        - Stripe Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.stripetrigger.md
+        - SurveyMonkey Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.surveymonkeytrigger.md
+        - Taiga Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.taigatrigger.md
+        - Telegram Trigger:
+          - Telegram Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.telegramtrigger/index.md
+          - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.telegramtrigger/common-issues.md
+        - TheHive 5 Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.thehive5trigger.md
+        - TheHive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.thehivetrigger.md
+        - Toggl Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.toggltrigger.md
+        - Trello Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.trellotrigger.md
+        - Twilio Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.twiliotrigger.md
+        - Typeform Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.typeformtrigger.md
+        - Venafi TLS Protect Cloud Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.venafitlsprotectcloudtrigger.md
+        - Webex by Cisco Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.ciscowebextrigger.md
+        - Webflow Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.webflowtrigger.md
+        - WhatsApp Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.whatsapptrigger.md
+        - Wise Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.wisetrigger.md
+        - WooCommerce Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.woocommercetrigger.md
+        - Workable Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.workabletrigger.md
+        - Wufoo Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.wufootrigger.md
+        - Zendesk Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.zendesktrigger.md
+      - Cluster nodes:
+        - integrations/builtin/cluster-nodes/index.md
+        - Root nodes:
+          - integrations/builtin/cluster-nodes/root-nodes/index.md
+          - AI Agent:
+            - AI Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/index.md
+            - Conversational Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/conversational-agent.md
+            - OpenAI Functions Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/openai-functions-agent.md
+            - Plan and Execute Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/plan-execute-agent.md
+            - ReAct Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/react-agent.md
+            - SQL Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/sql-agent.md
+            - Tools Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
+            - Common issues: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/common-issues.md
+          - Basic LLM Chain: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainllm.md
+          - Question and Answer Chain:
+            - Question and Answer Chain: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainretrievalqa/index.md
+            - Common issues: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainretrievalqa/common-issues.md
+          - Summarization Chain: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainsummarization.md
+          - Information Extractor: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.information-extractor.md
+          - Text Classifier: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.text-classifier.md
+          - Sentiment Analysis: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.sentimentanalysis.md
+          - LangChain Code: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.code.md
+          - Microsoft Agent 365 Trigger: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.microsoftagent365trigger/index.md
+          - Azure AI Search Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreazureaisearch.md
+          - Simple Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreinmemory.md
+          - Milvus Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremilvus.md
+          - MongoDB Atlas Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md
+          - PGVector Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepgvector.md
+          - Chroma Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorechroma.md
+          - Pinecone Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepinecone.md
+          - Qdrant Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreqdrant.md
+          - Redis Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreredis.md
+          - Supabase Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoresupabase.md
+          - Weaviate Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreweaviate.md
+          - Zep Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorezep.md
+        - Sub-nodes:
+          - integrations/builtin/cluster-nodes/sub-nodes/index.md
+          - Default Data Loader: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentdefaultdataloader.md
+          - GitHub Document Loader: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentgithubloader.md
+          - Embeddings AWS Bedrock: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsawsbedrock.md
+          - Embeddings Azure OpenAI: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsazureopenai.md
+          - Embeddings Cohere: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingscohere.md
+          - Embeddings Google Gemini: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsgooglegemini.md
+          - Embeddings Google PaLM: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsgooglepalm.md
+          - Embeddings Google Vertex: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsgooglevertex.md
+          - Embeddings HuggingFace Inference: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingshuggingfaceinference.md
+          - Embeddings Lemonade: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingslemonade.md
+          - Embeddings Mistral Cloud: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsmistralcloud.md
+          - Embeddings Ollama: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsollama.md
+          - Embeddings OpenAI: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsopenai.md
+          - Anthropic Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatanthropic.md
+          - AWS Bedrock Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatawsbedrock.md
+          - Azure OpenAI Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatazureopenai.md
+          - Cohere Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatcohere.md
+          - DeepSeek Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatdeepseek.md
+          - Google Gemini Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgooglegemini.md
+          - Google Vertex Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgooglevertex.md
+          - Groq Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgroq.md
+          - Lemonade Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatlemonade.md
+          - Mistral Cloud Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatmistralcloud.md
+          - Ollama Chat Model:
+            - Ollama Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatollama/index.md
+            - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatollama/common-issues.md
+          - OpenAI Chat Model:
+            - OpenAI Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai/index.md
+            - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai/common-issues.md
+          - OpenRouter Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenrouter.md
+          - Vercel AI Gateway Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatvercel.md
+          - xAI Grok Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatxaigrok.md
+          - Cohere Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmcohere.md
+          - Lemonade Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmlemonade.md
+          - Ollama Model:
+            - Ollama Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmollama/index.md
+            - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmollama/common-issues.md
+          - Hugging Face Inference Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmopenhuggingfaceinference.md
+          - Chat Memory Manager: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorymanager.md
+          - Simple Memory: 
+            - integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorybufferwindow/index.md
+            - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorybufferwindow/common-issues.md
+          - Motorhead: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorymotorhead.md
+          - MongoDB Chat Memory: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorymongochat.md
+          - Redis Chat Memory: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memoryredischat.md
+          - Postgres Chat Memory: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorypostgreschat.md
+          - Xata: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memoryxata.md
+          - Zep: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memoryzep.md
+          - Auto-fixing Output Parser: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparserautofixing.md
+          - Item List Output Parser: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparseritemlist.md
+          - Structured Output Parser:
+            - Structured Output Parser: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparserstructured/index.md
+            - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparserstructured/common-issues.md
+          - Contextual Compression Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrievercontextualcompression.md
+          - MultiQuery Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrievermultiquery.md
+          - Vector Store Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrievervectorstore.md
+          - Workflow Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrieverworkflow.md
+          - Character Text Splitter: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.textsplittercharactertextsplitter.md
+          - Recursive Character Text Splitter: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.textsplitterrecursivecharactertextsplitter.md
+          - Token Splitter: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.textsplittertokensplitter.md
+          - AI Agent Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolaiagent.md
+          - Calculator: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcalculator.md
+          - Custom Code Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcode.md
+          - MCP Client Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md
+          - SearXNG Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolsearxng.md
+          - SerpApi (Google Search): integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolserpapi.md
+          - Think Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolthink.md        
+          - Vector Store Question Answer Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolvectorstore.md
+          - Wikipedia: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolwikipedia.md
+          - Wolfram|Alpha: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolwolframalpha.md
+          - Call n8n Workflow Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md
+          - Reranker Cohere: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.rerankercohere.md
+          - Model Selector: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.modelselector.md
+      - Credentials:
+        - integrations/builtin/credentials/index.md
+        - integrations/builtin/credentials/actionnetwork.md
+        - integrations/builtin/credentials/activecampaign.md
+        - integrations/builtin/credentials/acuityscheduling.md
+        - integrations/builtin/credentials/adalo.md
+        - integrations/builtin/credentials/affinity.md
+        - integrations/builtin/credentials/agilecrm.md
+        - integrations/builtin/credentials/airtable.md
+        - integrations/builtin/credentials/airtop.md
+        - integrations/builtin/credentials/alienvault.md
+        - integrations/builtin/credentials/amqp.md
+        - integrations/builtin/credentials/anthropic.md
+        - integrations/builtin/credentials/apitemplateio.md
+        - integrations/builtin/credentials/asana.md
+        - integrations/builtin/credentials/auth0management.md
+        - integrations/builtin/credentials/autopilot.md
+        - integrations/builtin/credentials/aws.md
+        - integrations/builtin/credentials/azureopenai.md
+        - integrations/builtin/credentials/azurecosmosdb.md
+        - integrations/builtin/credentials/azureaisearch.md
+        - integrations/builtin/credentials/azurestorage.md
+        - integrations/builtin/credentials/bamboohr.md
+        - integrations/builtin/credentials/bannerbear.md
+        - integrations/builtin/credentials/baserow.md
+        - integrations/builtin/credentials/beeminder.md
+        - integrations/builtin/credentials/bitbucket.md
+        - integrations/builtin/credentials/bitly.md
+        - integrations/builtin/credentials/bitwarden.md
+        - integrations/builtin/credentials/box.md
+        - integrations/builtin/credentials/brandfetch.md
+        - integrations/builtin/credentials/brevo.md
+        - integrations/builtin/credentials/bubble.md
+        - integrations/builtin/credentials/cal.md
+        - integrations/builtin/credentials/calendly.md
+        - integrations/builtin/credentials/carbonblack.md
+        - integrations/builtin/credentials/chargebee.md
+        - integrations/builtin/credentials/circleci.md
+        - integrations/builtin/credentials/ciscomeraki.md
+        - integrations/builtin/credentials/ciscosecureendpoint.md
+        - integrations/builtin/credentials/ciscoumbrella.md
+        - integrations/builtin/credentials/clearbit.md
+        - integrations/builtin/credentials/clickup.md
+        - integrations/builtin/credentials/clockify.md
+        - integrations/builtin/credentials/cloudflare.md
+        - integrations/builtin/credentials/cockpit.md
+        - integrations/builtin/credentials/coda.md
+        - integrations/builtin/credentials/cohere.md
+        - integrations/builtin/credentials/contentful.md
+        - integrations/builtin/credentials/convertapi.md
+        - integrations/builtin/credentials/convertkit.md
+        - integrations/builtin/credentials/copper.md
+        - integrations/builtin/credentials/cortex.md
+        - integrations/builtin/credentials/cratedb.md
+        - integrations/builtin/credentials/crowddev.md
+        - integrations/builtin/credentials/crowdstrike.md
+        - integrations/builtin/credentials/customerio.md
+        - integrations/builtin/credentials/databricks.md
+        - integrations/builtin/credentials/datadog.md
+        - integrations/builtin/credentials/deepl.md
+        - integrations/builtin/credentials/deepseek.md
+        - integrations/builtin/credentials/demio.md
+        - integrations/builtin/credentials/dfiriris.md
+        - integrations/builtin/credentials/dhl.md
+        - integrations/builtin/credentials/discord.md
+        - integrations/builtin/credentials/discourse.md
+        - integrations/builtin/credentials/disqus.md
+        - integrations/builtin/credentials/drift.md
+        - integrations/builtin/credentials/dropbox.md
+        - integrations/builtin/credentials/dropcontact.md
+        - integrations/builtin/credentials/dynatrace.md
+        - integrations/builtin/credentials/egoi.md
+        - integrations/builtin/credentials/elasticsearch.md
+        - integrations/builtin/credentials/elasticsecurity.md
+        - integrations/builtin/credentials/emelia.md
+        - integrations/builtin/credentials/erpnext.md
+        - integrations/builtin/credentials/eventbrite.md
+        - integrations/builtin/credentials/f5bigip.md
+        - integrations/builtin/credentials/facebookapp.md
+        - integrations/builtin/credentials/facebookgraph.md
+        - integrations/builtin/credentials/facebookleadads.md
+        - integrations/builtin/credentials/figma.md
+        - integrations/builtin/credentials/filemaker.md
+        - integrations/builtin/credentials/filescan.md
+        - integrations/builtin/credentials/flow.md
+        - integrations/builtin/credentials/formiotrigger.md
+        - integrations/builtin/credentials/formstacktrigger.md
+        - integrations/builtin/credentials/fortigate.md
+        - integrations/builtin/credentials/freshdesk.md
+        - integrations/builtin/credentials/freshservice.md
+        - integrations/builtin/credentials/freshworkscrm.md
+        - integrations/builtin/credentials/ftp.md
+        - integrations/builtin/credentials/getresponse.md
+        - integrations/builtin/credentials/ghost.md
+        - integrations/builtin/credentials/git.md
+        - integrations/builtin/credentials/github.md
+        - integrations/builtin/credentials/gitlab.md
+        - integrations/builtin/credentials/gong.md
+        - Google:
+          - integrations/builtin/credentials/google/index.md
+          - integrations/builtin/credentials/google/oauth-single-service.md
+          - integrations/builtin/credentials/google/oauth-generic.md
+          - integrations/builtin/credentials/google/service-account.md
+        - integrations/builtin/credentials/googleai.md
+        - integrations/builtin/credentials/gotify.md
+        - integrations/builtin/credentials/gotowebinar.md
+        - integrations/builtin/credentials/grafana.md
+        - integrations/builtin/credentials/grist.md
+        - integrations/builtin/credentials/groq.md
+        - integrations/builtin/credentials/gumroad.md
+        - integrations/builtin/credentials/halopsa.md
+        - integrations/builtin/credentials/harvest.md
+        - integrations/builtin/credentials/helpscout.md
+        - integrations/builtin/credentials/highlevel.md
+        - integrations/builtin/credentials/homeassistant.md
+        - integrations/builtin/credentials/httprequest.md
+        - integrations/builtin/credentials/hubspot.md
+        - integrations/builtin/credentials/huggingface.md
+        - integrations/builtin/credentials/humanticai.md
+        - integrations/builtin/credentials/hunter.md
+        - integrations/builtin/credentials/hybridanalysis.md
+        - IMAP:
+          - integrations/builtin/credentials/imap/index.md
+          - integrations/builtin/credentials/imap/gmail.md
+          - integrations/builtin/credentials/imap/outlook.md
+          - integrations/builtin/credentials/imap/yahoo.md
+        - integrations/builtin/credentials/impervawaf.md
+        - integrations/builtin/credentials/intercom.md
+        - integrations/builtin/credentials/invoiceninja.md
+        - integrations/builtin/credentials/iterable.md
+        - integrations/builtin/credentials/jenkins.md
+        - integrations/builtin/credentials/jinaai.md
+        - integrations/builtin/credentials/jira.md
+        - integrations/builtin/credentials/jotform.md
+        - integrations/builtin/credentials/jwt.md
+        - integrations/builtin/credentials/kafka.md
+        - integrations/builtin/credentials/keap.md
+        - integrations/builtin/credentials/kibana.md
+        - integrations/builtin/credentials/kitemaker.md
+        - integrations/builtin/credentials/kobotoolbox.md
+        - integrations/builtin/credentials/ldap.md
+        - integrations/builtin/credentials/lemlist.md
+        - integrations/builtin/credentials/lemonade.md
+        - integrations/builtin/credentials/line.md
+        - integrations/builtin/credentials/linear.md
+        - integrations/builtin/credentials/lingvanex.md
+        - integrations/builtin/credentials/linkedin.md
+        - integrations/builtin/credentials/lonescale.md
+        - integrations/builtin/credentials/magento2.md
+        - integrations/builtin/credentials/mailcheck.md
+        - integrations/builtin/credentials/mailchimp.md
+        - integrations/builtin/credentials/mailerlite.md
+        - integrations/builtin/credentials/mailgun.md
+        - integrations/builtin/credentials/mailjet.md
+        - integrations/builtin/credentials/malcore.md
+        - integrations/builtin/credentials/mandrill.md
+        - integrations/builtin/credentials/marketstack.md
+        - integrations/builtin/credentials/matrix.md
+        - integrations/builtin/credentials/mattermost.md
+        - integrations/builtin/credentials/mautic.md
+        - integrations/builtin/credentials/medium.md
+        - integrations/builtin/credentials/messagebird.md
+        - integrations/builtin/credentials/metabase.md
+        - integrations/builtin/credentials/microsoft.md
+        - integrations/builtin/credentials/microsoftazuremonitor.md
+        - integrations/builtin/credentials/microsoftentra.md
+        - integrations/builtin/credentials/microsoftsql.md
+        - integrations/builtin/credentials/microsoftagent365.md
+        - integrations/builtin/credentials/milvus.md
+        - integrations/builtin/credentials/mindee.md
+        - integrations/builtin/credentials/miro.md
+        - integrations/builtin/credentials/misp.md
+        - integrations/builtin/credentials/mist.md
+        - integrations/builtin/credentials/mistral.md
+        - integrations/builtin/credentials/mocean.md
+        - integrations/builtin/credentials/mondaycom.md
+        - integrations/builtin/credentials/mongodb.md
+        - integrations/builtin/credentials/monicacrm.md
+        - integrations/builtin/credentials/motorhead.md
+        - integrations/builtin/credentials/mqtt.md
+        - integrations/builtin/credentials/msg91.md
+        - integrations/builtin/credentials/mysql.md
+        - integrations/builtin/credentials/nasa.md
+        - integrations/builtin/credentials/netlify.md
+        - integrations/builtin/credentials/netscaleradc.md
+        - integrations/builtin/credentials/nextcloud.md
+        - integrations/builtin/credentials/nocodb.md
+        - integrations/builtin/credentials/notion.md
+        - integrations/builtin/credentials/npm.md
+        - integrations/builtin/credentials/odoo.md
+        - integrations/builtin/credentials/okta.md
+        - integrations/builtin/credentials/ollama.md
+        - integrations/builtin/credentials/onesimpleapi.md
+        - integrations/builtin/credentials/onfleet.md
+        - integrations/builtin/credentials/openai.md
+        - integrations/builtin/credentials/opencti.md
+        - integrations/builtin/credentials/openrouter.md
+        - integrations/builtin/credentials/openweathermap.md
+        - integrations/builtin/credentials/oracledb.md
+        - integrations/builtin/credentials/oura.md
+        - integrations/builtin/credentials/paddle.md
+        - integrations/builtin/credentials/pagerduty.md
+        - integrations/builtin/credentials/paypal.md
+        - integrations/builtin/credentials/peekalink.md
+        - integrations/builtin/credentials/perplexity.md
+        - integrations/builtin/credentials/phantombuster.md
+        - integrations/builtin/credentials/philipshue.md
+        - integrations/builtin/credentials/chroma.md
+        - integrations/builtin/credentials/pinecone.md
+        - integrations/builtin/credentials/pipedrive.md
+        - integrations/builtin/credentials/plivo.md
+        - integrations/builtin/credentials/postgres.md
+        - integrations/builtin/credentials/posthog.md
+        - integrations/builtin/credentials/postmark.md
+        - integrations/builtin/credentials/profitwell.md
+        - integrations/builtin/credentials/pushbullet.md
+        - integrations/builtin/credentials/pushcut.md
+        - integrations/builtin/credentials/pushover.md
+        - integrations/builtin/credentials/qradar.md
+        - integrations/builtin/credentials/qdrant.md
+        - integrations/builtin/credentials/qualys.md
+        - integrations/builtin/credentials/questdb.md
+        - integrations/builtin/credentials/quickbase.md
+        - integrations/builtin/credentials/quickbooks.md
+        - integrations/builtin/credentials/rabbitmq.md
+        - integrations/builtin/credentials/raindrop.md
+        - integrations/builtin/credentials/rapid7insightvm.md
+        - integrations/builtin/credentials/recordedfuture.md
+        - integrations/builtin/credentials/reddit.md
+        - integrations/builtin/credentials/redis.md
+        - integrations/builtin/credentials/rocketchat.md
+        - integrations/builtin/credentials/rundeck.md
+        - integrations/builtin/credentials/s3.md
+        - integrations/builtin/credentials/salesforce.md
+        - integrations/builtin/credentials/salesmate.md
+        - integrations/builtin/credentials/searxng.md
+        - integrations/builtin/credentials/seatable.md
+        - integrations/builtin/credentials/securityscorecard.md
+        - integrations/builtin/credentials/segment.md
+        - integrations/builtin/credentials/sekoia.md
+        - Send Email:
+          - integrations/builtin/credentials/sendemail/index.md
+          - integrations/builtin/credentials/sendemail/gmail.md
+          - integrations/builtin/credentials/sendemail/outlook.md
+          - integrations/builtin/credentials/sendemail/yahoo.md
+        - integrations/builtin/credentials/sendgrid.md
+        - integrations/builtin/credentials/sendy.md
+        - integrations/builtin/credentials/sentryio.md
+        - integrations/builtin/credentials/serp.md
+        - integrations/builtin/credentials/servicenow.md
+        - integrations/builtin/credentials/sms77.md
+        - integrations/builtin/credentials/shopify.md
+        - integrations/builtin/credentials/shuffler.md
+        - integrations/builtin/credentials/signl4.md
+        - integrations/builtin/credentials/slack.md
+        - integrations/builtin/credentials/snowflake.md
+        - integrations/builtin/credentials/solarwindsipam.md
+        - integrations/builtin/credentials/solarwindsobservability.md
+        - integrations/builtin/credentials/splunk.md
+        - integrations/builtin/credentials/spotify.md
+        - integrations/builtin/credentials/ssh.md
+        - integrations/builtin/credentials/stackby.md
+        - integrations/builtin/credentials/storyblok.md
+        - integrations/builtin/credentials/strapi.md
+        - integrations/builtin/credentials/strava.md
+        - integrations/builtin/credentials/stripe.md
+        - integrations/builtin/credentials/supabase.md
+        - integrations/builtin/credentials/surveymonkey.md
+        - integrations/builtin/credentials/syncromsp.md
+        - integrations/builtin/credentials/sysdig.md
+        - integrations/builtin/credentials/taiga.md
+        - integrations/builtin/credentials/tapfiliate.md
+        - integrations/builtin/credentials/telegram.md
+        - integrations/builtin/credentials/thehive.md
+        - integrations/builtin/credentials/thehive5.md
+        - integrations/builtin/credentials/timescaledb.md
+        - integrations/builtin/credentials/todoist.md
+        - integrations/builtin/credentials/toggl.md
+        - integrations/builtin/credentials/totp.md
+        - integrations/builtin/credentials/travisci.md
+        - integrations/builtin/credentials/trellixepo.md
+        - integrations/builtin/credentials/trello.md
+        - integrations/builtin/credentials/twake.md
+        - integrations/builtin/credentials/twilio.md
+        - integrations/builtin/credentials/twist.md
+        - integrations/builtin/credentials/typeform.md
+        - integrations/builtin/credentials/unleashedsoftware.md
+        - integrations/builtin/credentials/uplead.md
+        - integrations/builtin/credentials/uproc.md
+        - integrations/builtin/credentials/uptimerobot.md
+        - integrations/builtin/credentials/urlscanio.md
+        - integrations/builtin/credentials/venafitlsprotectcloud.md
+        - integrations/builtin/credentials/venafitlsprotectdatacenter.md
+        - integrations/builtin/credentials/vercel.md
+        - integrations/builtin/credentials/vero.md
+        - integrations/builtin/credentials/virustotal.md
+        - integrations/builtin/credentials/vonage.md
+        - integrations/builtin/credentials/weaviate.md        
+        - integrations/builtin/credentials/ciscowebex.md
+        - integrations/builtin/credentials/webflow.md
+        - integrations/builtin/credentials/webhook.md
+        - integrations/builtin/credentials/wekan.md
+        - integrations/builtin/credentials/whatsapp.md
+        - integrations/builtin/credentials/wise.md
+        - integrations/builtin/credentials/wolframalpha.md
+        - integrations/builtin/credentials/woocommerce.md
+        - integrations/builtin/credentials/wordpress.md
+        - integrations/builtin/credentials/workable.md
+        - integrations/builtin/credentials/wufoo.md
+        - integrations/builtin/credentials/twitter.md
+        - integrations/builtin/credentials/xai.md
+        - integrations/builtin/credentials/xata.md
+        - integrations/builtin/credentials/xero.md
+        - integrations/builtin/credentials/yourls.md
+        - integrations/builtin/credentials/zabbix.md
+        - integrations/builtin/credentials/zammad.md
+        - integrations/builtin/credentials/zendesk.md
+        - integrations/builtin/credentials/zep.md
+        - integrations/builtin/credentials/zoho.md
+        - integrations/builtin/credentials/zoom.md
+        - integrations/builtin/credentials/zscalerzia.md
+        - integrations/builtin/credentials/zulip.md
+      - Custom API actions for existing nodes: integrations/custom-operations.md
+      - Handle rate limits: integrations/builtin/rate-limits.md
+    - Community nodes:
+      - Installation and management:
+        - integrations/community-nodes/installation/index.md
+        - Install verified community nodes: integrations/community-nodes/installation/verified-install.md
+        - GUI installation: integrations/community-nodes/installation/gui-install.md
+        - Manual installation: integrations/community-nodes/installation/manual-install.md
+      - Risks: integrations/community-nodes/risks.md
+      - Blocklist: integrations/community-nodes/blocklist.md
+      - Using community nodes: integrations/community-nodes/usage.md
+      - Troubleshooting: integrations/community-nodes/troubleshooting.md
+      - Building community nodes: integrations/community-nodes/build-community-nodes.md
+    - Creating nodes:
+      - Overview: integrations/creating-nodes/overview.md
+      - Plan your node:
+        - integrations/creating-nodes/plan/index.md
+        - Choose a node type: integrations/creating-nodes/plan/node-types.md
+        - Choose a node building style: integrations/creating-nodes/plan/choose-node-method.md
+        - Node UI design: integrations/creating-nodes/plan/node-ui-design.md
+        - Choose node file structure: integrations/creating-nodes/build/reference/node-file-structure.md
+      - Build your node:
+        - integrations/creating-nodes/build/index.md
+        - Set up your development environment: integrations/creating-nodes/build/node-development-environment.md
+        - Using the n8n-node tool: integrations/creating-nodes/build/n8n-node.md
+        - "Tutorial: Build a declarative-style node": integrations/creating-nodes/build/declarative-style-node.md
+        - "Tutorial: Build a programmatic-style node": integrations/creating-nodes/build/programmatic-style-node.md
+        - Reference:
+          - integrations/creating-nodes/build/reference/index.md
+          - Node UI elements: integrations/creating-nodes/build/reference/ui-elements.md
+          - Code standards: integrations/creating-nodes/build/reference/code-standards.md
+          - Error handling: integrations/creating-nodes/build/reference/error-handling.md
+          - Versioning: integrations/creating-nodes/build/reference/node-versioning.md
+          - File structure: integrations/creating-nodes/build/reference/node-file-structure.md
+          - Base files:
+            - integrations/creating-nodes/build/reference/node-base-files/index.md
+            - Structure: integrations/creating-nodes/build/reference/node-base-files/structure.md
+            - Standard parameters: integrations/creating-nodes/build/reference/node-base-files/standard-parameters.md
+            - Declarative-style parameters: integrations/creating-nodes/build/reference/node-base-files/declarative-style-parameters.md
+            - Programmatic-style parameters: integrations/creating-nodes/build/reference/node-base-files/programmatic-style-parameters.md
+            - Programmatic-style execute method: integrations/creating-nodes/build/reference/node-base-files/programmatic-style-execute-method.md
+          - Codex files: integrations/creating-nodes/build/reference/node-codex-files.md
+          - Credentials files: integrations/creating-nodes/build/reference/credentials-files.md
+          - HTTP request helpers: integrations/creating-nodes/build/reference/http-helpers.md
+          - Item linking: integrations/creating-nodes/build/reference/paired-items.md
+          - UX guidelines: integrations/creating-nodes/build/reference/ux-guidelines.md
+          - Verification guidelines: integrations/creating-nodes/build/reference/verification-guidelines.md
+      - Test your node:
+        - integrations/creating-nodes/test/index.md
+        - Run your node locally: integrations/creating-nodes/test/run-node-locally.md
+        - Node linter: integrations/creating-nodes/test/node-linter.md
+        - Troubleshooting: integrations/creating-nodes/test/troubleshooting-node-development.md
+      - Deploy your node:
+        - integrations/creating-nodes/deploy/index.md
+        - Submit community nodes: integrations/creating-nodes/deploy/submit-community-nodes.md
+        - Install private nodes: integrations/creating-nodes/deploy/install-private-nodes.md
   - Hosting n8n:
-      - Overview: hosting/index.md
-      - Community vs Enterprise: hosting/community-edition-features.md
-      - Installation:
-          - npm: hosting/installation/npm.md
-          - Docker: hosting/installation/docker.md
-          - Server setups:
-              - hosting/installation/server-setups/index.md
-              - Digital Ocean: hosting/installation/server-setups/digital-ocean.md
-              - Heroku: hosting/installation/server-setups/heroku.md
-              - Hetzner: hosting/installation/server-setups/hetzner.md
-              - Amazon Web Services: hosting/installation/server-setups/aws.md
-              - Azure: hosting/installation/server-setups/azure.md
-              - Google Cloud Run: hosting/installation/server-setups/google-cloud-run.md
-              - Google Kubernetes Engine: hosting/installation/server-setups/google-kubernetes-engine.md
-              - OpenShift CRC: hosting/installation/server-setups/openshift-crc.md
-              - Docker Compose: hosting/installation/server-setups/docker-compose.md
-          - Updating: hosting/installation/updating.md
-      - Configuration:
-          - Environment variables:
-              - Environment variables overview: hosting/configuration/environment-variables/index.md
-              - AI Assistant: hosting/configuration/environment-variables/ai-assistant.md
-              - Binary data: hosting/configuration/environment-variables/binary-data.md
-              - Credentials: hosting/configuration/environment-variables/credentials.md
-              - Database: hosting/configuration/environment-variables/database.md
-              - Deployment: hosting/configuration/environment-variables/deployment.md
-              - Endpoints: hosting/configuration/environment-variables/endpoints.md
-              - Executions: hosting/configuration/environment-variables/executions.md
-              - External data storage: hosting/configuration/environment-variables/external-data-storage.md
-              - External hooks: hosting/configuration/environment-variables/external-hooks.md
-              - External secrets: hosting/configuration/environment-variables/external-secrets.md
-              - Insights: hosting/configuration/environment-variables/insights.md
-              - Logs: hosting/configuration/environment-variables/logs.md
-              - License: hosting/configuration/environment-variables/licenses.md
-              - Nodes: hosting/configuration/environment-variables/nodes.md
-              - Queue mode: hosting/configuration/environment-variables/queue-mode.md
-              - Security: hosting/configuration/environment-variables/security.md
-              - SSRF protection: hosting/configuration/environment-variables/ssrf-protection.md
-              - Source control: hosting/configuration/environment-variables/source-control.md
-              - Task runners: hosting/configuration/environment-variables/task-runners.md
-              - Timezone and localization: hosting/configuration/environment-variables/timezone-localization.md
-              - User management and 2FA: hosting/configuration/environment-variables/user-management-smtp-2fa.md
-              - Workflows: hosting/configuration/environment-variables/workflows.md
-              - Workflow history: hosting/configuration/environment-variables/workflow-history.md
-          - Configuration methods: hosting/configuration/configuration-methods.md
-          - Configuration examples:
-              - hosting/configuration/configuration-examples/index.md
-              - Isolate n8n: hosting/configuration/configuration-examples/isolation.md
-              - Configure the Base URL: hosting/configuration/configuration-examples/base-url.md
-              - Configure custom SSL certificate authorities: hosting/configuration/configuration-examples/custom-certificate-authority.md
-              - Set a custom encryption key: hosting/configuration/configuration-examples/encryption-key.md
-              - Configure workflow timeouts: hosting/configuration/configuration-examples/execution-timeout.md
-              - Specify custom nodes location: hosting/configuration/configuration-examples/custom-nodes-location.md
-              - Enable modules in Code node: hosting/configuration/configuration-examples/modules-in-code-node.md
-              - Set the timezone: hosting/configuration/configuration-examples/time-zone.md
-              - Specify user folder path: hosting/configuration/configuration-examples/user-folder.md
-              - Configure webhook URLs with reverse proxy: hosting/configuration/configuration-examples/webhook-url.md
-              - Enable Prometheus metrics: hosting/configuration/configuration-examples/prometheus.md
-              - Pre-configure Microsoft OAuth credentials: hosting/configuration/configuration-examples/microsoft-oauth-credential-overwrites.md
-              - Configure a custom workflow templates library: hosting/configuration/configuration-examples/custom-templates.md
-          - Supported databases and settings: hosting/configuration/supported-databases-settings.md
-          - Credential overwrites: hosting/configuration/credential-overwrites.md
-          - External hooks: hosting/configuration/external-hooks.md
-          - Task runners: hosting/configuration/task-runners.md
-          - User management: hosting/configuration/user-management-self-hosted.md
-      - Logging and monitoring:
-          - Logging: hosting/logging-monitoring/logging.md
-          - Monitoring: hosting/logging-monitoring/monitoring.md
-          - Security audit: hosting/securing/security-audit.md
-      - Scaling and performance:
-          - Overview: hosting/scaling/overview.md
-          - Performance and benchmarking: hosting/scaling/performance-benchmarking.md
-          - Configuring queue mode: hosting/scaling/queue-mode.md
-          - Concurrency control: hosting/scaling/concurrency-control.md
-          - Execution data: hosting/scaling/execution-data.md
-          - Binary data: hosting/scaling/binary-data.md
-          - External storage for binary data: hosting/scaling/external-storage.md
-          - Memory-related errors: hosting/scaling/memory-errors.md
-      - Securing n8n:
-          - Overview: hosting/securing/overview.md
-          - Set up SSL: hosting/securing/set-up-ssl.md
-          - Set up SSO: hosting/securing/set-up-sso.md
-          - Security audit: hosting/securing/security-audit.md
-          - Disable the API: hosting/securing/disable-public-api.md
-          - Opt out of data collection: hosting/securing/telemetry-opt-out.md
-          - Blocking nodes: hosting/securing/blocking-nodes.md
-          - Hardening task runners: hosting/securing/hardening-task-runners.md
-          - SSRF protection: hosting/securing/ssrf-protection.md
-          - Execution data redaction: workflows/executions/execution-data-redaction.md
-          - Restrict account registration to email-verified users: hosting/securing/restrict-by-email-verification.md
-      - Starter Kits:
-          - AI Starter Kit: hosting/starter-kits/ai-starter-kit.md
-      - OEM deployment:
-          - Overview: hosting/oem-deployment/index.md
-          - Prerequisites: hosting/oem-deployment/prerequisites.md
-          - Managing workflows: hosting/oem-deployment/managing-workflows.md
-      - Architecture:
-          - Overview: hosting/architecture/overview.md
-          - Database structure: hosting/architecture/database-structure.md
-      - Using the CLI:
-          - CLI commands: hosting/cli-commands.md
+    - Overview: hosting/index.md
+    - Community vs Enterprise: hosting/community-edition-features.md
+    - Installation:
+      - npm: hosting/installation/npm.md
+      - Docker: hosting/installation/docker.md
+      - Server setups:
+        - hosting/installation/server-setups/index.md
+        - Digital Ocean: hosting/installation/server-setups/digital-ocean.md
+        - Heroku: hosting/installation/server-setups/heroku.md
+        - Hetzner: hosting/installation/server-setups/hetzner.md
+        - Amazon Web Services: hosting/installation/server-setups/aws.md
+        - Azure: hosting/installation/server-setups/azure.md
+        - Google Cloud Run: hosting/installation/server-setups/google-cloud-run.md
+        - Google Kubernetes Engine: hosting/installation/server-setups/google-kubernetes-engine.md
+        - OpenShift CRC: hosting/installation/server-setups/openshift-crc.md
+        - Docker Compose: hosting/installation/server-setups/docker-compose.md
+      - Updating: hosting/installation/updating.md
+    - Configuration:
+      - Environment variables:
+        - Environment variables overview : hosting/configuration/environment-variables/index.md
+        - AI Assistant: hosting/configuration/environment-variables/ai-assistant.md
+        - Binary data: hosting/configuration/environment-variables/binary-data.md
+        - Credentials: hosting/configuration/environment-variables/credentials.md
+        - Database: hosting/configuration/environment-variables/database.md
+        - Deployment: hosting/configuration/environment-variables/deployment.md
+        - Endpoints: hosting/configuration/environment-variables/endpoints.md
+        - Executions: hosting/configuration/environment-variables/executions.md
+        - External data storage: hosting/configuration/environment-variables/external-data-storage.md
+        - External hooks: hosting/configuration/environment-variables/external-hooks.md
+        - External secrets: hosting/configuration/environment-variables/external-secrets.md
+        - Insights: hosting/configuration/environment-variables/insights.md
+        - Logs: hosting/configuration/environment-variables/logs.md
+        - License: hosting/configuration/environment-variables/licenses.md
+        - Nodes: hosting/configuration/environment-variables/nodes.md
+        - Queue mode: hosting/configuration/environment-variables/queue-mode.md
+        - Security: hosting/configuration/environment-variables/security.md
+        - SSRF protection: hosting/configuration/environment-variables/ssrf-protection.md
+        - Source control: hosting/configuration/environment-variables/source-control.md
+        - Task runners: hosting/configuration/environment-variables/task-runners.md
+        - Timezone and localization: hosting/configuration/environment-variables/timezone-localization.md
+        - User management and 2FA: hosting/configuration/environment-variables/user-management-smtp-2fa.md
+        - Workflows: hosting/configuration/environment-variables/workflows.md
+        - Workflow history: hosting/configuration/environment-variables/workflow-history.md
+      - Configuration methods: hosting/configuration/configuration-methods.md
+      - Configuration examples:
+        - hosting/configuration/configuration-examples/index.md
+        - Isolate n8n: hosting/configuration/configuration-examples/isolation.md
+        - Configure the Base URL: hosting/configuration/configuration-examples/base-url.md
+        - Configure custom SSL certificate authorities: hosting/configuration/configuration-examples/custom-certificate-authority.md
+        - Set a custom encryption key: hosting/configuration/configuration-examples/encryption-key.md
+        - Configure workflow timeouts: hosting/configuration/configuration-examples/execution-timeout.md
+        - Specify custom nodes location: hosting/configuration/configuration-examples/custom-nodes-location.md
+        - Enable modules in Code node: hosting/configuration/configuration-examples/modules-in-code-node.md
+        - Set the timezone: hosting/configuration/configuration-examples/time-zone.md
+        - Specify user folder path: hosting/configuration/configuration-examples/user-folder.md
+        - Configure webhook URLs with reverse proxy: hosting/configuration/configuration-examples/webhook-url.md
+        - Enable Prometheus metrics: hosting/configuration/configuration-examples/prometheus.md
+        - Pre-configure Microsoft OAuth credentials: hosting/configuration/configuration-examples/microsoft-oauth-credential-overwrites.md
+        - Configure a custom workflow templates library: hosting/configuration/configuration-examples/custom-templates.md
+      - Supported databases and settings: hosting/configuration/supported-databases-settings.md
+      - Credential overwrites: hosting/configuration/credential-overwrites.md
+      - External hooks: hosting/configuration/external-hooks.md
+      - Task runners: hosting/configuration/task-runners.md
+      - User management: hosting/configuration/user-management-self-hosted.md
+    - Logging and monitoring:
+      - Logging: hosting/logging-monitoring/logging.md
+      - Monitoring: hosting/logging-monitoring/monitoring.md
+      - Security audit: hosting/securing/security-audit.md
+    - Scaling and performance:
+      - Overview: hosting/scaling/overview.md
+      - Performance and benchmarking: hosting/scaling/performance-benchmarking.md
+      - Configuring queue mode: hosting/scaling/queue-mode.md
+      - Concurrency control: hosting/scaling/concurrency-control.md
+      - Execution data: hosting/scaling/execution-data.md
+      - Binary data: hosting/scaling/binary-data.md
+      - External storage for binary data: hosting/scaling/external-storage.md
+      - Memory-related errors: hosting/scaling/memory-errors.md
+    - Securing n8n:
+      - Overview: hosting/securing/overview.md
+      - Set up SSL: hosting/securing/set-up-ssl.md
+      - Set up SSO: hosting/securing/set-up-sso.md
+      - Security audit: hosting/securing/security-audit.md
+      - Disable the API: hosting/securing/disable-public-api.md
+      - Opt out of data collection: hosting/securing/telemetry-opt-out.md
+      - Blocking nodes: hosting/securing/blocking-nodes.md
+      - Hardening task runners: hosting/securing/hardening-task-runners.md
+      - SSRF protection: hosting/securing/ssrf-protection.md
+      - Execution data redaction: workflows/executions/execution-data-redaction.md
+      - Restrict account registration to email-verified users: hosting/securing/restrict-by-email-verification.md
+    - Starter Kits:
+      - AI Starter Kit: hosting/starter-kits/ai-starter-kit.md
+    - OEM deployment:
+      - Overview: hosting/oem-deployment/index.md
+      - Prerequisites: hosting/oem-deployment/prerequisites.md
+      - Managing workflows: hosting/oem-deployment/managing-workflows.md
+    - Architecture:
+      - Overview: hosting/architecture/overview.md
+      - Database structure: hosting/architecture/database-structure.md
+    - Using the CLI:
+      - CLI commands: hosting/cli-commands.md
   - Code in n8n:
       - code/index.md
       - Using the Code node: code/code-node.md
@@ -1350,8 +1350,8 @@ nav:
       - "AI Workflow Builder": advanced-ai/ai-workflow-builder.md
       - "Chat Hub": advanced-ai/chat-hub.md
       - Instance-level MCP server:
-          - "Set up and use n8n MCP server": advanced-ai/mcp/accessing-n8n-mcp-server.md
-          - "MCP server tools reference": advanced-ai/mcp/mcp_tools_reference.md
+        - "Set up and use n8n MCP server": advanced-ai/mcp/accessing-n8n-mcp-server.md
+        - "MCP server tools reference": advanced-ai/mcp/mcp_tools_reference.md
       - "Tutorial: Build an AI workflow in n8n": advanced-ai/intro-tutorial.md
       - RAG in n8n: advanced-ai/rag-in-n8n.md
       - LangChain in n8n:

--- a/nav.yml
+++ b/nav.yml
@@ -1,1323 +1,1323 @@
 nav:
   - Using n8n:
-    - Welcome: index.md
-    - Getting started:
-      - Learning path: learning-path.md
-      - Choose your n8n: choose-n8n.md
-      - Quickstarts:
-        - try-it-out/index.md
-        - A very quick quickstart: try-it-out/quickstart.md
-        - A longer introduction: try-it-out/tutorial-first-workflow.md
-      - Video courses: video-courses.md
-      - Text courses:
-        - courses/index.md
-        - Level one:
-          - courses/level-one/index.md
-          - Navigating the editor UI: courses/level-one/chapter-1.md
-          - Building a mini-workflow: courses/level-one/chapter-2.md
-          - Automating a (real-world) use case: courses/level-one/chapter-3.md
-          - Designing the workflow: courses/level-one/chapter-4.md
-          - Building the workflow:
-            - Getting data from the data warehouse: courses/level-one/chapter-5/chapter-5.1.md
-            - Inserting data into airtable: courses/level-one/chapter-5/chapter-5.2.md
-            - Filtering orders: courses/level-one/chapter-5/chapter-5.3.md
-            - Setting values for processing orders: courses/level-one/chapter-5/chapter-5.4.md
-            - Calculating booked orders: courses/level-one/chapter-5/chapter-5.5.md
-            - Notifying the team: courses/level-one/chapter-5/chapter-5.6.md
-            - Scheduling the workflow: courses/level-one/chapter-5/chapter-5.7.md
-            - Activating and examining the workflow: courses/level-one/chapter-5/chapter-5.8.md
-          - Exporting and importing workflows: courses/level-one/chapter-6.md
-          - Test your knowledge: courses/level-one/chapter-7.md
-        - Level two:
-          - courses/level-two/index.md
-          - Understanding the data structure: courses/level-two/chapter-1.md
-          - Processing different data types: courses/level-two/chapter-2.md
-          - Merging and splitting data: courses/level-two/chapter-3.md
-          - Dealing with errors in workflows: courses/level-two/chapter-4.md
-          - Automating a business workflow:
-            - Use case: courses/level-two/chapter-5/chapter-5.0.md
-            - Workflow 1: courses/level-two/chapter-5/chapter-5.1.md
-            - Workflow 2: courses/level-two/chapter-5/chapter-5.2.md
-            - Workflow 3: courses/level-two/chapter-5/chapter-5.3.md
-          - Test your knowledge: courses/level-two/chapter-6.md
-    - Using the app:
-      - Understand workflows:
-        - workflows/index.md
-        - Create and run: workflows/create.md
-        - Save and publish: workflows/publish.md
-        - Components:
-          - workflows/components/index.md
-          - Nodes: workflows/components/nodes.md
-          - Connections: workflows/components/connections.md
-          - Sticky Notes: workflows/components/sticky-notes.md
-        - Executions:
-          - workflows/executions/index.md
-          - Manual, partial, and production executions: workflows/executions/manual-partial-and-production-executions.md
-          - Dirty nodes: workflows/executions/dirty-nodes.md
-          - Workflow-level executions: workflows/executions/single-workflow-executions.md
-          - All executions: workflows/executions/all-executions.md
-          - Custom executions data: workflows/executions/custom-executions-data.md
-          - Debug executions: workflows/executions/debug.md
-          - Redact execution data: workflows/executions/execution-data-redaction.md
-        - Tags: workflows/tags.md
-        - Export and import: workflows/export-import.md
-        - Templates: workflows/templates.md
-        - Sharing: workflows/sharing.md
-        - Settings: workflows/settings.md
-        - Streaming responses: workflows/streaming.md
-        - Workflow history: workflows/history.md
-        - Workflow ID: workflows/workflow-id.md
-        - Sub-workflow conversion: workflows/subworkflow-conversion.md
-      - Manage credentials:
-        - credentials/index.md
-        - Create and edit: credentials/add-edit-credentials.md
-        - Credential sharing: credentials/credential-sharing.md
-      - Manage users and access:
-        - user-management/index.md
-        - Cloud setup: user-management/cloud-setup.md
-        - Manage users: user-management/manage-users.md
-        - Account types: user-management/account-types.md
-        - Role-based access control:
-          - user-management/rbac/index.md
-          - Role types: user-management/rbac/role-types.md
-          - Projects: user-management/rbac/projects.md
-          - Custom roles: user-management/rbac/custom-roles.md
-        - Best practices: user-management/best-practices.md
-        - 2FA: user-management/two-factor-auth.md
-        - LDAP: user-management/ldap.md
-        - OIDC:
-          - user-management/oidc/index.md
-          - Set up OIDC: user-management/oidc/setup.md
-          - Troubleshooting: user-management/oidc/troubleshooting.md
-        - SAML:
-          - user-management/saml/index.md
-          - Set up SAML: user-management/saml/setup.md
-          - Okta Workforce Identity SAML setup: user-management/saml/okta.md
-          - Azure AD SAML setup: user-management/saml/azuread.md
-          - Manage users with SAML: user-management/saml/managing.md
-          - Troubleshooting: user-management/saml/troubleshooting.md
-      - Keyboard shortcuts: keyboard-shortcuts.md
-    - Key concepts:
-      - Flow logic:
-        - flow-logic/index.md
-        - Splitting with conditionals: flow-logic/splitting.md
-        - Merging data: flow-logic/merging.md
-        - Looping: flow-logic/looping.md
-        - Waiting: flow-logic/waiting.md
-        - Sub-workflows: flow-logic/subworkflows.md
-        - Error handling: flow-logic/error-handling.md
-        - Execution order in multi-branch workflows: flow-logic/execution-order.md
-      - Working with data:
-        - Overview: data/index.md
-        - How n8n structures data: data/data-structure.md
-        - Expressions versus data nodes: data/expressions.md
-        - Referencing data:
-          - data/data-mapping/index.md
-          - Referencing data in the UI: data/data-mapping/data-mapping-ui.md
-          - Referencing previous nodes: data/data-mapping/referencing-other-nodes.md
-          - Linking data items:
-            - data/data-mapping/data-item-linking/index.md
-            - How items link through workflows: data/data-mapping/data-item-linking/item-linking-concepts.md
-            - Accessing linked items in the Code node: data/data-mapping/itemmatching.md
-            - Preserving linking in the Code node: data/data-mapping/data-item-linking/item-linking-code-node.md
-            - Item linking errors: data/data-mapping/data-item-linking/item-linking-errors.md
-            - Item linking for node creators: data/data-mapping/data-item-linking/item-linking-node-building.md
-        - Transforming data:
-          - Approaches for transforming data: data/transforming-data.md
-          - Expressions for data transformation: data/expressions-for-transformation.md
-          - Expression reference: 
-            - data/expression-reference/index.md
-            - data/expression-reference/array.md
-            - data/expression-reference/binaryfile.md
-            - data/expression-reference/boolean.md
-            - data/expression-reference/customdata.md
-            - data/expression-reference/date.md
-            - data/expression-reference/datetime.md
-            - data/expression-reference/execdata.md
-            - data/expression-reference/httpresponse.md
-            - data/expression-reference/item.md
-            - data/expression-reference/nodeinputdata.md
-            - data/expression-reference/nodeoutputdata.md
-            - data/expression-reference/number.md
-            - data/expression-reference/object.md
-            - data/expression-reference/prevnodedata.md
-            - data/expression-reference/root.md
-            - data/expression-reference/string.md
-            - data/expression-reference/workflowdata.md
-        - Filtering data: data/data-filtering.md
-        - Pinning and mocking data: data/data-pinning.md
-        - Specific data types:
-          - Binary data: data/specific-data-types/binary-data.md
-          - Date and time with Luxon: data/specific-data-types/luxon.md
-          - Query JSON with JMESPath: data/specific-data-types/jmespath.md
-        - Data tables: data/data-tables.md
-      - Glossary: glossary.md
-    - n8n Cloud:
-      - Overview: manage-cloud/overview.md
-      - Cloud free trial: manage-cloud/cloud-free-trial.md
-      - Access the Cloud admin dashboard: manage-cloud/cloud-admin-dashboard.md
-      - Update your n8n Cloud version: manage-cloud/update-cloud-version.md
-      - Set the timezone: manage-cloud/set-cloud-timezone.md
-      - Cloud IP addresses: manage-cloud/cloud-ip.md
-      - Cloud data management: manage-cloud/cloud-data-management.md
-      - Change ownership or username: manage-cloud/change-ownership-or-username.md
-      - Concurrency: manage-cloud/concurrency.md
-      - Download workflows: manage-cloud/download-workflows.md
-      - AI Assistant: manage-cloud/ai-assistant.md
-    - Enterprise features:
-      - Source control and environments:
-        - source-control-environments/index.md
-        - Understand:
-          - source-control-environments/understand/index.md
-          - Environments: source-control-environments/understand/environments.md
-          - Git in n8n: source-control-environments/understand/git.md
-          - Branch patterns: source-control-environments/understand/patterns.md
-        - Set up: source-control-environments/setup.md
-        - Using:
-          - source-control-environments/using/index.md
-          - Push and pull: source-control-environments/using/push-pull.md
-          - Compare workflow changes: source-control-environments/using/compare-changes.md
-          - Copy work between environments: source-control-environments/using/copy-work.md
-        - "Tutorial: Create environments with source control": source-control-environments/create-environments.md
-      - External secrets: external-secrets.md
-      - Log streaming: log-streaming.md
-      - Security settings: security-settings.md
-      - Insights: insights.md
-      - License key: license-key.md
-    - Releases:
-      - Release notes:
-        - 2.x: release-notes.md
-        - 1.x: release-notes/1-x.md
-        - 0.x: release-notes/0-x.md
-      - v2.0 breaking changes: 2-0-breaking-changes.md
-      - v2.0 Migration tool: migration-tool-v2.md
-      - v1.0 migration guide: 1-0-migration-checklist.md
-    - Help and community:
-      - Where to get help: help-community/help.md
-      - Contributing: help-community/contributing.md
-    - Licenses and privacy:
-      - Privacy and security:
-          - privacy-security/index.md
-          - Privacy: privacy-security/privacy.md
-          - Security: https://n8n.io/legal/#security
-          - Incident response: privacy-security/incident-response.md
-          - What you can do: privacy-security/what-you-can-do.md
-      - Sustainable use license: sustainable-use-license.md
+      - Welcome: index.md
+      - Getting started:
+          - Learning path: learning-path.md
+          - Choose your n8n: choose-n8n.md
+          - Quickstarts:
+              - try-it-out/index.md
+              - A very quick quickstart: try-it-out/quickstart.md
+              - A longer introduction: try-it-out/tutorial-first-workflow.md
+          - Video courses: video-courses.md
+          - Text courses:
+              - courses/index.md
+              - Level one:
+                  - courses/level-one/index.md
+                  - Navigating the editor UI: courses/level-one/chapter-1.md
+                  - Building a mini-workflow: courses/level-one/chapter-2.md
+                  - Automating a (real-world) use case: courses/level-one/chapter-3.md
+                  - Designing the workflow: courses/level-one/chapter-4.md
+                  - Building the workflow:
+                      - Getting data from the data warehouse: courses/level-one/chapter-5/chapter-5.1.md
+                      - Inserting data into airtable: courses/level-one/chapter-5/chapter-5.2.md
+                      - Filtering orders: courses/level-one/chapter-5/chapter-5.3.md
+                      - Setting values for processing orders: courses/level-one/chapter-5/chapter-5.4.md
+                      - Calculating booked orders: courses/level-one/chapter-5/chapter-5.5.md
+                      - Notifying the team: courses/level-one/chapter-5/chapter-5.6.md
+                      - Scheduling the workflow: courses/level-one/chapter-5/chapter-5.7.md
+                      - Activating and examining the workflow: courses/level-one/chapter-5/chapter-5.8.md
+                  - Exporting and importing workflows: courses/level-one/chapter-6.md
+                  - Test your knowledge: courses/level-one/chapter-7.md
+              - Level two:
+                  - courses/level-two/index.md
+                  - Understanding the data structure: courses/level-two/chapter-1.md
+                  - Processing different data types: courses/level-two/chapter-2.md
+                  - Merging and splitting data: courses/level-two/chapter-3.md
+                  - Dealing with errors in workflows: courses/level-two/chapter-4.md
+                  - Automating a business workflow:
+                      - Use case: courses/level-two/chapter-5/chapter-5.0.md
+                      - Workflow 1: courses/level-two/chapter-5/chapter-5.1.md
+                      - Workflow 2: courses/level-two/chapter-5/chapter-5.2.md
+                      - Workflow 3: courses/level-two/chapter-5/chapter-5.3.md
+                  - Test your knowledge: courses/level-two/chapter-6.md
+      - Using the app:
+          - Understand workflows:
+              - workflows/index.md
+              - Create and run: workflows/create.md
+              - Save and publish: workflows/publish.md
+              - Components:
+                  - workflows/components/index.md
+                  - Nodes: workflows/components/nodes.md
+                  - Connections: workflows/components/connections.md
+                  - Sticky Notes: workflows/components/sticky-notes.md
+              - Executions:
+                  - workflows/executions/index.md
+                  - Manual, partial, and production executions: workflows/executions/manual-partial-and-production-executions.md
+                  - Dirty nodes: workflows/executions/dirty-nodes.md
+                  - Workflow-level executions: workflows/executions/single-workflow-executions.md
+                  - All executions: workflows/executions/all-executions.md
+                  - Custom executions data: workflows/executions/custom-executions-data.md
+                  - Debug executions: workflows/executions/debug.md
+                  - Redact execution data: workflows/executions/execution-data-redaction.md
+              - Tags: workflows/tags.md
+              - Export and import: workflows/export-import.md
+              - Templates: workflows/templates.md
+              - Sharing: workflows/sharing.md
+              - Settings: workflows/settings.md
+              - Streaming responses: workflows/streaming.md
+              - Workflow history: workflows/history.md
+              - Workflow ID: workflows/workflow-id.md
+              - Sub-workflow conversion: workflows/subworkflow-conversion.md
+          - Manage credentials:
+              - credentials/index.md
+              - Create and edit: credentials/add-edit-credentials.md
+              - Credential sharing: credentials/credential-sharing.md
+          - Manage users and access:
+              - user-management/index.md
+              - Cloud setup: user-management/cloud-setup.md
+              - Manage users: user-management/manage-users.md
+              - Account types: user-management/account-types.md
+              - Role-based access control:
+                  - user-management/rbac/index.md
+                  - Role types: user-management/rbac/role-types.md
+                  - Projects: user-management/rbac/projects.md
+                  - Custom roles: user-management/rbac/custom-roles.md
+              - Best practices: user-management/best-practices.md
+              - 2FA: user-management/two-factor-auth.md
+              - LDAP: user-management/ldap.md
+              - OIDC:
+                  - user-management/oidc/index.md
+                  - Set up OIDC: user-management/oidc/setup.md
+                  - Troubleshooting: user-management/oidc/troubleshooting.md
+              - SAML:
+                  - user-management/saml/index.md
+                  - Set up SAML: user-management/saml/setup.md
+                  - Okta Workforce Identity SAML setup: user-management/saml/okta.md
+                  - Azure AD SAML setup: user-management/saml/azuread.md
+                  - Manage users with SAML: user-management/saml/managing.md
+                  - Troubleshooting: user-management/saml/troubleshooting.md
+          - Keyboard shortcuts: keyboard-shortcuts.md
+      - Key concepts:
+          - Flow logic:
+              - flow-logic/index.md
+              - Splitting with conditionals: flow-logic/splitting.md
+              - Merging data: flow-logic/merging.md
+              - Looping: flow-logic/looping.md
+              - Waiting: flow-logic/waiting.md
+              - Sub-workflows: flow-logic/subworkflows.md
+              - Error handling: flow-logic/error-handling.md
+              - Execution order in multi-branch workflows: flow-logic/execution-order.md
+          - Working with data:
+              - Overview: data/index.md
+              - How n8n structures data: data/data-structure.md
+              - Expressions versus data nodes: data/expressions.md
+              - Referencing data:
+                  - data/data-mapping/index.md
+                  - Referencing data in the UI: data/data-mapping/data-mapping-ui.md
+                  - Referencing previous nodes: data/data-mapping/referencing-other-nodes.md
+                  - Linking data items:
+                      - data/data-mapping/data-item-linking/index.md
+                      - How items link through workflows: data/data-mapping/data-item-linking/item-linking-concepts.md
+                      - Accessing linked items in the Code node: data/data-mapping/itemmatching.md
+                      - Preserving linking in the Code node: data/data-mapping/data-item-linking/item-linking-code-node.md
+                      - Item linking errors: data/data-mapping/data-item-linking/item-linking-errors.md
+                      - Item linking for node creators: data/data-mapping/data-item-linking/item-linking-node-building.md
+              - Transforming data:
+                  - Approaches for transforming data: data/transforming-data.md
+                  - Expressions for data transformation: data/expressions-for-transformation.md
+                  - Expression reference:
+                      - data/expression-reference/index.md
+                      - data/expression-reference/array.md
+                      - data/expression-reference/binaryfile.md
+                      - data/expression-reference/boolean.md
+                      - data/expression-reference/customdata.md
+                      - data/expression-reference/date.md
+                      - data/expression-reference/datetime.md
+                      - data/expression-reference/execdata.md
+                      - data/expression-reference/httpresponse.md
+                      - data/expression-reference/item.md
+                      - data/expression-reference/nodeinputdata.md
+                      - data/expression-reference/nodeoutputdata.md
+                      - data/expression-reference/number.md
+                      - data/expression-reference/object.md
+                      - data/expression-reference/prevnodedata.md
+                      - data/expression-reference/root.md
+                      - data/expression-reference/string.md
+                      - data/expression-reference/workflowdata.md
+              - Filtering data: data/data-filtering.md
+              - Pinning and mocking data: data/data-pinning.md
+              - Specific data types:
+                  - Binary data: data/specific-data-types/binary-data.md
+                  - Date and time with Luxon: data/specific-data-types/luxon.md
+                  - Query JSON with JMESPath: data/specific-data-types/jmespath.md
+              - Data tables: data/data-tables.md
+          - Glossary: glossary.md
+      - n8n Cloud:
+          - Overview: manage-cloud/overview.md
+          - Cloud free trial: manage-cloud/cloud-free-trial.md
+          - Access the Cloud admin dashboard: manage-cloud/cloud-admin-dashboard.md
+          - Update your n8n Cloud version: manage-cloud/update-cloud-version.md
+          - Set the timezone: manage-cloud/set-cloud-timezone.md
+          - Cloud IP addresses: manage-cloud/cloud-ip.md
+          - Cloud data management: manage-cloud/cloud-data-management.md
+          - Change ownership or username: manage-cloud/change-ownership-or-username.md
+          - Concurrency: manage-cloud/concurrency.md
+          - Download workflows: manage-cloud/download-workflows.md
+          - AI Assistant: manage-cloud/ai-assistant.md
+      - Enterprise features:
+          - Source control and environments:
+              - source-control-environments/index.md
+              - Understand:
+                  - source-control-environments/understand/index.md
+                  - Environments: source-control-environments/understand/environments.md
+                  - Git in n8n: source-control-environments/understand/git.md
+                  - Branch patterns: source-control-environments/understand/patterns.md
+              - Set up: source-control-environments/setup.md
+              - Using:
+                  - source-control-environments/using/index.md
+                  - Push and pull: source-control-environments/using/push-pull.md
+                  - Compare workflow changes: source-control-environments/using/compare-changes.md
+                  - Copy work between environments: source-control-environments/using/copy-work.md
+              - "Tutorial: Create environments with source control": source-control-environments/create-environments.md
+          - External secrets: external-secrets.md
+          - Log streaming: log-streaming.md
+          - Security settings: security-settings.md
+          - Insights: insights.md
+          - License key: license-key.md
+      - Releases:
+          - Release notes:
+              - 2.x: release-notes.md
+              - 1.x: release-notes/1-x.md
+              - 0.x: release-notes/0-x.md
+          - v2.0 breaking changes: 2-0-breaking-changes.md
+          - v2.0 Migration tool: migration-tool-v2.md
+          - v1.0 migration guide: 1-0-migration-checklist.md
+      - Help and community:
+          - Where to get help: help-community/help.md
+          - Contributing: help-community/contributing.md
+      - Licenses and privacy:
+          - Privacy and security:
+              - privacy-security/index.md
+              - Privacy: privacy-security/privacy.md
+              - Security: https://n8n.io/legal/#security
+              - Incident response: privacy-security/incident-response.md
+              - What you can do: privacy-security/what-you-can-do.md
+          - Sustainable use license: sustainable-use-license.md
   - Integrations:
-    - integrations/index.md
-    - Built-in nodes:
-      - Node types: integrations/builtin/node-types.md
-      - Core nodes:
-        - integrations/builtin/core-nodes/index.md
-        - Activation Trigger: integrations/builtin/core-nodes/n8n-nodes-base.activationtrigger.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.aggregate.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.aitransform.md
-        - Code:
-          - Code: integrations/builtin/core-nodes/n8n-nodes-base.code/index.md
-          - Keyboard shortcuts: integrations/builtin/core-nodes/n8n-nodes-base.code/keyboard-shortcuts.md
-          - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.code/common-issues.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.comparedatasets.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.compression.md
-        - Chat Trigger:
-          - Chat Trigger: integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/index.md
-          - Common issues: integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/common-issues.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.converttofile.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.crypto.md
-        - Data Table:
-          - Data Table: integrations/builtin/core-nodes/n8n-nodes-base.datatable/index.md
-          - Row operations: integrations/builtin/core-nodes/n8n-nodes-base.datatable/rows.md
-          - Table operations: integrations/builtin/core-nodes/n8n-nodes-base.datatable/tables.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.datetime.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.debughelper.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.set.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.editimage.md
-        - Email Trigger (IMAP): integrations/builtin/core-nodes/n8n-nodes-base.emailimap.md
-        - Error Trigger: integrations/builtin/core-nodes/n8n-nodes-base.errortrigger.md
-        - Evaluation: integrations/builtin/core-nodes/n8n-nodes-base.evaluation.md
-        - Evaluation Trigger: integrations/builtin/core-nodes/n8n-nodes-base.evaluationtrigger.md
-        - Execute Command:
-          - Execute Command: integrations/builtin/core-nodes/n8n-nodes-base.executecommand/index.md
-          - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.executecommand/common-issues.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.executeworkflow.md
-        - Execute Sub-workflow Trigger: integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.executiondata.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.extractfromfile.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.filter.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.ftp.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.git.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.graphql.md
-        - Guardrails: integrations/builtin/core-nodes/n8n-nodes-langchain.guardrails.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.html.md
-        - HTTP Request:
-          - HTTP Request: integrations/builtin/core-nodes/n8n-nodes-base.httprequest/index.md
-          - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.httprequest/common-issues.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.if.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.jwt.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.ldap.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.limit.md
-        - Local File Trigger: integrations/builtin/core-nodes/n8n-nodes-base.localfiletrigger.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches.md
-        - Manual Trigger: integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.markdown.md
-        - MCP Client: integrations/builtin/core-nodes/n8n-nodes-langchain.mcpClient.md
-        - MCP Server Trigger: integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.merge.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.n8n.md
-        - n8n Form: integrations/builtin/core-nodes/n8n-nodes-base.form.md
-        - n8n Form Trigger: integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
-        - n8n Trigger: integrations/builtin/core-nodes/n8n-nodes-base.n8ntrigger.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.noop.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.readwritefile.md
-        - Remove Duplicates:
-          - integrations/builtin/core-nodes/n8n-nodes-base.removeduplicates/index.md
-          - Templates and examples: integrations/builtin/core-nodes/n8n-nodes-base.removeduplicates/templates-and-examples.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.renamekeys.md
-        - Chat: integrations/builtin/core-nodes/n8n-nodes-langchain.chat.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.respondtowebhook.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.rssfeedread.md
-        - RSS Feed Trigger: integrations/builtin/core-nodes/n8n-nodes-base.rssfeedreadtrigger.md
-        - Schedule Trigger:
-          - Schedule Trigger: integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/index.md
-          - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/common-issues.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.sendemail.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.sort.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.splitout.md
-        - SSE Trigger: integrations/builtin/core-nodes/n8n-nodes-base.ssetrigger.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.ssh.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.stopanderror.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.summarize.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.switch.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.totp.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.wait.md
-        - Webhook:
-          - integrations/builtin/core-nodes/n8n-nodes-base.webhook/index.md
-          - Workflow development: integrations/builtin/core-nodes/n8n-nodes-base.webhook/workflow-development.md
-          - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.webhook/common-issues.md
-        - Workflow Trigger: integrations/builtin/core-nodes/n8n-nodes-base.workflowtrigger.md
-        - integrations/builtin/core-nodes/n8n-nodes-base.xml.md
-      - Actions:
-        - integrations/builtin/app-nodes/index.md
-        - Action Network: integrations/builtin/app-nodes/n8n-nodes-base.actionnetwork.md
-        - ActiveCampaign: integrations/builtin/app-nodes/n8n-nodes-base.activecampaign.md
-        - Adalo: integrations/builtin/app-nodes/n8n-nodes-base.adalo.md
-        - Affinity: integrations/builtin/app-nodes/n8n-nodes-base.affinity.md
-        - Agile CRM: integrations/builtin/app-nodes/n8n-nodes-base.agilecrm.md
-        - Airtable:
-          - Airtable: integrations/builtin/app-nodes/n8n-nodes-base.airtable/index.md
-          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.airtable/common-issues.md
-        - Airtop: integrations/builtin/app-nodes/n8n-nodes-base.airtop.md
-        - AMQP Sender: integrations/builtin/app-nodes/n8n-nodes-base.amqp.md
-        - Anthropic: integrations/builtin/app-nodes/n8n-nodes-langchain.anthropic.md
-        - APITemplate.io: integrations/builtin/app-nodes/n8n-nodes-base.apitemplateio.md
-        - Asana: integrations/builtin/app-nodes/n8n-nodes-base.asana.md
-        - Autopilot: integrations/builtin/app-nodes/n8n-nodes-base.autopilot.md
-        - AWS Certificate Manager: integrations/builtin/app-nodes/n8n-nodes-base.awscertificatemanager.md
-        - AWS Cognito: integrations/builtin/app-nodes/n8n-nodes-base.awscognito.md
-        - AWS Comprehend: integrations/builtin/app-nodes/n8n-nodes-base.awscomprehend.md
-        - AWS DynamoDB: integrations/builtin/app-nodes/n8n-nodes-base.awsdynamodb.md
-        - AWS Elastic Load Balancing: integrations/builtin/app-nodes/n8n-nodes-base.awselb.md
-        - AWS IAM: integrations/builtin/app-nodes/n8n-nodes-base.awsiam.md
-        - AWS Lambda: integrations/builtin/app-nodes/n8n-nodes-base.awslambda.md
-        - AWS Rekognition: integrations/builtin/app-nodes/n8n-nodes-base.awsrekognition.md
-        - AWS S3: integrations/builtin/app-nodes/n8n-nodes-base.awss3.md
-        - AWS SES: integrations/builtin/app-nodes/n8n-nodes-base.awsses.md
-        - AWS SNS: integrations/builtin/app-nodes/n8n-nodes-base.awssns.md
-        - AWS SQS: integrations/builtin/app-nodes/n8n-nodes-base.awssqs.md
-        - AWS Textract: integrations/builtin/app-nodes/n8n-nodes-base.awstextract.md
-        - AWS Transcribe: integrations/builtin/app-nodes/n8n-nodes-base.awstranscribe.md
-        - Azure Cosmos DB: integrations/builtin/app-nodes/n8n-nodes-base.azurecosmosdb.md
-        - Azure Storage: integrations/builtin/app-nodes/n8n-nodes-base.azurestorage.md
-        - BambooHR: integrations/builtin/app-nodes/n8n-nodes-base.bamboohr.md
-        - Bannerbear: integrations/builtin/app-nodes/n8n-nodes-base.bannerbear.md
-        - Baserow: integrations/builtin/app-nodes/n8n-nodes-base.baserow.md
-        - Beeminder: integrations/builtin/app-nodes/n8n-nodes-base.beeminder.md
-        - Bitly: integrations/builtin/app-nodes/n8n-nodes-base.bitly.md
-        - Bitwarden: integrations/builtin/app-nodes/n8n-nodes-base.bitwarden.md
-        - Box: integrations/builtin/app-nodes/n8n-nodes-base.box.md
-        - Brandfetch: integrations/builtin/app-nodes/n8n-nodes-base.brandfetch.md
-        - Brevo: integrations/builtin/app-nodes/n8n-nodes-base.brevo.md
-        - Bubble: integrations/builtin/app-nodes/n8n-nodes-base.bubble.md
-        - Chargebee: integrations/builtin/app-nodes/n8n-nodes-base.chargebee.md
-        - CircleCI: integrations/builtin/app-nodes/n8n-nodes-base.circleci.md
-        - Webex by Cisco: integrations/builtin/app-nodes/n8n-nodes-base.ciscowebex.md
-        - Clearbit: integrations/builtin/app-nodes/n8n-nodes-base.clearbit.md
-        - ClickUp: integrations/builtin/app-nodes/n8n-nodes-base.clickup.md
-        - Clockify: integrations/builtin/app-nodes/n8n-nodes-base.clockify.md
-        - Cloudflare: integrations/builtin/app-nodes/n8n-nodes-base.cloudflare.md
-        - Cockpit: integrations/builtin/app-nodes/n8n-nodes-base.cockpit.md
-        - Coda: integrations/builtin/app-nodes/n8n-nodes-base.coda.md
-        - CoinGecko: integrations/builtin/app-nodes/n8n-nodes-base.coingecko.md
-        - Contentful: integrations/builtin/app-nodes/n8n-nodes-base.contentful.md
-        - ConvertKit: integrations/builtin/app-nodes/n8n-nodes-base.convertkit.md
-        - Copper: integrations/builtin/app-nodes/n8n-nodes-base.copper.md
-        - Cortex: integrations/builtin/app-nodes/n8n-nodes-base.cortex.md
-        - CrateDB: integrations/builtin/app-nodes/n8n-nodes-base.cratedb.md
-        - crowd.dev: integrations/builtin/app-nodes/n8n-nodes-base.crowddev.md
-        - Customer.io: integrations/builtin/app-nodes/n8n-nodes-base.customerio.md
-        - Databricks: integrations/builtin/app-nodes/n8n-nodes-base.databricks.md
-        - DeepL: integrations/builtin/app-nodes/n8n-nodes-base.deepl.md
-        - Demio: integrations/builtin/app-nodes/n8n-nodes-base.demio.md
-        - DHL: integrations/builtin/app-nodes/n8n-nodes-base.dhl.md
-        - Discord:
-          - Discord: integrations/builtin/app-nodes/n8n-nodes-base.discord/index.md
-          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.discord/common-issues.md
-        - Discourse: integrations/builtin/app-nodes/n8n-nodes-base.discourse.md
-        - Disqus: integrations/builtin/app-nodes/n8n-nodes-base.disqus.md
-        - Drift: integrations/builtin/app-nodes/n8n-nodes-base.drift.md
-        - Dropbox: integrations/builtin/app-nodes/n8n-nodes-base.dropbox.md
-        - Dropcontact: integrations/builtin/app-nodes/n8n-nodes-base.dropcontact.md
-        - E-goi: integrations/builtin/app-nodes/n8n-nodes-base.egoi.md
-        - Elasticsearch: integrations/builtin/app-nodes/n8n-nodes-base.elasticsearch.md
-        - Elastic Security: integrations/builtin/app-nodes/n8n-nodes-base.elasticsecurity.md
-        - Emelia: integrations/builtin/app-nodes/n8n-nodes-base.emelia.md
-        - ERPNext: integrations/builtin/app-nodes/n8n-nodes-base.erpnext.md
-        - Facebook Graph API: integrations/builtin/app-nodes/n8n-nodes-base.facebookgraphapi.md
-        - FileMaker: integrations/builtin/app-nodes/n8n-nodes-base.filemaker.md
-        - Flow: integrations/builtin/app-nodes/n8n-nodes-base.flow.md
-        - Freshdesk: integrations/builtin/app-nodes/n8n-nodes-base.freshdesk.md
-        - Freshservice: integrations/builtin/app-nodes/n8n-nodes-base.freshservice.md
-        - Freshworks CRM: integrations/builtin/app-nodes/n8n-nodes-base.freshworkscrm.md
-        - GetResponse: integrations/builtin/app-nodes/n8n-nodes-base.getresponse.md
-        - Ghost: integrations/builtin/app-nodes/n8n-nodes-base.ghost.md
-        - GitHub: integrations/builtin/app-nodes/n8n-nodes-base.github.md
-        - GitLab: integrations/builtin/app-nodes/n8n-nodes-base.gitlab.md
-        - Gmail:
-          - Gmail: integrations/builtin/app-nodes/n8n-nodes-base.gmail/index.md
-          - Draft operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/draft-operations.md
-          - Label operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/label-operations.md
-          - Message operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/message-operations.md
-          - Thread operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/thread-operations.md
-          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.gmail/common-issues.md
-        - Gong: integrations/builtin/app-nodes/n8n-nodes-base.gong.md
-        - Google Ads: integrations/builtin/app-nodes/n8n-nodes-base.googleads.md
-        - Google Analytics: integrations/builtin/app-nodes/n8n-nodes-base.googleanalytics.md
-        - Google BigQuery: integrations/builtin/app-nodes/n8n-nodes-base.googlebigquery.md
-        - Google Books: integrations/builtin/app-nodes/n8n-nodes-base.googlebooks.md
-        - Google Business Profile: integrations/builtin/app-nodes/n8n-nodes-base.googlebusinessprofile.md
-        - Google Calendar:
-          - Google Calendar: integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/index.md
-          - Calendar operations: integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/calendar-operations.md
-          - Event operations: integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/event-operations.md
-        - Google Chat: integrations/builtin/app-nodes/n8n-nodes-base.googlechat.md
-        - Google Cloud Firestore: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudfirestore.md
-        - Google Cloud Natural Language: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudnaturallanguage.md
-        - Google Cloud Realtime Database: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudrealtimedatabase.md
-        - Google Cloud Storage: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudstorage.md
-        - Google Contacts: integrations/builtin/app-nodes/n8n-nodes-base.googlecontacts.md
-        - Google Docs: integrations/builtin/app-nodes/n8n-nodes-base.googledocs.md
-        - Google Drive:
-          - Google Drive: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/index.md
-          - File operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/file-operations.md
-          - File and folder operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/file-folder-operations.md
-          - Folder operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/folder-operations.md
-          - Shared drive operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/shared-drive-operations.md
-          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/common-issues.md
-        - Google Gemini: integrations/builtin/app-nodes/n8n-nodes-langchain.googlegemini.md
-        - Google Perspective: integrations/builtin/app-nodes/n8n-nodes-base.googleperspective.md
-        - Google Sheets:
-          - Google Sheets: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/index.md
-          - Document operations: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/document-operations.md
-          - Sheet within Document operations: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/sheet-operations.md
-          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/common-issues.md
-        - Google Slides: integrations/builtin/app-nodes/n8n-nodes-base.googleslides.md
-        - Google Tasks: integrations/builtin/app-nodes/n8n-nodes-base.googletasks.md
-        - Google Translate: integrations/builtin/app-nodes/n8n-nodes-base.googletranslate.md
-        - Google Workspace Admin: integrations/builtin/app-nodes/n8n-nodes-base.gsuiteadmin.md
-        - Gotify: integrations/builtin/app-nodes/n8n-nodes-base.gotify.md
-        - GoToWebinar: integrations/builtin/app-nodes/n8n-nodes-base.gotowebinar.md
-        - Grafana: integrations/builtin/app-nodes/n8n-nodes-base.grafana.md
-        - Grist: integrations/builtin/app-nodes/n8n-nodes-base.grist.md
-        - Hacker News: integrations/builtin/app-nodes/n8n-nodes-base.hackernews.md
-        - HaloPSA: integrations/builtin/app-nodes/n8n-nodes-base.halopsa.md
-        - Harvest: integrations/builtin/app-nodes/n8n-nodes-base.harvest.md
-        - Help Scout: integrations/builtin/app-nodes/n8n-nodes-base.helpscout.md
-        - HighLevel: integrations/builtin/app-nodes/n8n-nodes-base.highlevel.md
-        - Home Assistant: integrations/builtin/app-nodes/n8n-nodes-base.homeassistant.md
-        - HubSpot: integrations/builtin/app-nodes/n8n-nodes-base.hubspot.md
-        - Humantic AI: integrations/builtin/app-nodes/n8n-nodes-base.humanticai.md
-        - Hunter: integrations/builtin/app-nodes/n8n-nodes-base.hunter.md
-        - Intercom: integrations/builtin/app-nodes/n8n-nodes-base.intercom.md
-        - Invoice Ninja: integrations/builtin/app-nodes/n8n-nodes-base.invoiceninja.md
-        - Iterable: integrations/builtin/app-nodes/n8n-nodes-base.iterable.md
-        - Jenkins: integrations/builtin/app-nodes/n8n-nodes-base.jenkins.md
-        - Jina AI: integrations/builtin/app-nodes/n8n-nodes-base.jinaai.md
-        - Jira Software: integrations/builtin/app-nodes/n8n-nodes-base.jira.md
-        - Kafka: integrations/builtin/app-nodes/n8n-nodes-base.kafka.md
-        - Keap: integrations/builtin/app-nodes/n8n-nodes-base.keap.md
-        - Kitemaker: integrations/builtin/app-nodes/n8n-nodes-base.kitemaker.md
-        - KoboToolbox: integrations/builtin/app-nodes/n8n-nodes-base.kobotoolbox.md
-        - Lemlist: integrations/builtin/app-nodes/n8n-nodes-base.lemlist.md
-        - Line: integrations/builtin/app-nodes/n8n-nodes-base.line.md
-        - Linear: integrations/builtin/app-nodes/n8n-nodes-base.linear.md
-        - LingvaNex: integrations/builtin/app-nodes/n8n-nodes-base.lingvanex.md
-        - LinkedIn: integrations/builtin/app-nodes/n8n-nodes-base.linkedin.md
-        - LoneScale: integrations/builtin/app-nodes/n8n-nodes-base.lonescale.md
-        - Magento 2: integrations/builtin/app-nodes/n8n-nodes-base.magento2.md
-        - Mailcheck: integrations/builtin/app-nodes/n8n-nodes-base.mailcheck.md
-        - Mailchimp: integrations/builtin/app-nodes/n8n-nodes-base.mailchimp.md
-        - MailerLite: integrations/builtin/app-nodes/n8n-nodes-base.mailerlite.md
-        - Mailgun: integrations/builtin/app-nodes/n8n-nodes-base.mailgun.md
-        - Mailjet: integrations/builtin/app-nodes/n8n-nodes-base.mailjet.md
-        - Mandrill: integrations/builtin/app-nodes/n8n-nodes-base.mandrill.md
-        - marketstack: integrations/builtin/app-nodes/n8n-nodes-base.marketstack.md
-        - Matrix: integrations/builtin/app-nodes/n8n-nodes-base.matrix.md
-        - Mattermost: integrations/builtin/app-nodes/n8n-nodes-base.mattermost.md
-        - Mautic: integrations/builtin/app-nodes/n8n-nodes-base.mautic.md
-        - Medium: integrations/builtin/app-nodes/n8n-nodes-base.medium.md
-        - MessageBird: integrations/builtin/app-nodes/n8n-nodes-base.messagebird.md
-        - Metabase: integrations/builtin/app-nodes/n8n-nodes-base.metabase.md
-        - Microsoft Dynamics CRM: integrations/builtin/app-nodes/n8n-nodes-base.microsoftdynamicscrm.md
-        - Microsoft Entra ID: integrations/builtin/app-nodes/n8n-nodes-base.microsoftentra.md
-        - Microsoft Excel 365: integrations/builtin/app-nodes/n8n-nodes-base.microsoftexcel.md
-        - Microsoft Graph Security: integrations/builtin/app-nodes/n8n-nodes-base.microsoftgraphsecurity.md
-        - Microsoft OneDrive: integrations/builtin/app-nodes/n8n-nodes-base.microsoftonedrive.md
-        - Microsoft Outlook: integrations/builtin/app-nodes/n8n-nodes-base.microsoftoutlook.md
-        - Microsoft SharePoint: integrations/builtin/app-nodes/n8n-nodes-base.microsoftsharepoint.md
-        - Microsoft SQL: integrations/builtin/app-nodes/n8n-nodes-base.microsoftsql.md
-        - Microsoft Teams: integrations/builtin/app-nodes/n8n-nodes-base.microsoftteams.md
-        - Microsoft To Do: integrations/builtin/app-nodes/n8n-nodes-base.microsofttodo.md
-        - Mindee: integrations/builtin/app-nodes/n8n-nodes-base.mindee.md
-        - MISP: integrations/builtin/app-nodes/n8n-nodes-base.misp.md
-        - Mistral AI: integrations/builtin/app-nodes/n8n-nodes-base.mistralai.md
-        - Mocean: integrations/builtin/app-nodes/n8n-nodes-base.mocean.md
-        - monday.com: integrations/builtin/app-nodes/n8n-nodes-base.mondaycom.md
-        - MongoDB: integrations/builtin/app-nodes/n8n-nodes-base.mongodb.md
-        - Monica CRM: integrations/builtin/app-nodes/n8n-nodes-base.monicacrm.md
-        - MQTT: integrations/builtin/app-nodes/n8n-nodes-base.mqtt.md
-        - MSG91: integrations/builtin/app-nodes/n8n-nodes-base.msg91.md
-        - MySQL:
-          - MySQL: integrations/builtin/app-nodes/n8n-nodes-base.mysql/index.md
-          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.mysql/common-issues.md
-        - Customer Datastore (n8n Training): integrations/builtin/app-nodes/n8n-nodes-base.n8ntrainingcustomerdatastore.md
-        - Customer Messenger (n8n Training): integrations/builtin/app-nodes/n8n-nodes-base.n8ntrainingcustomermessenger.md
-        - NASA: integrations/builtin/app-nodes/n8n-nodes-base.nasa.md
-        - Netlify: integrations/builtin/app-nodes/n8n-nodes-base.netlify.md
-        - Netscaler ADC: integrations/builtin/app-nodes/n8n-nodes-base.netscaleradc.md
-        - Nextcloud: integrations/builtin/app-nodes/n8n-nodes-base.nextcloud.md
-        - NocoDB: integrations/builtin/app-nodes/n8n-nodes-base.nocodb.md
-        - Notion:
-          - Notion: integrations/builtin/app-nodes/n8n-nodes-base.notion/index.md
-          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.notion/common-issues.md
-        - npm: integrations/builtin/app-nodes/n8n-nodes-base.npm.md
-        - Odoo: integrations/builtin/app-nodes/n8n-nodes-base.odoo.md
-        - Okta: integrations/builtin/app-nodes/n8n-nodes-base.okta.md
-        - One Simple API: integrations/builtin/app-nodes/n8n-nodes-base.onesimpleapi.md
-        - Onfleet: integrations/builtin/app-nodes/n8n-nodes-base.onfleet.md
-        - OpenAI:
-          - OpenAI: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/index.md
-          - Assistant operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/assistant-operations.md
-          - Audio operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/audio-operations.md
-          - Conversation operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/conversation-operations.md
-          - File operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/file-operations.md
-          - Image operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/image-operations.md
-          - Text operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/text-operations.md
-          - Video operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/video-operations.md
-          - Common issues: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
-        - OpenThesaurus: integrations/builtin/app-nodes/n8n-nodes-base.openthesaurus.md
-        - OpenWeatherMap: integrations/builtin/app-nodes/n8n-nodes-base.openweathermap.md
-        - Oracle Database:
-          - Oracle Database: integrations/builtin/app-nodes/n8n-nodes-base.oracledb/index.md
-        - Oura: integrations/builtin/app-nodes/n8n-nodes-base.oura.md
-        - Paddle: integrations/builtin/app-nodes/n8n-nodes-base.paddle.md
-        - PagerDuty: integrations/builtin/app-nodes/n8n-nodes-base.pagerduty.md
-        - PayPal: integrations/builtin/app-nodes/n8n-nodes-base.paypal.md
-        - Peekalink: integrations/builtin/app-nodes/n8n-nodes-base.peekalink.md
-        - Perplexity: integrations/builtin/app-nodes/n8n-nodes-langchain.perplexity.md
-        - PhantomBuster: integrations/builtin/app-nodes/n8n-nodes-base.phantombuster.md
-        - Philips Hue: integrations/builtin/app-nodes/n8n-nodes-base.philipshue.md
-        - Pipedrive: integrations/builtin/app-nodes/n8n-nodes-base.pipedrive.md
-        - Plivo: integrations/builtin/app-nodes/n8n-nodes-base.plivo.md
-        - PostBin: integrations/builtin/app-nodes/n8n-nodes-base.postbin.md
-        - Postgres:
-          - Postgres: integrations/builtin/app-nodes/n8n-nodes-base.postgres/index.md
-          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.postgres/common-issues.md
-        - PostHog: integrations/builtin/app-nodes/n8n-nodes-base.posthog.md
-        - ProfitWell: integrations/builtin/app-nodes/n8n-nodes-base.profitwell.md
-        - Pushbullet: integrations/builtin/app-nodes/n8n-nodes-base.pushbullet.md
-        - Pushcut: integrations/builtin/app-nodes/n8n-nodes-base.pushcut.md
-        - Pushover: integrations/builtin/app-nodes/n8n-nodes-base.pushover.md
-        - QuestDB: integrations/builtin/app-nodes/n8n-nodes-base.questdb.md
-        - Quick Base: integrations/builtin/app-nodes/n8n-nodes-base.quickbase.md
-        - QuickBooks Online: integrations/builtin/app-nodes/n8n-nodes-base.quickbooks.md
-        - QuickChart: integrations/builtin/app-nodes/n8n-nodes-base.quickchart.md
-        - RabbitMQ: integrations/builtin/app-nodes/n8n-nodes-base.rabbitmq.md
-        - Raindrop: integrations/builtin/app-nodes/n8n-nodes-base.raindrop.md
-        - Reddit: integrations/builtin/app-nodes/n8n-nodes-base.reddit.md
-        - Redis: integrations/builtin/app-nodes/n8n-nodes-base.redis.md
-        - Rocket.Chat: integrations/builtin/app-nodes/n8n-nodes-base.rocketchat.md
-        - Rundeck: integrations/builtin/app-nodes/n8n-nodes-base.rundeck.md
-        - S3: integrations/builtin/app-nodes/n8n-nodes-base.s3.md
-        - Salesforce: integrations/builtin/app-nodes/n8n-nodes-base.salesforce.md
-        - Salesmate: integrations/builtin/app-nodes/n8n-nodes-base.salesmate.md
-        - SeaTable: integrations/builtin/app-nodes/n8n-nodes-base.seatable.md
-        - SecurityScorecard: integrations/builtin/app-nodes/n8n-nodes-base.securityscorecard.md
-        - Segment: integrations/builtin/app-nodes/n8n-nodes-base.segment.md
-        - SendGrid: integrations/builtin/app-nodes/n8n-nodes-base.sendgrid.md
-        - Sendy: integrations/builtin/app-nodes/n8n-nodes-base.sendy.md
-        - Sentry.io: integrations/builtin/app-nodes/n8n-nodes-base.sentryio.md
-        - ServiceNow: integrations/builtin/app-nodes/n8n-nodes-base.servicenow.md
-        - seven: integrations/builtin/app-nodes/n8n-nodes-base.sms77.md
-        - Shopify: integrations/builtin/app-nodes/n8n-nodes-base.shopify.md
-        - SIGNL4: integrations/builtin/app-nodes/n8n-nodes-base.signl4.md
-        - Slack: integrations/builtin/app-nodes/n8n-nodes-base.slack.md
-        - Snowflake: integrations/builtin/app-nodes/n8n-nodes-base.snowflake.md
-        - Splunk: integrations/builtin/app-nodes/n8n-nodes-base.splunk.md
-        - Spotify: integrations/builtin/app-nodes/n8n-nodes-base.spotify.md
-        - Stackby: integrations/builtin/app-nodes/n8n-nodes-base.stackby.md
-        - Storyblok: integrations/builtin/app-nodes/n8n-nodes-base.storyblok.md
-        - Strapi: integrations/builtin/app-nodes/n8n-nodes-base.strapi.md
-        - Strava: integrations/builtin/app-nodes/n8n-nodes-base.strava.md
-        - Stripe: integrations/builtin/app-nodes/n8n-nodes-base.stripe.md
-        - Supabase:
-          - Supabase: integrations/builtin/app-nodes/n8n-nodes-base.supabase/index.md
-          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.supabase/common-issues.md
-        - SyncroMSP: integrations/builtin/app-nodes/n8n-nodes-base.syncromsp.md
-        - Taiga: integrations/builtin/app-nodes/n8n-nodes-base.taiga.md
-        - Tapfiliate: integrations/builtin/app-nodes/n8n-nodes-base.tapfiliate.md
-        - Telegram:
-          - integrations/builtin/app-nodes/n8n-nodes-base.telegram/index.md
-          - Chat operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/chat-operations.md
-          - Callback operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/callback-operations.md
-          - File operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/file-operations.md
-          - Message operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/message-operations.md
-          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.telegram/common-issues.md
-        - TheHive: integrations/builtin/app-nodes/n8n-nodes-base.thehive.md
-        - TheHive 5: integrations/builtin/app-nodes/n8n-nodes-base.thehive5.md
-        - TimescaleDB: integrations/builtin/app-nodes/n8n-nodes-base.timescaledb.md
-        - Todoist: integrations/builtin/app-nodes/n8n-nodes-base.todoist.md
-        - Travis CI: integrations/builtin/app-nodes/n8n-nodes-base.travisci.md
-        - Trello: integrations/builtin/app-nodes/n8n-nodes-base.trello.md
-        - Twake: integrations/builtin/app-nodes/n8n-nodes-base.twake.md
-        - Twilio: integrations/builtin/app-nodes/n8n-nodes-base.twilio.md
-        - Twist: integrations/builtin/app-nodes/n8n-nodes-base.twist.md
-        - Unleashed Software: integrations/builtin/app-nodes/n8n-nodes-base.unleashedsoftware.md
-        - UpLead: integrations/builtin/app-nodes/n8n-nodes-base.uplead.md
-        - uProc: integrations/builtin/app-nodes/n8n-nodes-base.uproc.md
-        - UptimeRobot: integrations/builtin/app-nodes/n8n-nodes-base.uptimerobot.md
-        - urlscan.io: integrations/builtin/app-nodes/n8n-nodes-base.urlscanio.md
-        - Venafi TLS Protect Cloud: integrations/builtin/app-nodes/n8n-nodes-base.venafitlsprotectcloud.md
-        - Venafi TLS Protect Datacenter: integrations/builtin/app-nodes/n8n-nodes-base.venafitlsprotectdatacenter.md
-        - Vero: integrations/builtin/app-nodes/n8n-nodes-base.vero.md
-        - Vonage: integrations/builtin/app-nodes/n8n-nodes-base.vonage.md
-        - Webflow: integrations/builtin/app-nodes/n8n-nodes-base.webflow.md
-        - Wekan: integrations/builtin/app-nodes/n8n-nodes-base.wekan.md
-        - WhatsApp Business Cloud:
-          - WhatsApp Business Cloud: integrations/builtin/app-nodes/n8n-nodes-base.whatsapp/index.md
-          - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.whatsapp/common-issues.md
-        - Wise: integrations/builtin/app-nodes/n8n-nodes-base.wise.md
-        - WooCommerce: integrations/builtin/app-nodes/n8n-nodes-base.woocommerce.md
-        - WordPress: integrations/builtin/app-nodes/n8n-nodes-base.wordpress.md
-        - X (Formerly Twitter): integrations/builtin/app-nodes/n8n-nodes-base.twitter.md
-        - Xero: integrations/builtin/app-nodes/n8n-nodes-base.xero.md
-        - Yourls: integrations/builtin/app-nodes/n8n-nodes-base.yourls.md
-        - YouTube: integrations/builtin/app-nodes/n8n-nodes-base.youtube.md
-        - Zammad: integrations/builtin/app-nodes/n8n-nodes-base.zammad.md
-        - Zendesk: integrations/builtin/app-nodes/n8n-nodes-base.zendesk.md
-        - Zoho CRM: integrations/builtin/app-nodes/n8n-nodes-base.zohocrm.md
-        - Zoom: integrations/builtin/app-nodes/n8n-nodes-base.zoom.md
-        - Zulip: integrations/builtin/app-nodes/n8n-nodes-base.zulip.md
-      - Triggers:
-        - integrations/builtin/trigger-nodes/index.md
-        - ActiveCampaign Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.activecampaigntrigger.md
-        - Acuity Scheduling Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.acuityschedulingtrigger.md
-        - Affinity Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.affinitytrigger.md
-        - Airtable Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.airtabletrigger.md
-        - AMQP Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.amqptrigger.md
-        - Asana Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.asanatrigger.md
-        - Autopilot Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.autopilottrigger.md
-        - AWS SNS Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.awssnstrigger.md
-        - Bitbucket Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.bitbuckettrigger.md
-        - Box Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.boxtrigger.md
-        - Brevo Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.brevotrigger.md
-        - Calendly Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.calendlytrigger.md
-        - Cal Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.caltrigger.md
-        - Chargebee Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.chargebeetrigger.md
-        - ClickUp Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.clickuptrigger.md
-        - Clockify Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.clockifytrigger.md
-        - ConvertKit Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.convertkittrigger.md
-        - Copper Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.coppertrigger.md
-        - crowd.dev Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.crowddevtrigger.md
-        - Customer.io Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.customeriotrigger.md
-        - Emelia Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.emeliatrigger.md
-        - Eventbrite Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.eventbritetrigger.md
-        - Facebook Lead Ads Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.facebookleadadstrigger.md
-        - Facebook Trigger:
-          - Facebook Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/index.md
-          - Ad Account: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/ad-account.md
-          - Application: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/application.md
-          - Certificate Transparency: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/certificate-transparency.md
-          - Group: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/group.md
-          - Instagram: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/instagram.md
-          - Link: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/link.md
-          - Page: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/page.md
-          - Permissions: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/permissions.md
-          - User: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/user.md
-          - WhatsApp Business Account: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/whatsapp.md
-          - Workplace Security: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/workplace-security.md
-        - Figma Trigger (Beta): integrations/builtin/trigger-nodes/n8n-nodes-base.figmatrigger.md
-        - Flow Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.flowtrigger.md
-        - Form.io Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.formiotrigger.md
-        - Formstack Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.formstacktrigger.md
-        - GetResponse Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.getresponsetrigger.md
-        - GitHub Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.githubtrigger.md
-        - GitLab Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.gitlabtrigger.md
-        - Gmail Trigger:
-          - integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/index.md
-          - Poll Mode options: integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/poll-mode-options.md
-          - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/common-issues.md
-        - Google Calendar Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googlecalendartrigger.md
-        - Google Drive Trigger:
-          - Google Drive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googledrivetrigger/index.md
-          - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.googledrivetrigger/common-issues.md
-        - Google Business Profile Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googlebusinessprofiletrigger.md
-        - Google Sheets Trigger:
-          - Google Sheets Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googlesheetstrigger/index.md
-          - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.googlesheetstrigger/common-issues.md
-        - Gumroad Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.gumroadtrigger.md
-        - Help Scout Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.helpscouttrigger.md
-        - Hubspot Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.hubspottrigger.md
-        - Invoice Ninja Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.invoiceninjatrigger.md
-        - Jira Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.jiratrigger.md
-        - Jotform Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.jotformtrigger.md
-        - Kafka Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.kafkatrigger.md
-        - Keap Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.keaptrigger.md
-        - KoboToolbox Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.kobotoolboxtrigger.md
-        - Lemlist Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.lemlisttrigger.md
-        - Linear Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.lineartrigger.md
-        - LoneScale Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.lonescaletrigger.md
-        - Mailchimp Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mailchimptrigger.md
-        - MailerLite Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mailerlitetrigger.md
-        - Mailjet Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mailjettrigger.md
-        - Mautic Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mautictrigger.md
-        - Microsoft OneDrive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftonedrivetrigger.md
-        - Microsoft Outlook Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftoutlooktrigger.md
-        - Microsoft Teams Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftteamstrigger.md
-        - MQTT Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mqtttrigger.md
-        - Netlify Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.netlifytrigger.md
-        - Notion Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.notiontrigger.md
-        - Onfleet Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.onfleettrigger.md
-        - PayPal Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.paypaltrigger.md
-        - Pipedrive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.pipedrivetrigger.md
-        - Postgres Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.postgrestrigger.md
-        - Postmark Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.postmarktrigger.md
-        - Pushcut Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.pushcuttrigger.md
-        - RabbitMQ Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.rabbitmqtrigger.md
-        - Redis Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.redistrigger.md
-        - Salesforce Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.salesforcetrigger.md
-        - SeaTable Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.seatabletrigger.md
-        - Shopify Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.shopifytrigger.md
-        - Slack Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
-        - Strava Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.stravatrigger.md
-        - Stripe Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.stripetrigger.md
-        - SurveyMonkey Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.surveymonkeytrigger.md
-        - Taiga Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.taigatrigger.md
-        - Telegram Trigger:
-          - Telegram Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.telegramtrigger/index.md
-          - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.telegramtrigger/common-issues.md
-        - TheHive 5 Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.thehive5trigger.md
-        - TheHive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.thehivetrigger.md
-        - Toggl Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.toggltrigger.md
-        - Trello Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.trellotrigger.md
-        - Twilio Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.twiliotrigger.md
-        - Typeform Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.typeformtrigger.md
-        - Venafi TLS Protect Cloud Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.venafitlsprotectcloudtrigger.md
-        - Webex by Cisco Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.ciscowebextrigger.md
-        - Webflow Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.webflowtrigger.md
-        - WhatsApp Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.whatsapptrigger.md
-        - Wise Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.wisetrigger.md
-        - WooCommerce Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.woocommercetrigger.md
-        - Workable Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.workabletrigger.md
-        - Wufoo Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.wufootrigger.md
-        - Zendesk Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.zendesktrigger.md
-      - Cluster nodes:
-        - integrations/builtin/cluster-nodes/index.md
-        - Root nodes:
-          - integrations/builtin/cluster-nodes/root-nodes/index.md
-          - AI Agent:
-            - AI Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/index.md
-            - Conversational Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/conversational-agent.md
-            - OpenAI Functions Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/openai-functions-agent.md
-            - Plan and Execute Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/plan-execute-agent.md
-            - ReAct Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/react-agent.md
-            - SQL Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/sql-agent.md
-            - Tools Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
-            - Common issues: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/common-issues.md
-          - Basic LLM Chain: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainllm.md
-          - Question and Answer Chain:
-            - Question and Answer Chain: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainretrievalqa/index.md
-            - Common issues: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainretrievalqa/common-issues.md
-          - Summarization Chain: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainsummarization.md
-          - Information Extractor: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.information-extractor.md
-          - Text Classifier: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.text-classifier.md
-          - Sentiment Analysis: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.sentimentanalysis.md
-          - LangChain Code: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.code.md
-          - Microsoft Agent 365 Trigger: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.microsoftagent365trigger/index.md
-          - Azure AI Search Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreazureaisearch.md
-          - Simple Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreinmemory.md
-          - Milvus Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremilvus.md
-          - MongoDB Atlas Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md
-          - PGVector Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepgvector.md
-          - Chroma Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorechroma.md
-          - Pinecone Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepinecone.md
-          - Qdrant Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreqdrant.md
-          - Redis Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreredis.md
-          - Supabase Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoresupabase.md
-          - Weaviate Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreweaviate.md
-          - Zep Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorezep.md
-        - Sub-nodes:
-          - integrations/builtin/cluster-nodes/sub-nodes/index.md
-          - Default Data Loader: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentdefaultdataloader.md
-          - GitHub Document Loader: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentgithubloader.md
-          - Embeddings AWS Bedrock: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsawsbedrock.md
-          - Embeddings Azure OpenAI: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsazureopenai.md
-          - Embeddings Cohere: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingscohere.md
-          - Embeddings Google Gemini: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsgooglegemini.md
-          - Embeddings Google PaLM: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsgooglepalm.md
-          - Embeddings Google Vertex: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsgooglevertex.md
-          - Embeddings HuggingFace Inference: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingshuggingfaceinference.md
-          - Embeddings Lemonade: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingslemonade.md
-          - Embeddings Mistral Cloud: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsmistralcloud.md
-          - Embeddings Ollama: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsollama.md
-          - Embeddings OpenAI: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsopenai.md
-          - Anthropic Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatanthropic.md
-          - AWS Bedrock Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatawsbedrock.md
-          - Azure OpenAI Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatazureopenai.md
-          - Cohere Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatcohere.md
-          - DeepSeek Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatdeepseek.md
-          - Google Gemini Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgooglegemini.md
-          - Google Vertex Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgooglevertex.md
-          - Groq Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgroq.md
-          - Lemonade Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatlemonade.md
-          - Mistral Cloud Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatmistralcloud.md
-          - Ollama Chat Model:
-            - Ollama Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatollama/index.md
-            - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatollama/common-issues.md
-          - OpenAI Chat Model:
-            - OpenAI Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai/index.md
-            - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai/common-issues.md
-          - OpenRouter Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenrouter.md
-          - Vercel AI Gateway Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatvercel.md
-          - xAI Grok Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatxaigrok.md
-          - Cohere Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmcohere.md
-          - Lemonade Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmlemonade.md
-          - Ollama Model:
-            - Ollama Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmollama/index.md
-            - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmollama/common-issues.md
-          - Hugging Face Inference Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmopenhuggingfaceinference.md
-          - Chat Memory Manager: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorymanager.md
-          - Simple Memory: 
-            - integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorybufferwindow/index.md
-            - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorybufferwindow/common-issues.md
-          - Motorhead: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorymotorhead.md
-          - MongoDB Chat Memory: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorymongochat.md
-          - Redis Chat Memory: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memoryredischat.md
-          - Postgres Chat Memory: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorypostgreschat.md
-          - Xata: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memoryxata.md
-          - Zep: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memoryzep.md
-          - Auto-fixing Output Parser: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparserautofixing.md
-          - Item List Output Parser: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparseritemlist.md
-          - Structured Output Parser:
-            - Structured Output Parser: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparserstructured/index.md
-            - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparserstructured/common-issues.md
-          - Contextual Compression Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrievercontextualcompression.md
-          - MultiQuery Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrievermultiquery.md
-          - Vector Store Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrievervectorstore.md
-          - Workflow Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrieverworkflow.md
-          - Character Text Splitter: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.textsplittercharactertextsplitter.md
-          - Recursive Character Text Splitter: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.textsplitterrecursivecharactertextsplitter.md
-          - Token Splitter: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.textsplittertokensplitter.md
-          - AI Agent Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolaiagent.md
-          - Calculator: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcalculator.md
-          - Custom Code Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcode.md
-          - MCP Client Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md
-          - SearXNG Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolsearxng.md
-          - SerpApi (Google Search): integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolserpapi.md
-          - Think Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolthink.md        
-          - Vector Store Question Answer Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolvectorstore.md
-          - Wikipedia: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolwikipedia.md
-          - Wolfram|Alpha: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolwolframalpha.md
-          - Call n8n Workflow Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md
-          - Reranker Cohere: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.rerankercohere.md
-          - Model Selector: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.modelselector.md
-      - Credentials:
-        - integrations/builtin/credentials/index.md
-        - integrations/builtin/credentials/actionnetwork.md
-        - integrations/builtin/credentials/activecampaign.md
-        - integrations/builtin/credentials/acuityscheduling.md
-        - integrations/builtin/credentials/adalo.md
-        - integrations/builtin/credentials/affinity.md
-        - integrations/builtin/credentials/agilecrm.md
-        - integrations/builtin/credentials/airtable.md
-        - integrations/builtin/credentials/airtop.md
-        - integrations/builtin/credentials/alienvault.md
-        - integrations/builtin/credentials/amqp.md
-        - integrations/builtin/credentials/anthropic.md
-        - integrations/builtin/credentials/apitemplateio.md
-        - integrations/builtin/credentials/asana.md
-        - integrations/builtin/credentials/auth0management.md
-        - integrations/builtin/credentials/autopilot.md
-        - integrations/builtin/credentials/aws.md
-        - integrations/builtin/credentials/azureopenai.md
-        - integrations/builtin/credentials/azurecosmosdb.md
-        - integrations/builtin/credentials/azureaisearch.md
-        - integrations/builtin/credentials/azurestorage.md
-        - integrations/builtin/credentials/bamboohr.md
-        - integrations/builtin/credentials/bannerbear.md
-        - integrations/builtin/credentials/baserow.md
-        - integrations/builtin/credentials/beeminder.md
-        - integrations/builtin/credentials/bitbucket.md
-        - integrations/builtin/credentials/bitly.md
-        - integrations/builtin/credentials/bitwarden.md
-        - integrations/builtin/credentials/box.md
-        - integrations/builtin/credentials/brandfetch.md
-        - integrations/builtin/credentials/brevo.md
-        - integrations/builtin/credentials/bubble.md
-        - integrations/builtin/credentials/cal.md
-        - integrations/builtin/credentials/calendly.md
-        - integrations/builtin/credentials/carbonblack.md
-        - integrations/builtin/credentials/chargebee.md
-        - integrations/builtin/credentials/circleci.md
-        - integrations/builtin/credentials/ciscomeraki.md
-        - integrations/builtin/credentials/ciscosecureendpoint.md
-        - integrations/builtin/credentials/ciscoumbrella.md
-        - integrations/builtin/credentials/clearbit.md
-        - integrations/builtin/credentials/clickup.md
-        - integrations/builtin/credentials/clockify.md
-        - integrations/builtin/credentials/cloudflare.md
-        - integrations/builtin/credentials/cockpit.md
-        - integrations/builtin/credentials/coda.md
-        - integrations/builtin/credentials/cohere.md
-        - integrations/builtin/credentials/contentful.md
-        - integrations/builtin/credentials/convertapi.md
-        - integrations/builtin/credentials/convertkit.md
-        - integrations/builtin/credentials/copper.md
-        - integrations/builtin/credentials/cortex.md
-        - integrations/builtin/credentials/cratedb.md
-        - integrations/builtin/credentials/crowddev.md
-        - integrations/builtin/credentials/crowdstrike.md
-        - integrations/builtin/credentials/customerio.md
-        - integrations/builtin/credentials/databricks.md
-        - integrations/builtin/credentials/datadog.md
-        - integrations/builtin/credentials/deepl.md
-        - integrations/builtin/credentials/deepseek.md
-        - integrations/builtin/credentials/demio.md
-        - integrations/builtin/credentials/dfiriris.md
-        - integrations/builtin/credentials/dhl.md
-        - integrations/builtin/credentials/discord.md
-        - integrations/builtin/credentials/discourse.md
-        - integrations/builtin/credentials/disqus.md
-        - integrations/builtin/credentials/drift.md
-        - integrations/builtin/credentials/dropbox.md
-        - integrations/builtin/credentials/dropcontact.md
-        - integrations/builtin/credentials/dynatrace.md
-        - integrations/builtin/credentials/egoi.md
-        - integrations/builtin/credentials/elasticsearch.md
-        - integrations/builtin/credentials/elasticsecurity.md
-        - integrations/builtin/credentials/emelia.md
-        - integrations/builtin/credentials/erpnext.md
-        - integrations/builtin/credentials/eventbrite.md
-        - integrations/builtin/credentials/f5bigip.md
-        - integrations/builtin/credentials/facebookapp.md
-        - integrations/builtin/credentials/facebookgraph.md
-        - integrations/builtin/credentials/facebookleadads.md
-        - integrations/builtin/credentials/figma.md
-        - integrations/builtin/credentials/filemaker.md
-        - integrations/builtin/credentials/filescan.md
-        - integrations/builtin/credentials/flow.md
-        - integrations/builtin/credentials/formiotrigger.md
-        - integrations/builtin/credentials/formstacktrigger.md
-        - integrations/builtin/credentials/fortigate.md
-        - integrations/builtin/credentials/freshdesk.md
-        - integrations/builtin/credentials/freshservice.md
-        - integrations/builtin/credentials/freshworkscrm.md
-        - integrations/builtin/credentials/ftp.md
-        - integrations/builtin/credentials/getresponse.md
-        - integrations/builtin/credentials/ghost.md
-        - integrations/builtin/credentials/git.md
-        - integrations/builtin/credentials/github.md
-        - integrations/builtin/credentials/gitlab.md
-        - integrations/builtin/credentials/gong.md
-        - Google:
-          - integrations/builtin/credentials/google/index.md
-          - integrations/builtin/credentials/google/oauth-single-service.md
-          - integrations/builtin/credentials/google/oauth-generic.md
-          - integrations/builtin/credentials/google/service-account.md
-        - integrations/builtin/credentials/googleai.md
-        - integrations/builtin/credentials/gotify.md
-        - integrations/builtin/credentials/gotowebinar.md
-        - integrations/builtin/credentials/grafana.md
-        - integrations/builtin/credentials/grist.md
-        - integrations/builtin/credentials/groq.md
-        - integrations/builtin/credentials/gumroad.md
-        - integrations/builtin/credentials/halopsa.md
-        - integrations/builtin/credentials/harvest.md
-        - integrations/builtin/credentials/helpscout.md
-        - integrations/builtin/credentials/highlevel.md
-        - integrations/builtin/credentials/homeassistant.md
-        - integrations/builtin/credentials/httprequest.md
-        - integrations/builtin/credentials/hubspot.md
-        - integrations/builtin/credentials/huggingface.md
-        - integrations/builtin/credentials/humanticai.md
-        - integrations/builtin/credentials/hunter.md
-        - integrations/builtin/credentials/hybridanalysis.md
-        - IMAP:
-          - integrations/builtin/credentials/imap/index.md
-          - integrations/builtin/credentials/imap/gmail.md
-          - integrations/builtin/credentials/imap/outlook.md
-          - integrations/builtin/credentials/imap/yahoo.md
-        - integrations/builtin/credentials/impervawaf.md
-        - integrations/builtin/credentials/intercom.md
-        - integrations/builtin/credentials/invoiceninja.md
-        - integrations/builtin/credentials/iterable.md
-        - integrations/builtin/credentials/jenkins.md
-        - integrations/builtin/credentials/jinaai.md
-        - integrations/builtin/credentials/jira.md
-        - integrations/builtin/credentials/jotform.md
-        - integrations/builtin/credentials/jwt.md
-        - integrations/builtin/credentials/kafka.md
-        - integrations/builtin/credentials/keap.md
-        - integrations/builtin/credentials/kibana.md
-        - integrations/builtin/credentials/kitemaker.md
-        - integrations/builtin/credentials/kobotoolbox.md
-        - integrations/builtin/credentials/ldap.md
-        - integrations/builtin/credentials/lemlist.md
-        - integrations/builtin/credentials/lemonade.md
-        - integrations/builtin/credentials/line.md
-        - integrations/builtin/credentials/linear.md
-        - integrations/builtin/credentials/lingvanex.md
-        - integrations/builtin/credentials/linkedin.md
-        - integrations/builtin/credentials/lonescale.md
-        - integrations/builtin/credentials/magento2.md
-        - integrations/builtin/credentials/mailcheck.md
-        - integrations/builtin/credentials/mailchimp.md
-        - integrations/builtin/credentials/mailerlite.md
-        - integrations/builtin/credentials/mailgun.md
-        - integrations/builtin/credentials/mailjet.md
-        - integrations/builtin/credentials/malcore.md
-        - integrations/builtin/credentials/mandrill.md
-        - integrations/builtin/credentials/marketstack.md
-        - integrations/builtin/credentials/matrix.md
-        - integrations/builtin/credentials/mattermost.md
-        - integrations/builtin/credentials/mautic.md
-        - integrations/builtin/credentials/medium.md
-        - integrations/builtin/credentials/messagebird.md
-        - integrations/builtin/credentials/metabase.md
-        - integrations/builtin/credentials/microsoft.md
-        - integrations/builtin/credentials/microsoftazuremonitor.md
-        - integrations/builtin/credentials/microsoftentra.md
-        - integrations/builtin/credentials/microsoftsql.md
-        - integrations/builtin/credentials/microsoftagent365.md
-        - integrations/builtin/credentials/milvus.md
-        - integrations/builtin/credentials/mindee.md
-        - integrations/builtin/credentials/miro.md
-        - integrations/builtin/credentials/misp.md
-        - integrations/builtin/credentials/mist.md
-        - integrations/builtin/credentials/mistral.md
-        - integrations/builtin/credentials/mocean.md
-        - integrations/builtin/credentials/mondaycom.md
-        - integrations/builtin/credentials/mongodb.md
-        - integrations/builtin/credentials/monicacrm.md
-        - integrations/builtin/credentials/motorhead.md
-        - integrations/builtin/credentials/mqtt.md
-        - integrations/builtin/credentials/msg91.md
-        - integrations/builtin/credentials/mysql.md
-        - integrations/builtin/credentials/nasa.md
-        - integrations/builtin/credentials/netlify.md
-        - integrations/builtin/credentials/netscaleradc.md
-        - integrations/builtin/credentials/nextcloud.md
-        - integrations/builtin/credentials/nocodb.md
-        - integrations/builtin/credentials/notion.md
-        - integrations/builtin/credentials/npm.md
-        - integrations/builtin/credentials/odoo.md
-        - integrations/builtin/credentials/okta.md
-        - integrations/builtin/credentials/ollama.md
-        - integrations/builtin/credentials/onesimpleapi.md
-        - integrations/builtin/credentials/onfleet.md
-        - integrations/builtin/credentials/openai.md
-        - integrations/builtin/credentials/opencti.md
-        - integrations/builtin/credentials/openrouter.md
-        - integrations/builtin/credentials/openweathermap.md
-        - integrations/builtin/credentials/oracledb.md
-        - integrations/builtin/credentials/oura.md
-        - integrations/builtin/credentials/paddle.md
-        - integrations/builtin/credentials/pagerduty.md
-        - integrations/builtin/credentials/paypal.md
-        - integrations/builtin/credentials/peekalink.md
-        - integrations/builtin/credentials/perplexity.md
-        - integrations/builtin/credentials/phantombuster.md
-        - integrations/builtin/credentials/philipshue.md
-        - integrations/builtin/credentials/chroma.md
-        - integrations/builtin/credentials/pinecone.md
-        - integrations/builtin/credentials/pipedrive.md
-        - integrations/builtin/credentials/plivo.md
-        - integrations/builtin/credentials/postgres.md
-        - integrations/builtin/credentials/posthog.md
-        - integrations/builtin/credentials/postmark.md
-        - integrations/builtin/credentials/profitwell.md
-        - integrations/builtin/credentials/pushbullet.md
-        - integrations/builtin/credentials/pushcut.md
-        - integrations/builtin/credentials/pushover.md
-        - integrations/builtin/credentials/qradar.md
-        - integrations/builtin/credentials/qdrant.md
-        - integrations/builtin/credentials/qualys.md
-        - integrations/builtin/credentials/questdb.md
-        - integrations/builtin/credentials/quickbase.md
-        - integrations/builtin/credentials/quickbooks.md
-        - integrations/builtin/credentials/rabbitmq.md
-        - integrations/builtin/credentials/raindrop.md
-        - integrations/builtin/credentials/rapid7insightvm.md
-        - integrations/builtin/credentials/recordedfuture.md
-        - integrations/builtin/credentials/reddit.md
-        - integrations/builtin/credentials/redis.md
-        - integrations/builtin/credentials/rocketchat.md
-        - integrations/builtin/credentials/rundeck.md
-        - integrations/builtin/credentials/s3.md
-        - integrations/builtin/credentials/salesforce.md
-        - integrations/builtin/credentials/salesmate.md
-        - integrations/builtin/credentials/searxng.md
-        - integrations/builtin/credentials/seatable.md
-        - integrations/builtin/credentials/securityscorecard.md
-        - integrations/builtin/credentials/segment.md
-        - integrations/builtin/credentials/sekoia.md
-        - Send Email:
-          - integrations/builtin/credentials/sendemail/index.md
-          - integrations/builtin/credentials/sendemail/gmail.md
-          - integrations/builtin/credentials/sendemail/outlook.md
-          - integrations/builtin/credentials/sendemail/yahoo.md
-        - integrations/builtin/credentials/sendgrid.md
-        - integrations/builtin/credentials/sendy.md
-        - integrations/builtin/credentials/sentryio.md
-        - integrations/builtin/credentials/serp.md
-        - integrations/builtin/credentials/servicenow.md
-        - integrations/builtin/credentials/sms77.md
-        - integrations/builtin/credentials/shopify.md
-        - integrations/builtin/credentials/shuffler.md
-        - integrations/builtin/credentials/signl4.md
-        - integrations/builtin/credentials/slack.md
-        - integrations/builtin/credentials/snowflake.md
-        - integrations/builtin/credentials/solarwindsipam.md
-        - integrations/builtin/credentials/solarwindsobservability.md
-        - integrations/builtin/credentials/splunk.md
-        - integrations/builtin/credentials/spotify.md
-        - integrations/builtin/credentials/ssh.md
-        - integrations/builtin/credentials/stackby.md
-        - integrations/builtin/credentials/storyblok.md
-        - integrations/builtin/credentials/strapi.md
-        - integrations/builtin/credentials/strava.md
-        - integrations/builtin/credentials/stripe.md
-        - integrations/builtin/credentials/supabase.md
-        - integrations/builtin/credentials/surveymonkey.md
-        - integrations/builtin/credentials/syncromsp.md
-        - integrations/builtin/credentials/sysdig.md
-        - integrations/builtin/credentials/taiga.md
-        - integrations/builtin/credentials/tapfiliate.md
-        - integrations/builtin/credentials/telegram.md
-        - integrations/builtin/credentials/thehive.md
-        - integrations/builtin/credentials/thehive5.md
-        - integrations/builtin/credentials/timescaledb.md
-        - integrations/builtin/credentials/todoist.md
-        - integrations/builtin/credentials/toggl.md
-        - integrations/builtin/credentials/totp.md
-        - integrations/builtin/credentials/travisci.md
-        - integrations/builtin/credentials/trellixepo.md
-        - integrations/builtin/credentials/trello.md
-        - integrations/builtin/credentials/twake.md
-        - integrations/builtin/credentials/twilio.md
-        - integrations/builtin/credentials/twist.md
-        - integrations/builtin/credentials/typeform.md
-        - integrations/builtin/credentials/unleashedsoftware.md
-        - integrations/builtin/credentials/uplead.md
-        - integrations/builtin/credentials/uproc.md
-        - integrations/builtin/credentials/uptimerobot.md
-        - integrations/builtin/credentials/urlscanio.md
-        - integrations/builtin/credentials/venafitlsprotectcloud.md
-        - integrations/builtin/credentials/venafitlsprotectdatacenter.md
-        - integrations/builtin/credentials/vercel.md
-        - integrations/builtin/credentials/vero.md
-        - integrations/builtin/credentials/virustotal.md
-        - integrations/builtin/credentials/vonage.md
-        - integrations/builtin/credentials/weaviate.md        
-        - integrations/builtin/credentials/ciscowebex.md
-        - integrations/builtin/credentials/webflow.md
-        - integrations/builtin/credentials/webhook.md
-        - integrations/builtin/credentials/wekan.md
-        - integrations/builtin/credentials/whatsapp.md
-        - integrations/builtin/credentials/wise.md
-        - integrations/builtin/credentials/wolframalpha.md
-        - integrations/builtin/credentials/woocommerce.md
-        - integrations/builtin/credentials/wordpress.md
-        - integrations/builtin/credentials/workable.md
-        - integrations/builtin/credentials/wufoo.md
-        - integrations/builtin/credentials/twitter.md
-        - integrations/builtin/credentials/xai.md
-        - integrations/builtin/credentials/xata.md
-        - integrations/builtin/credentials/xero.md
-        - integrations/builtin/credentials/yourls.md
-        - integrations/builtin/credentials/zabbix.md
-        - integrations/builtin/credentials/zammad.md
-        - integrations/builtin/credentials/zendesk.md
-        - integrations/builtin/credentials/zep.md
-        - integrations/builtin/credentials/zoho.md
-        - integrations/builtin/credentials/zoom.md
-        - integrations/builtin/credentials/zscalerzia.md
-        - integrations/builtin/credentials/zulip.md
-      - Custom API actions for existing nodes: integrations/custom-operations.md
-      - Handle rate limits: integrations/builtin/rate-limits.md
-    - Community nodes:
-      - Installation and management:
-        - integrations/community-nodes/installation/index.md
-        - Install verified community nodes: integrations/community-nodes/installation/verified-install.md
-        - GUI installation: integrations/community-nodes/installation/gui-install.md
-        - Manual installation: integrations/community-nodes/installation/manual-install.md
-      - Risks: integrations/community-nodes/risks.md
-      - Blocklist: integrations/community-nodes/blocklist.md
-      - Using community nodes: integrations/community-nodes/usage.md
-      - Troubleshooting: integrations/community-nodes/troubleshooting.md
-      - Building community nodes: integrations/community-nodes/build-community-nodes.md
-    - Creating nodes:
-      - Overview: integrations/creating-nodes/overview.md
-      - Plan your node:
-        - integrations/creating-nodes/plan/index.md
-        - Choose a node type: integrations/creating-nodes/plan/node-types.md
-        - Choose a node building style: integrations/creating-nodes/plan/choose-node-method.md
-        - Node UI design: integrations/creating-nodes/plan/node-ui-design.md
-        - Choose node file structure: integrations/creating-nodes/build/reference/node-file-structure.md
-      - Build your node:
-        - integrations/creating-nodes/build/index.md
-        - Set up your development environment: integrations/creating-nodes/build/node-development-environment.md
-        - Using the n8n-node tool: integrations/creating-nodes/build/n8n-node.md
-        - "Tutorial: Build a declarative-style node": integrations/creating-nodes/build/declarative-style-node.md
-        - "Tutorial: Build a programmatic-style node": integrations/creating-nodes/build/programmatic-style-node.md
-        - Reference:
-          - integrations/creating-nodes/build/reference/index.md
-          - Node UI elements: integrations/creating-nodes/build/reference/ui-elements.md
-          - Code standards: integrations/creating-nodes/build/reference/code-standards.md
-          - Error handling: integrations/creating-nodes/build/reference/error-handling.md
-          - Versioning: integrations/creating-nodes/build/reference/node-versioning.md
-          - File structure: integrations/creating-nodes/build/reference/node-file-structure.md
-          - Base files:
-            - integrations/creating-nodes/build/reference/node-base-files/index.md
-            - Structure: integrations/creating-nodes/build/reference/node-base-files/structure.md
-            - Standard parameters: integrations/creating-nodes/build/reference/node-base-files/standard-parameters.md
-            - Declarative-style parameters: integrations/creating-nodes/build/reference/node-base-files/declarative-style-parameters.md
-            - Programmatic-style parameters: integrations/creating-nodes/build/reference/node-base-files/programmatic-style-parameters.md
-            - Programmatic-style execute method: integrations/creating-nodes/build/reference/node-base-files/programmatic-style-execute-method.md
-          - Codex files: integrations/creating-nodes/build/reference/node-codex-files.md
-          - Credentials files: integrations/creating-nodes/build/reference/credentials-files.md
-          - HTTP request helpers: integrations/creating-nodes/build/reference/http-helpers.md
-          - Item linking: integrations/creating-nodes/build/reference/paired-items.md
-          - UX guidelines: integrations/creating-nodes/build/reference/ux-guidelines.md
-          - Verification guidelines: integrations/creating-nodes/build/reference/verification-guidelines.md
-      - Test your node:
-        - integrations/creating-nodes/test/index.md
-        - Run your node locally: integrations/creating-nodes/test/run-node-locally.md
-        - Node linter: integrations/creating-nodes/test/node-linter.md
-        - Troubleshooting: integrations/creating-nodes/test/troubleshooting-node-development.md
-      - Deploy your node:
-        - integrations/creating-nodes/deploy/index.md
-        - Submit community nodes: integrations/creating-nodes/deploy/submit-community-nodes.md
-        - Install private nodes: integrations/creating-nodes/deploy/install-private-nodes.md
+      - integrations/index.md
+      - Built-in nodes:
+          - Node types: integrations/builtin/node-types.md
+          - Core nodes:
+              - integrations/builtin/core-nodes/index.md
+              - Activation Trigger: integrations/builtin/core-nodes/n8n-nodes-base.activationtrigger.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.aggregate.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.aitransform.md
+              - Code:
+                  - Code: integrations/builtin/core-nodes/n8n-nodes-base.code/index.md
+                  - Keyboard shortcuts: integrations/builtin/core-nodes/n8n-nodes-base.code/keyboard-shortcuts.md
+                  - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.code/common-issues.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.comparedatasets.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.compression.md
+              - Chat Trigger:
+                  - Chat Trigger: integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/index.md
+                  - Common issues: integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/common-issues.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.converttofile.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.crypto.md
+              - Data Table:
+                  - Data Table: integrations/builtin/core-nodes/n8n-nodes-base.datatable/index.md
+                  - Row operations: integrations/builtin/core-nodes/n8n-nodes-base.datatable/rows.md
+                  - Table operations: integrations/builtin/core-nodes/n8n-nodes-base.datatable/tables.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.datetime.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.debughelper.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.set.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.editimage.md
+              - Email Trigger (IMAP): integrations/builtin/core-nodes/n8n-nodes-base.emailimap.md
+              - Error Trigger: integrations/builtin/core-nodes/n8n-nodes-base.errortrigger.md
+              - Evaluation: integrations/builtin/core-nodes/n8n-nodes-base.evaluation.md
+              - Evaluation Trigger: integrations/builtin/core-nodes/n8n-nodes-base.evaluationtrigger.md
+              - Execute Command:
+                  - Execute Command: integrations/builtin/core-nodes/n8n-nodes-base.executecommand/index.md
+                  - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.executecommand/common-issues.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.executeworkflow.md
+              - Execute Sub-workflow Trigger: integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.executiondata.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.extractfromfile.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.filter.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.ftp.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.git.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.graphql.md
+              - Guardrails: integrations/builtin/core-nodes/n8n-nodes-langchain.guardrails.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.html.md
+              - HTTP Request:
+                  - HTTP Request: integrations/builtin/core-nodes/n8n-nodes-base.httprequest/index.md
+                  - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.httprequest/common-issues.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.if.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.jwt.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.ldap.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.limit.md
+              - Local File Trigger: integrations/builtin/core-nodes/n8n-nodes-base.localfiletrigger.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches.md
+              - Manual Trigger: integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.markdown.md
+              - MCP Client: integrations/builtin/core-nodes/n8n-nodes-langchain.mcpClient.md
+              - MCP Server Trigger: integrations/builtin/core-nodes/n8n-nodes-langchain.mcptrigger.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.merge.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.n8n.md
+              - n8n Form: integrations/builtin/core-nodes/n8n-nodes-base.form.md
+              - n8n Form Trigger: integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
+              - n8n Trigger: integrations/builtin/core-nodes/n8n-nodes-base.n8ntrigger.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.noop.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.readwritefile.md
+              - Remove Duplicates:
+                  - integrations/builtin/core-nodes/n8n-nodes-base.removeduplicates/index.md
+                  - Templates and examples: integrations/builtin/core-nodes/n8n-nodes-base.removeduplicates/templates-and-examples.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.renamekeys.md
+              - Chat: integrations/builtin/core-nodes/n8n-nodes-langchain.chat.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.respondtowebhook.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.rssfeedread.md
+              - RSS Feed Trigger: integrations/builtin/core-nodes/n8n-nodes-base.rssfeedreadtrigger.md
+              - Schedule Trigger:
+                  - Schedule Trigger: integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/index.md
+                  - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/common-issues.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.sendemail.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.sort.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.splitout.md
+              - SSE Trigger: integrations/builtin/core-nodes/n8n-nodes-base.ssetrigger.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.ssh.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.stopanderror.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.summarize.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.switch.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.totp.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.wait.md
+              - Webhook:
+                  - integrations/builtin/core-nodes/n8n-nodes-base.webhook/index.md
+                  - Workflow development: integrations/builtin/core-nodes/n8n-nodes-base.webhook/workflow-development.md
+                  - Common issues: integrations/builtin/core-nodes/n8n-nodes-base.webhook/common-issues.md
+              - Workflow Trigger: integrations/builtin/core-nodes/n8n-nodes-base.workflowtrigger.md
+              - integrations/builtin/core-nodes/n8n-nodes-base.xml.md
+          - Actions:
+              - integrations/builtin/app-nodes/index.md
+              - Action Network: integrations/builtin/app-nodes/n8n-nodes-base.actionnetwork.md
+              - ActiveCampaign: integrations/builtin/app-nodes/n8n-nodes-base.activecampaign.md
+              - Adalo: integrations/builtin/app-nodes/n8n-nodes-base.adalo.md
+              - Affinity: integrations/builtin/app-nodes/n8n-nodes-base.affinity.md
+              - Agile CRM: integrations/builtin/app-nodes/n8n-nodes-base.agilecrm.md
+              - Airtable:
+                  - Airtable: integrations/builtin/app-nodes/n8n-nodes-base.airtable/index.md
+                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.airtable/common-issues.md
+              - Airtop: integrations/builtin/app-nodes/n8n-nodes-base.airtop.md
+              - AMQP Sender: integrations/builtin/app-nodes/n8n-nodes-base.amqp.md
+              - Anthropic: integrations/builtin/app-nodes/n8n-nodes-langchain.anthropic.md
+              - APITemplate.io: integrations/builtin/app-nodes/n8n-nodes-base.apitemplateio.md
+              - Asana: integrations/builtin/app-nodes/n8n-nodes-base.asana.md
+              - Autopilot: integrations/builtin/app-nodes/n8n-nodes-base.autopilot.md
+              - AWS Certificate Manager: integrations/builtin/app-nodes/n8n-nodes-base.awscertificatemanager.md
+              - AWS Cognito: integrations/builtin/app-nodes/n8n-nodes-base.awscognito.md
+              - AWS Comprehend: integrations/builtin/app-nodes/n8n-nodes-base.awscomprehend.md
+              - AWS DynamoDB: integrations/builtin/app-nodes/n8n-nodes-base.awsdynamodb.md
+              - AWS Elastic Load Balancing: integrations/builtin/app-nodes/n8n-nodes-base.awselb.md
+              - AWS IAM: integrations/builtin/app-nodes/n8n-nodes-base.awsiam.md
+              - AWS Lambda: integrations/builtin/app-nodes/n8n-nodes-base.awslambda.md
+              - AWS Rekognition: integrations/builtin/app-nodes/n8n-nodes-base.awsrekognition.md
+              - AWS S3: integrations/builtin/app-nodes/n8n-nodes-base.awss3.md
+              - AWS SES: integrations/builtin/app-nodes/n8n-nodes-base.awsses.md
+              - AWS SNS: integrations/builtin/app-nodes/n8n-nodes-base.awssns.md
+              - AWS SQS: integrations/builtin/app-nodes/n8n-nodes-base.awssqs.md
+              - AWS Textract: integrations/builtin/app-nodes/n8n-nodes-base.awstextract.md
+              - AWS Transcribe: integrations/builtin/app-nodes/n8n-nodes-base.awstranscribe.md
+              - Azure Cosmos DB: integrations/builtin/app-nodes/n8n-nodes-base.azurecosmosdb.md
+              - Azure Storage: integrations/builtin/app-nodes/n8n-nodes-base.azurestorage.md
+              - BambooHR: integrations/builtin/app-nodes/n8n-nodes-base.bamboohr.md
+              - Bannerbear: integrations/builtin/app-nodes/n8n-nodes-base.bannerbear.md
+              - Baserow: integrations/builtin/app-nodes/n8n-nodes-base.baserow.md
+              - Beeminder: integrations/builtin/app-nodes/n8n-nodes-base.beeminder.md
+              - Bitly: integrations/builtin/app-nodes/n8n-nodes-base.bitly.md
+              - Bitwarden: integrations/builtin/app-nodes/n8n-nodes-base.bitwarden.md
+              - Box: integrations/builtin/app-nodes/n8n-nodes-base.box.md
+              - Brandfetch: integrations/builtin/app-nodes/n8n-nodes-base.brandfetch.md
+              - Brevo: integrations/builtin/app-nodes/n8n-nodes-base.brevo.md
+              - Bubble: integrations/builtin/app-nodes/n8n-nodes-base.bubble.md
+              - Chargebee: integrations/builtin/app-nodes/n8n-nodes-base.chargebee.md
+              - CircleCI: integrations/builtin/app-nodes/n8n-nodes-base.circleci.md
+              - Webex by Cisco: integrations/builtin/app-nodes/n8n-nodes-base.ciscowebex.md
+              - Clearbit: integrations/builtin/app-nodes/n8n-nodes-base.clearbit.md
+              - ClickUp: integrations/builtin/app-nodes/n8n-nodes-base.clickup.md
+              - Clockify: integrations/builtin/app-nodes/n8n-nodes-base.clockify.md
+              - Cloudflare: integrations/builtin/app-nodes/n8n-nodes-base.cloudflare.md
+              - Cockpit: integrations/builtin/app-nodes/n8n-nodes-base.cockpit.md
+              - Coda: integrations/builtin/app-nodes/n8n-nodes-base.coda.md
+              - CoinGecko: integrations/builtin/app-nodes/n8n-nodes-base.coingecko.md
+              - Contentful: integrations/builtin/app-nodes/n8n-nodes-base.contentful.md
+              - ConvertKit: integrations/builtin/app-nodes/n8n-nodes-base.convertkit.md
+              - Copper: integrations/builtin/app-nodes/n8n-nodes-base.copper.md
+              - Cortex: integrations/builtin/app-nodes/n8n-nodes-base.cortex.md
+              - CrateDB: integrations/builtin/app-nodes/n8n-nodes-base.cratedb.md
+              - crowd.dev: integrations/builtin/app-nodes/n8n-nodes-base.crowddev.md
+              - Customer.io: integrations/builtin/app-nodes/n8n-nodes-base.customerio.md
+              - Databricks: integrations/builtin/app-nodes/n8n-nodes-base.databricks.md
+              - DeepL: integrations/builtin/app-nodes/n8n-nodes-base.deepl.md
+              - Demio: integrations/builtin/app-nodes/n8n-nodes-base.demio.md
+              - DHL: integrations/builtin/app-nodes/n8n-nodes-base.dhl.md
+              - Discord:
+                  - Discord: integrations/builtin/app-nodes/n8n-nodes-base.discord/index.md
+                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.discord/common-issues.md
+              - Discourse: integrations/builtin/app-nodes/n8n-nodes-base.discourse.md
+              - Disqus: integrations/builtin/app-nodes/n8n-nodes-base.disqus.md
+              - Drift: integrations/builtin/app-nodes/n8n-nodes-base.drift.md
+              - Dropbox: integrations/builtin/app-nodes/n8n-nodes-base.dropbox.md
+              - Dropcontact: integrations/builtin/app-nodes/n8n-nodes-base.dropcontact.md
+              - E-goi: integrations/builtin/app-nodes/n8n-nodes-base.egoi.md
+              - Elasticsearch: integrations/builtin/app-nodes/n8n-nodes-base.elasticsearch.md
+              - Elastic Security: integrations/builtin/app-nodes/n8n-nodes-base.elasticsecurity.md
+              - Emelia: integrations/builtin/app-nodes/n8n-nodes-base.emelia.md
+              - ERPNext: integrations/builtin/app-nodes/n8n-nodes-base.erpnext.md
+              - Facebook Graph API: integrations/builtin/app-nodes/n8n-nodes-base.facebookgraphapi.md
+              - FileMaker: integrations/builtin/app-nodes/n8n-nodes-base.filemaker.md
+              - Flow: integrations/builtin/app-nodes/n8n-nodes-base.flow.md
+              - Freshdesk: integrations/builtin/app-nodes/n8n-nodes-base.freshdesk.md
+              - Freshservice: integrations/builtin/app-nodes/n8n-nodes-base.freshservice.md
+              - Freshworks CRM: integrations/builtin/app-nodes/n8n-nodes-base.freshworkscrm.md
+              - GetResponse: integrations/builtin/app-nodes/n8n-nodes-base.getresponse.md
+              - Ghost: integrations/builtin/app-nodes/n8n-nodes-base.ghost.md
+              - GitHub: integrations/builtin/app-nodes/n8n-nodes-base.github.md
+              - GitLab: integrations/builtin/app-nodes/n8n-nodes-base.gitlab.md
+              - Gmail:
+                  - Gmail: integrations/builtin/app-nodes/n8n-nodes-base.gmail/index.md
+                  - Draft operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/draft-operations.md
+                  - Label operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/label-operations.md
+                  - Message operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/message-operations.md
+                  - Thread operations: integrations/builtin/app-nodes/n8n-nodes-base.gmail/thread-operations.md
+                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.gmail/common-issues.md
+              - Gong: integrations/builtin/app-nodes/n8n-nodes-base.gong.md
+              - Google Ads: integrations/builtin/app-nodes/n8n-nodes-base.googleads.md
+              - Google Analytics: integrations/builtin/app-nodes/n8n-nodes-base.googleanalytics.md
+              - Google BigQuery: integrations/builtin/app-nodes/n8n-nodes-base.googlebigquery.md
+              - Google Books: integrations/builtin/app-nodes/n8n-nodes-base.googlebooks.md
+              - Google Business Profile: integrations/builtin/app-nodes/n8n-nodes-base.googlebusinessprofile.md
+              - Google Calendar:
+                  - Google Calendar: integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/index.md
+                  - Calendar operations: integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/calendar-operations.md
+                  - Event operations: integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/event-operations.md
+              - Google Chat: integrations/builtin/app-nodes/n8n-nodes-base.googlechat.md
+              - Google Cloud Firestore: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudfirestore.md
+              - Google Cloud Natural Language: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudnaturallanguage.md
+              - Google Cloud Realtime Database: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudrealtimedatabase.md
+              - Google Cloud Storage: integrations/builtin/app-nodes/n8n-nodes-base.googlecloudstorage.md
+              - Google Contacts: integrations/builtin/app-nodes/n8n-nodes-base.googlecontacts.md
+              - Google Docs: integrations/builtin/app-nodes/n8n-nodes-base.googledocs.md
+              - Google Drive:
+                  - Google Drive: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/index.md
+                  - File operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/file-operations.md
+                  - File and folder operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/file-folder-operations.md
+                  - Folder operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/folder-operations.md
+                  - Shared drive operations: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/shared-drive-operations.md
+                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.googledrive/common-issues.md
+              - Google Gemini: integrations/builtin/app-nodes/n8n-nodes-langchain.googlegemini.md
+              - Google Perspective: integrations/builtin/app-nodes/n8n-nodes-base.googleperspective.md
+              - Google Sheets:
+                  - Google Sheets: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/index.md
+                  - Document operations: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/document-operations.md
+                  - Sheet within Document operations: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/sheet-operations.md
+                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.googlesheets/common-issues.md
+              - Google Slides: integrations/builtin/app-nodes/n8n-nodes-base.googleslides.md
+              - Google Tasks: integrations/builtin/app-nodes/n8n-nodes-base.googletasks.md
+              - Google Translate: integrations/builtin/app-nodes/n8n-nodes-base.googletranslate.md
+              - Google Workspace Admin: integrations/builtin/app-nodes/n8n-nodes-base.gsuiteadmin.md
+              - Gotify: integrations/builtin/app-nodes/n8n-nodes-base.gotify.md
+              - GoToWebinar: integrations/builtin/app-nodes/n8n-nodes-base.gotowebinar.md
+              - Grafana: integrations/builtin/app-nodes/n8n-nodes-base.grafana.md
+              - Grist: integrations/builtin/app-nodes/n8n-nodes-base.grist.md
+              - Hacker News: integrations/builtin/app-nodes/n8n-nodes-base.hackernews.md
+              - HaloPSA: integrations/builtin/app-nodes/n8n-nodes-base.halopsa.md
+              - Harvest: integrations/builtin/app-nodes/n8n-nodes-base.harvest.md
+              - Help Scout: integrations/builtin/app-nodes/n8n-nodes-base.helpscout.md
+              - HighLevel: integrations/builtin/app-nodes/n8n-nodes-base.highlevel.md
+              - Home Assistant: integrations/builtin/app-nodes/n8n-nodes-base.homeassistant.md
+              - HubSpot: integrations/builtin/app-nodes/n8n-nodes-base.hubspot.md
+              - Humantic AI: integrations/builtin/app-nodes/n8n-nodes-base.humanticai.md
+              - Hunter: integrations/builtin/app-nodes/n8n-nodes-base.hunter.md
+              - Intercom: integrations/builtin/app-nodes/n8n-nodes-base.intercom.md
+              - Invoice Ninja: integrations/builtin/app-nodes/n8n-nodes-base.invoiceninja.md
+              - Iterable: integrations/builtin/app-nodes/n8n-nodes-base.iterable.md
+              - Jenkins: integrations/builtin/app-nodes/n8n-nodes-base.jenkins.md
+              - Jina AI: integrations/builtin/app-nodes/n8n-nodes-base.jinaai.md
+              - Jira Software: integrations/builtin/app-nodes/n8n-nodes-base.jira.md
+              - Kafka: integrations/builtin/app-nodes/n8n-nodes-base.kafka.md
+              - Keap: integrations/builtin/app-nodes/n8n-nodes-base.keap.md
+              - Kitemaker: integrations/builtin/app-nodes/n8n-nodes-base.kitemaker.md
+              - KoboToolbox: integrations/builtin/app-nodes/n8n-nodes-base.kobotoolbox.md
+              - Lemlist: integrations/builtin/app-nodes/n8n-nodes-base.lemlist.md
+              - Line: integrations/builtin/app-nodes/n8n-nodes-base.line.md
+              - Linear: integrations/builtin/app-nodes/n8n-nodes-base.linear.md
+              - LingvaNex: integrations/builtin/app-nodes/n8n-nodes-base.lingvanex.md
+              - LinkedIn: integrations/builtin/app-nodes/n8n-nodes-base.linkedin.md
+              - LoneScale: integrations/builtin/app-nodes/n8n-nodes-base.lonescale.md
+              - Magento 2: integrations/builtin/app-nodes/n8n-nodes-base.magento2.md
+              - Mailcheck: integrations/builtin/app-nodes/n8n-nodes-base.mailcheck.md
+              - Mailchimp: integrations/builtin/app-nodes/n8n-nodes-base.mailchimp.md
+              - MailerLite: integrations/builtin/app-nodes/n8n-nodes-base.mailerlite.md
+              - Mailgun: integrations/builtin/app-nodes/n8n-nodes-base.mailgun.md
+              - Mailjet: integrations/builtin/app-nodes/n8n-nodes-base.mailjet.md
+              - Mandrill: integrations/builtin/app-nodes/n8n-nodes-base.mandrill.md
+              - marketstack: integrations/builtin/app-nodes/n8n-nodes-base.marketstack.md
+              - Matrix: integrations/builtin/app-nodes/n8n-nodes-base.matrix.md
+              - Mattermost: integrations/builtin/app-nodes/n8n-nodes-base.mattermost.md
+              - Mautic: integrations/builtin/app-nodes/n8n-nodes-base.mautic.md
+              - Medium: integrations/builtin/app-nodes/n8n-nodes-base.medium.md
+              - MessageBird: integrations/builtin/app-nodes/n8n-nodes-base.messagebird.md
+              - Metabase: integrations/builtin/app-nodes/n8n-nodes-base.metabase.md
+              - Microsoft Dynamics CRM: integrations/builtin/app-nodes/n8n-nodes-base.microsoftdynamicscrm.md
+              - Microsoft Entra ID: integrations/builtin/app-nodes/n8n-nodes-base.microsoftentra.md
+              - Microsoft Excel 365: integrations/builtin/app-nodes/n8n-nodes-base.microsoftexcel.md
+              - Microsoft Graph Security: integrations/builtin/app-nodes/n8n-nodes-base.microsoftgraphsecurity.md
+              - Microsoft OneDrive: integrations/builtin/app-nodes/n8n-nodes-base.microsoftonedrive.md
+              - Microsoft Outlook: integrations/builtin/app-nodes/n8n-nodes-base.microsoftoutlook.md
+              - Microsoft SharePoint: integrations/builtin/app-nodes/n8n-nodes-base.microsoftsharepoint.md
+              - Microsoft SQL: integrations/builtin/app-nodes/n8n-nodes-base.microsoftsql.md
+              - Microsoft Teams: integrations/builtin/app-nodes/n8n-nodes-base.microsoftteams.md
+              - Microsoft To Do: integrations/builtin/app-nodes/n8n-nodes-base.microsofttodo.md
+              - Mindee: integrations/builtin/app-nodes/n8n-nodes-base.mindee.md
+              - MISP: integrations/builtin/app-nodes/n8n-nodes-base.misp.md
+              - Mistral AI: integrations/builtin/app-nodes/n8n-nodes-base.mistralai.md
+              - Mocean: integrations/builtin/app-nodes/n8n-nodes-base.mocean.md
+              - monday.com: integrations/builtin/app-nodes/n8n-nodes-base.mondaycom.md
+              - MongoDB: integrations/builtin/app-nodes/n8n-nodes-base.mongodb.md
+              - Monica CRM: integrations/builtin/app-nodes/n8n-nodes-base.monicacrm.md
+              - MQTT: integrations/builtin/app-nodes/n8n-nodes-base.mqtt.md
+              - MSG91: integrations/builtin/app-nodes/n8n-nodes-base.msg91.md
+              - MySQL:
+                  - MySQL: integrations/builtin/app-nodes/n8n-nodes-base.mysql/index.md
+                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.mysql/common-issues.md
+              - Customer Datastore (n8n Training): integrations/builtin/app-nodes/n8n-nodes-base.n8ntrainingcustomerdatastore.md
+              - Customer Messenger (n8n Training): integrations/builtin/app-nodes/n8n-nodes-base.n8ntrainingcustomermessenger.md
+              - NASA: integrations/builtin/app-nodes/n8n-nodes-base.nasa.md
+              - Netlify: integrations/builtin/app-nodes/n8n-nodes-base.netlify.md
+              - Netscaler ADC: integrations/builtin/app-nodes/n8n-nodes-base.netscaleradc.md
+              - Nextcloud: integrations/builtin/app-nodes/n8n-nodes-base.nextcloud.md
+              - NocoDB: integrations/builtin/app-nodes/n8n-nodes-base.nocodb.md
+              - Notion:
+                  - Notion: integrations/builtin/app-nodes/n8n-nodes-base.notion/index.md
+                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.notion/common-issues.md
+              - npm: integrations/builtin/app-nodes/n8n-nodes-base.npm.md
+              - Odoo: integrations/builtin/app-nodes/n8n-nodes-base.odoo.md
+              - Okta: integrations/builtin/app-nodes/n8n-nodes-base.okta.md
+              - One Simple API: integrations/builtin/app-nodes/n8n-nodes-base.onesimpleapi.md
+              - Onfleet: integrations/builtin/app-nodes/n8n-nodes-base.onfleet.md
+              - OpenAI:
+                  - OpenAI: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/index.md
+                  - Assistant operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/assistant-operations.md
+                  - Audio operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/audio-operations.md
+                  - Conversation operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/conversation-operations.md
+                  - File operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/file-operations.md
+                  - Image operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/image-operations.md
+                  - Text operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/text-operations.md
+                  - Video operations: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/video-operations.md
+                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-langchain.openai/common-issues.md
+              - OpenThesaurus: integrations/builtin/app-nodes/n8n-nodes-base.openthesaurus.md
+              - OpenWeatherMap: integrations/builtin/app-nodes/n8n-nodes-base.openweathermap.md
+              - Oracle Database:
+                  - Oracle Database: integrations/builtin/app-nodes/n8n-nodes-base.oracledb/index.md
+              - Oura: integrations/builtin/app-nodes/n8n-nodes-base.oura.md
+              - Paddle: integrations/builtin/app-nodes/n8n-nodes-base.paddle.md
+              - PagerDuty: integrations/builtin/app-nodes/n8n-nodes-base.pagerduty.md
+              - PayPal: integrations/builtin/app-nodes/n8n-nodes-base.paypal.md
+              - Peekalink: integrations/builtin/app-nodes/n8n-nodes-base.peekalink.md
+              - Perplexity: integrations/builtin/app-nodes/n8n-nodes-langchain.perplexity.md
+              - PhantomBuster: integrations/builtin/app-nodes/n8n-nodes-base.phantombuster.md
+              - Philips Hue: integrations/builtin/app-nodes/n8n-nodes-base.philipshue.md
+              - Pipedrive: integrations/builtin/app-nodes/n8n-nodes-base.pipedrive.md
+              - Plivo: integrations/builtin/app-nodes/n8n-nodes-base.plivo.md
+              - PostBin: integrations/builtin/app-nodes/n8n-nodes-base.postbin.md
+              - Postgres:
+                  - Postgres: integrations/builtin/app-nodes/n8n-nodes-base.postgres/index.md
+                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.postgres/common-issues.md
+              - PostHog: integrations/builtin/app-nodes/n8n-nodes-base.posthog.md
+              - ProfitWell: integrations/builtin/app-nodes/n8n-nodes-base.profitwell.md
+              - Pushbullet: integrations/builtin/app-nodes/n8n-nodes-base.pushbullet.md
+              - Pushcut: integrations/builtin/app-nodes/n8n-nodes-base.pushcut.md
+              - Pushover: integrations/builtin/app-nodes/n8n-nodes-base.pushover.md
+              - QuestDB: integrations/builtin/app-nodes/n8n-nodes-base.questdb.md
+              - Quick Base: integrations/builtin/app-nodes/n8n-nodes-base.quickbase.md
+              - QuickBooks Online: integrations/builtin/app-nodes/n8n-nodes-base.quickbooks.md
+              - QuickChart: integrations/builtin/app-nodes/n8n-nodes-base.quickchart.md
+              - RabbitMQ: integrations/builtin/app-nodes/n8n-nodes-base.rabbitmq.md
+              - Raindrop: integrations/builtin/app-nodes/n8n-nodes-base.raindrop.md
+              - Reddit: integrations/builtin/app-nodes/n8n-nodes-base.reddit.md
+              - Redis: integrations/builtin/app-nodes/n8n-nodes-base.redis.md
+              - Rocket.Chat: integrations/builtin/app-nodes/n8n-nodes-base.rocketchat.md
+              - Rundeck: integrations/builtin/app-nodes/n8n-nodes-base.rundeck.md
+              - S3: integrations/builtin/app-nodes/n8n-nodes-base.s3.md
+              - Salesforce: integrations/builtin/app-nodes/n8n-nodes-base.salesforce.md
+              - Salesmate: integrations/builtin/app-nodes/n8n-nodes-base.salesmate.md
+              - SeaTable: integrations/builtin/app-nodes/n8n-nodes-base.seatable.md
+              - SecurityScorecard: integrations/builtin/app-nodes/n8n-nodes-base.securityscorecard.md
+              - Segment: integrations/builtin/app-nodes/n8n-nodes-base.segment.md
+              - SendGrid: integrations/builtin/app-nodes/n8n-nodes-base.sendgrid.md
+              - Sendy: integrations/builtin/app-nodes/n8n-nodes-base.sendy.md
+              - Sentry.io: integrations/builtin/app-nodes/n8n-nodes-base.sentryio.md
+              - ServiceNow: integrations/builtin/app-nodes/n8n-nodes-base.servicenow.md
+              - seven: integrations/builtin/app-nodes/n8n-nodes-base.sms77.md
+              - Shopify: integrations/builtin/app-nodes/n8n-nodes-base.shopify.md
+              - SIGNL4: integrations/builtin/app-nodes/n8n-nodes-base.signl4.md
+              - Slack: integrations/builtin/app-nodes/n8n-nodes-base.slack.md
+              - Snowflake: integrations/builtin/app-nodes/n8n-nodes-base.snowflake.md
+              - Splunk: integrations/builtin/app-nodes/n8n-nodes-base.splunk.md
+              - Spotify: integrations/builtin/app-nodes/n8n-nodes-base.spotify.md
+              - Stackby: integrations/builtin/app-nodes/n8n-nodes-base.stackby.md
+              - Storyblok: integrations/builtin/app-nodes/n8n-nodes-base.storyblok.md
+              - Strapi: integrations/builtin/app-nodes/n8n-nodes-base.strapi.md
+              - Strava: integrations/builtin/app-nodes/n8n-nodes-base.strava.md
+              - Stripe: integrations/builtin/app-nodes/n8n-nodes-base.stripe.md
+              - Supabase:
+                  - Supabase: integrations/builtin/app-nodes/n8n-nodes-base.supabase/index.md
+                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.supabase/common-issues.md
+              - SyncroMSP: integrations/builtin/app-nodes/n8n-nodes-base.syncromsp.md
+              - Taiga: integrations/builtin/app-nodes/n8n-nodes-base.taiga.md
+              - Tapfiliate: integrations/builtin/app-nodes/n8n-nodes-base.tapfiliate.md
+              - Telegram:
+                  - integrations/builtin/app-nodes/n8n-nodes-base.telegram/index.md
+                  - Chat operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/chat-operations.md
+                  - Callback operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/callback-operations.md
+                  - File operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/file-operations.md
+                  - Message operations: integrations/builtin/app-nodes/n8n-nodes-base.telegram/message-operations.md
+                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.telegram/common-issues.md
+              - TheHive: integrations/builtin/app-nodes/n8n-nodes-base.thehive.md
+              - TheHive 5: integrations/builtin/app-nodes/n8n-nodes-base.thehive5.md
+              - TimescaleDB: integrations/builtin/app-nodes/n8n-nodes-base.timescaledb.md
+              - Todoist: integrations/builtin/app-nodes/n8n-nodes-base.todoist.md
+              - Travis CI: integrations/builtin/app-nodes/n8n-nodes-base.travisci.md
+              - Trello: integrations/builtin/app-nodes/n8n-nodes-base.trello.md
+              - Twake: integrations/builtin/app-nodes/n8n-nodes-base.twake.md
+              - Twilio: integrations/builtin/app-nodes/n8n-nodes-base.twilio.md
+              - Twist: integrations/builtin/app-nodes/n8n-nodes-base.twist.md
+              - Unleashed Software: integrations/builtin/app-nodes/n8n-nodes-base.unleashedsoftware.md
+              - UpLead: integrations/builtin/app-nodes/n8n-nodes-base.uplead.md
+              - uProc: integrations/builtin/app-nodes/n8n-nodes-base.uproc.md
+              - UptimeRobot: integrations/builtin/app-nodes/n8n-nodes-base.uptimerobot.md
+              - urlscan.io: integrations/builtin/app-nodes/n8n-nodes-base.urlscanio.md
+              - Venafi TLS Protect Cloud: integrations/builtin/app-nodes/n8n-nodes-base.venafitlsprotectcloud.md
+              - Venafi TLS Protect Datacenter: integrations/builtin/app-nodes/n8n-nodes-base.venafitlsprotectdatacenter.md
+              - Vero: integrations/builtin/app-nodes/n8n-nodes-base.vero.md
+              - Vonage: integrations/builtin/app-nodes/n8n-nodes-base.vonage.md
+              - Webflow: integrations/builtin/app-nodes/n8n-nodes-base.webflow.md
+              - Wekan: integrations/builtin/app-nodes/n8n-nodes-base.wekan.md
+              - WhatsApp Business Cloud:
+                  - WhatsApp Business Cloud: integrations/builtin/app-nodes/n8n-nodes-base.whatsapp/index.md
+                  - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.whatsapp/common-issues.md
+              - Wise: integrations/builtin/app-nodes/n8n-nodes-base.wise.md
+              - WooCommerce: integrations/builtin/app-nodes/n8n-nodes-base.woocommerce.md
+              - WordPress: integrations/builtin/app-nodes/n8n-nodes-base.wordpress.md
+              - X (Formerly Twitter): integrations/builtin/app-nodes/n8n-nodes-base.twitter.md
+              - Xero: integrations/builtin/app-nodes/n8n-nodes-base.xero.md
+              - Yourls: integrations/builtin/app-nodes/n8n-nodes-base.yourls.md
+              - YouTube: integrations/builtin/app-nodes/n8n-nodes-base.youtube.md
+              - Zammad: integrations/builtin/app-nodes/n8n-nodes-base.zammad.md
+              - Zendesk: integrations/builtin/app-nodes/n8n-nodes-base.zendesk.md
+              - Zoho CRM: integrations/builtin/app-nodes/n8n-nodes-base.zohocrm.md
+              - Zoom: integrations/builtin/app-nodes/n8n-nodes-base.zoom.md
+              - Zulip: integrations/builtin/app-nodes/n8n-nodes-base.zulip.md
+          - Triggers:
+              - integrations/builtin/trigger-nodes/index.md
+              - ActiveCampaign Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.activecampaigntrigger.md
+              - Acuity Scheduling Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.acuityschedulingtrigger.md
+              - Affinity Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.affinitytrigger.md
+              - Airtable Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.airtabletrigger.md
+              - AMQP Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.amqptrigger.md
+              - Asana Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.asanatrigger.md
+              - Autopilot Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.autopilottrigger.md
+              - AWS SNS Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.awssnstrigger.md
+              - Bitbucket Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.bitbuckettrigger.md
+              - Box Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.boxtrigger.md
+              - Brevo Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.brevotrigger.md
+              - Calendly Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.calendlytrigger.md
+              - Cal Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.caltrigger.md
+              - Chargebee Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.chargebeetrigger.md
+              - ClickUp Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.clickuptrigger.md
+              - Clockify Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.clockifytrigger.md
+              - ConvertKit Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.convertkittrigger.md
+              - Copper Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.coppertrigger.md
+              - crowd.dev Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.crowddevtrigger.md
+              - Customer.io Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.customeriotrigger.md
+              - Emelia Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.emeliatrigger.md
+              - Eventbrite Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.eventbritetrigger.md
+              - Facebook Lead Ads Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.facebookleadadstrigger.md
+              - Facebook Trigger:
+                  - Facebook Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/index.md
+                  - Ad Account: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/ad-account.md
+                  - Application: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/application.md
+                  - Certificate Transparency: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/certificate-transparency.md
+                  - Group: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/group.md
+                  - Instagram: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/instagram.md
+                  - Link: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/link.md
+                  - Page: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/page.md
+                  - Permissions: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/permissions.md
+                  - User: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/user.md
+                  - WhatsApp Business Account: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/whatsapp.md
+                  - Workplace Security: integrations/builtin/trigger-nodes/n8n-nodes-base.facebooktrigger/workplace-security.md
+              - Figma Trigger (Beta): integrations/builtin/trigger-nodes/n8n-nodes-base.figmatrigger.md
+              - Flow Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.flowtrigger.md
+              - Form.io Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.formiotrigger.md
+              - Formstack Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.formstacktrigger.md
+              - GetResponse Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.getresponsetrigger.md
+              - GitHub Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.githubtrigger.md
+              - GitLab Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.gitlabtrigger.md
+              - Gmail Trigger:
+                  - integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/index.md
+                  - Poll Mode options: integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/poll-mode-options.md
+                  - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/common-issues.md
+              - Google Calendar Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googlecalendartrigger.md
+              - Google Drive Trigger:
+                  - Google Drive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googledrivetrigger/index.md
+                  - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.googledrivetrigger/common-issues.md
+              - Google Business Profile Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googlebusinessprofiletrigger.md
+              - Google Sheets Trigger:
+                  - Google Sheets Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.googlesheetstrigger/index.md
+                  - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.googlesheetstrigger/common-issues.md
+              - Gumroad Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.gumroadtrigger.md
+              - Help Scout Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.helpscouttrigger.md
+              - Hubspot Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.hubspottrigger.md
+              - Invoice Ninja Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.invoiceninjatrigger.md
+              - Jira Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.jiratrigger.md
+              - Jotform Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.jotformtrigger.md
+              - Kafka Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.kafkatrigger.md
+              - Keap Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.keaptrigger.md
+              - KoboToolbox Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.kobotoolboxtrigger.md
+              - Lemlist Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.lemlisttrigger.md
+              - Linear Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.lineartrigger.md
+              - LoneScale Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.lonescaletrigger.md
+              - Mailchimp Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mailchimptrigger.md
+              - MailerLite Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mailerlitetrigger.md
+              - Mailjet Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mailjettrigger.md
+              - Mautic Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mautictrigger.md
+              - Microsoft OneDrive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftonedrivetrigger.md
+              - Microsoft Outlook Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftoutlooktrigger.md
+              - Microsoft Teams Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftteamstrigger.md
+              - MQTT Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.mqtttrigger.md
+              - Netlify Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.netlifytrigger.md
+              - Notion Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.notiontrigger.md
+              - Onfleet Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.onfleettrigger.md
+              - PayPal Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.paypaltrigger.md
+              - Pipedrive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.pipedrivetrigger.md
+              - Postgres Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.postgrestrigger.md
+              - Postmark Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.postmarktrigger.md
+              - Pushcut Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.pushcuttrigger.md
+              - RabbitMQ Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.rabbitmqtrigger.md
+              - Redis Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.redistrigger.md
+              - Salesforce Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.salesforcetrigger.md
+              - SeaTable Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.seatabletrigger.md
+              - Shopify Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.shopifytrigger.md
+              - Slack Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
+              - Strava Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.stravatrigger.md
+              - Stripe Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.stripetrigger.md
+              - SurveyMonkey Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.surveymonkeytrigger.md
+              - Taiga Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.taigatrigger.md
+              - Telegram Trigger:
+                  - Telegram Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.telegramtrigger/index.md
+                  - Common issues: integrations/builtin/trigger-nodes/n8n-nodes-base.telegramtrigger/common-issues.md
+              - TheHive 5 Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.thehive5trigger.md
+              - TheHive Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.thehivetrigger.md
+              - Toggl Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.toggltrigger.md
+              - Trello Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.trellotrigger.md
+              - Twilio Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.twiliotrigger.md
+              - Typeform Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.typeformtrigger.md
+              - Venafi TLS Protect Cloud Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.venafitlsprotectcloudtrigger.md
+              - Webex by Cisco Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.ciscowebextrigger.md
+              - Webflow Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.webflowtrigger.md
+              - WhatsApp Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.whatsapptrigger.md
+              - Wise Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.wisetrigger.md
+              - WooCommerce Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.woocommercetrigger.md
+              - Workable Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.workabletrigger.md
+              - Wufoo Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.wufootrigger.md
+              - Zendesk Trigger: integrations/builtin/trigger-nodes/n8n-nodes-base.zendesktrigger.md
+          - Cluster nodes:
+              - integrations/builtin/cluster-nodes/index.md
+              - Root nodes:
+                  - integrations/builtin/cluster-nodes/root-nodes/index.md
+                  - AI Agent:
+                      - AI Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/index.md
+                      - Conversational Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/conversational-agent.md
+                      - OpenAI Functions Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/openai-functions-agent.md
+                      - Plan and Execute Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/plan-execute-agent.md
+                      - ReAct Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/react-agent.md
+                      - SQL Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/sql-agent.md
+                      - Tools Agent: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
+                      - Common issues: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/common-issues.md
+                  - Basic LLM Chain: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainllm.md
+                  - Question and Answer Chain:
+                      - Question and Answer Chain: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainretrievalqa/index.md
+                      - Common issues: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainretrievalqa/common-issues.md
+                  - Summarization Chain: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.chainsummarization.md
+                  - Information Extractor: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.information-extractor.md
+                  - Text Classifier: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.text-classifier.md
+                  - Sentiment Analysis: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.sentimentanalysis.md
+                  - LangChain Code: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.code.md
+                  - Microsoft Agent 365 Trigger: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.microsoftagent365trigger/index.md
+                  - Azure AI Search Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreazureaisearch.md
+                  - Simple Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreinmemory.md
+                  - Milvus Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremilvus.md
+                  - MongoDB Atlas Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoremongodbatlas.md
+                  - PGVector Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepgvector.md
+                  - Chroma Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorechroma.md
+                  - Pinecone Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepinecone.md
+                  - Qdrant Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreqdrant.md
+                  - Redis Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreredis.md
+                  - Supabase Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoresupabase.md
+                  - Weaviate Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreweaviate.md
+                  - Zep Vector Store: integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorezep.md
+              - Sub-nodes:
+                  - integrations/builtin/cluster-nodes/sub-nodes/index.md
+                  - Default Data Loader: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentdefaultdataloader.md
+                  - GitHub Document Loader: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.documentgithubloader.md
+                  - Embeddings AWS Bedrock: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsawsbedrock.md
+                  - Embeddings Azure OpenAI: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsazureopenai.md
+                  - Embeddings Cohere: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingscohere.md
+                  - Embeddings Google Gemini: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsgooglegemini.md
+                  - Embeddings Google PaLM: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsgooglepalm.md
+                  - Embeddings Google Vertex: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsgooglevertex.md
+                  - Embeddings HuggingFace Inference: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingshuggingfaceinference.md
+                  - Embeddings Lemonade: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingslemonade.md
+                  - Embeddings Mistral Cloud: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsmistralcloud.md
+                  - Embeddings Ollama: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsollama.md
+                  - Embeddings OpenAI: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsopenai.md
+                  - Anthropic Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatanthropic.md
+                  - AWS Bedrock Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatawsbedrock.md
+                  - Azure OpenAI Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatazureopenai.md
+                  - Cohere Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatcohere.md
+                  - DeepSeek Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatdeepseek.md
+                  - Google Gemini Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgooglegemini.md
+                  - Google Vertex Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgooglevertex.md
+                  - Groq Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgroq.md
+                  - Lemonade Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatlemonade.md
+                  - Mistral Cloud Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatmistralcloud.md
+                  - Ollama Chat Model:
+                      - Ollama Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatollama/index.md
+                      - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatollama/common-issues.md
+                  - OpenAI Chat Model:
+                      - OpenAI Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai/index.md
+                      - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai/common-issues.md
+                  - OpenRouter Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenrouter.md
+                  - Vercel AI Gateway Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatvercel.md
+                  - xAI Grok Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatxaigrok.md
+                  - Cohere Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmcohere.md
+                  - Lemonade Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmlemonade.md
+                  - Ollama Model:
+                      - Ollama Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmollama/index.md
+                      - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmollama/common-issues.md
+                  - Hugging Face Inference Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmopenhuggingfaceinference.md
+                  - Chat Memory Manager: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorymanager.md
+                  - Simple Memory:
+                      - integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorybufferwindow/index.md
+                      - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorybufferwindow/common-issues.md
+                  - Motorhead: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorymotorhead.md
+                  - MongoDB Chat Memory: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorymongochat.md
+                  - Redis Chat Memory: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memoryredischat.md
+                  - Postgres Chat Memory: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memorypostgreschat.md
+                  - Xata: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memoryxata.md
+                  - Zep: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.memoryzep.md
+                  - Auto-fixing Output Parser: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparserautofixing.md
+                  - Item List Output Parser: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparseritemlist.md
+                  - Structured Output Parser:
+                      - Structured Output Parser: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparserstructured/index.md
+                      - Common issues: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.outputparserstructured/common-issues.md
+                  - Contextual Compression Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrievercontextualcompression.md
+                  - MultiQuery Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrievermultiquery.md
+                  - Vector Store Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrievervectorstore.md
+                  - Workflow Retriever: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.retrieverworkflow.md
+                  - Character Text Splitter: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.textsplittercharactertextsplitter.md
+                  - Recursive Character Text Splitter: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.textsplitterrecursivecharactertextsplitter.md
+                  - Token Splitter: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.textsplittertokensplitter.md
+                  - AI Agent Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolaiagent.md
+                  - Calculator: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcalculator.md
+                  - Custom Code Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcode.md
+                  - MCP Client Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md
+                  - SearXNG Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolsearxng.md
+                  - SerpApi (Google Search): integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolserpapi.md
+                  - Think Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolthink.md
+                  - Vector Store Question Answer Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolvectorstore.md
+                  - Wikipedia: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolwikipedia.md
+                  - Wolfram|Alpha: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolwolframalpha.md
+                  - Call n8n Workflow Tool: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow.md
+                  - Reranker Cohere: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.rerankercohere.md
+                  - Model Selector: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.modelselector.md
+          - Credentials:
+              - integrations/builtin/credentials/index.md
+              - integrations/builtin/credentials/actionnetwork.md
+              - integrations/builtin/credentials/activecampaign.md
+              - integrations/builtin/credentials/acuityscheduling.md
+              - integrations/builtin/credentials/adalo.md
+              - integrations/builtin/credentials/affinity.md
+              - integrations/builtin/credentials/agilecrm.md
+              - integrations/builtin/credentials/airtable.md
+              - integrations/builtin/credentials/airtop.md
+              - integrations/builtin/credentials/alienvault.md
+              - integrations/builtin/credentials/amqp.md
+              - integrations/builtin/credentials/anthropic.md
+              - integrations/builtin/credentials/apitemplateio.md
+              - integrations/builtin/credentials/asana.md
+              - integrations/builtin/credentials/auth0management.md
+              - integrations/builtin/credentials/autopilot.md
+              - integrations/builtin/credentials/aws.md
+              - integrations/builtin/credentials/azureopenai.md
+              - integrations/builtin/credentials/azurecosmosdb.md
+              - integrations/builtin/credentials/azureaisearch.md
+              - integrations/builtin/credentials/azurestorage.md
+              - integrations/builtin/credentials/bamboohr.md
+              - integrations/builtin/credentials/bannerbear.md
+              - integrations/builtin/credentials/baserow.md
+              - integrations/builtin/credentials/beeminder.md
+              - integrations/builtin/credentials/bitbucket.md
+              - integrations/builtin/credentials/bitly.md
+              - integrations/builtin/credentials/bitwarden.md
+              - integrations/builtin/credentials/box.md
+              - integrations/builtin/credentials/brandfetch.md
+              - integrations/builtin/credentials/brevo.md
+              - integrations/builtin/credentials/bubble.md
+              - integrations/builtin/credentials/cal.md
+              - integrations/builtin/credentials/calendly.md
+              - integrations/builtin/credentials/carbonblack.md
+              - integrations/builtin/credentials/chargebee.md
+              - integrations/builtin/credentials/circleci.md
+              - integrations/builtin/credentials/ciscomeraki.md
+              - integrations/builtin/credentials/ciscosecureendpoint.md
+              - integrations/builtin/credentials/ciscoumbrella.md
+              - integrations/builtin/credentials/clearbit.md
+              - integrations/builtin/credentials/clickup.md
+              - integrations/builtin/credentials/clockify.md
+              - integrations/builtin/credentials/cloudflare.md
+              - integrations/builtin/credentials/cockpit.md
+              - integrations/builtin/credentials/coda.md
+              - integrations/builtin/credentials/cohere.md
+              - integrations/builtin/credentials/contentful.md
+              - integrations/builtin/credentials/convertapi.md
+              - integrations/builtin/credentials/convertkit.md
+              - integrations/builtin/credentials/copper.md
+              - integrations/builtin/credentials/cortex.md
+              - integrations/builtin/credentials/cratedb.md
+              - integrations/builtin/credentials/crowddev.md
+              - integrations/builtin/credentials/crowdstrike.md
+              - integrations/builtin/credentials/customerio.md
+              - integrations/builtin/credentials/databricks.md
+              - integrations/builtin/credentials/datadog.md
+              - integrations/builtin/credentials/deepl.md
+              - integrations/builtin/credentials/deepseek.md
+              - integrations/builtin/credentials/demio.md
+              - integrations/builtin/credentials/dfiriris.md
+              - integrations/builtin/credentials/dhl.md
+              - integrations/builtin/credentials/discord.md
+              - integrations/builtin/credentials/discourse.md
+              - integrations/builtin/credentials/disqus.md
+              - integrations/builtin/credentials/drift.md
+              - integrations/builtin/credentials/dropbox.md
+              - integrations/builtin/credentials/dropcontact.md
+              - integrations/builtin/credentials/dynatrace.md
+              - integrations/builtin/credentials/egoi.md
+              - integrations/builtin/credentials/elasticsearch.md
+              - integrations/builtin/credentials/elasticsecurity.md
+              - integrations/builtin/credentials/emelia.md
+              - integrations/builtin/credentials/erpnext.md
+              - integrations/builtin/credentials/eventbrite.md
+              - integrations/builtin/credentials/f5bigip.md
+              - integrations/builtin/credentials/facebookapp.md
+              - integrations/builtin/credentials/facebookgraph.md
+              - integrations/builtin/credentials/facebookleadads.md
+              - integrations/builtin/credentials/figma.md
+              - integrations/builtin/credentials/filemaker.md
+              - integrations/builtin/credentials/filescan.md
+              - integrations/builtin/credentials/flow.md
+              - integrations/builtin/credentials/formiotrigger.md
+              - integrations/builtin/credentials/formstacktrigger.md
+              - integrations/builtin/credentials/fortigate.md
+              - integrations/builtin/credentials/freshdesk.md
+              - integrations/builtin/credentials/freshservice.md
+              - integrations/builtin/credentials/freshworkscrm.md
+              - integrations/builtin/credentials/ftp.md
+              - integrations/builtin/credentials/getresponse.md
+              - integrations/builtin/credentials/ghost.md
+              - integrations/builtin/credentials/git.md
+              - integrations/builtin/credentials/github.md
+              - integrations/builtin/credentials/gitlab.md
+              - integrations/builtin/credentials/gong.md
+              - Google:
+                  - integrations/builtin/credentials/google/index.md
+                  - integrations/builtin/credentials/google/oauth-single-service.md
+                  - integrations/builtin/credentials/google/oauth-generic.md
+                  - integrations/builtin/credentials/google/service-account.md
+              - integrations/builtin/credentials/googleai.md
+              - integrations/builtin/credentials/gotify.md
+              - integrations/builtin/credentials/gotowebinar.md
+              - integrations/builtin/credentials/grafana.md
+              - integrations/builtin/credentials/grist.md
+              - integrations/builtin/credentials/groq.md
+              - integrations/builtin/credentials/gumroad.md
+              - integrations/builtin/credentials/halopsa.md
+              - integrations/builtin/credentials/harvest.md
+              - integrations/builtin/credentials/helpscout.md
+              - integrations/builtin/credentials/highlevel.md
+              - integrations/builtin/credentials/homeassistant.md
+              - integrations/builtin/credentials/httprequest.md
+              - integrations/builtin/credentials/hubspot.md
+              - integrations/builtin/credentials/huggingface.md
+              - integrations/builtin/credentials/humanticai.md
+              - integrations/builtin/credentials/hunter.md
+              - integrations/builtin/credentials/hybridanalysis.md
+              - IMAP:
+                  - integrations/builtin/credentials/imap/index.md
+                  - integrations/builtin/credentials/imap/gmail.md
+                  - integrations/builtin/credentials/imap/outlook.md
+                  - integrations/builtin/credentials/imap/yahoo.md
+              - integrations/builtin/credentials/impervawaf.md
+              - integrations/builtin/credentials/intercom.md
+              - integrations/builtin/credentials/invoiceninja.md
+              - integrations/builtin/credentials/iterable.md
+              - integrations/builtin/credentials/jenkins.md
+              - integrations/builtin/credentials/jinaai.md
+              - integrations/builtin/credentials/jira.md
+              - integrations/builtin/credentials/jotform.md
+              - integrations/builtin/credentials/jwt.md
+              - integrations/builtin/credentials/kafka.md
+              - integrations/builtin/credentials/keap.md
+              - integrations/builtin/credentials/kibana.md
+              - integrations/builtin/credentials/kitemaker.md
+              - integrations/builtin/credentials/kobotoolbox.md
+              - integrations/builtin/credentials/ldap.md
+              - integrations/builtin/credentials/lemlist.md
+              - integrations/builtin/credentials/lemonade.md
+              - integrations/builtin/credentials/line.md
+              - integrations/builtin/credentials/linear.md
+              - integrations/builtin/credentials/lingvanex.md
+              - integrations/builtin/credentials/linkedin.md
+              - integrations/builtin/credentials/lonescale.md
+              - integrations/builtin/credentials/magento2.md
+              - integrations/builtin/credentials/mailcheck.md
+              - integrations/builtin/credentials/mailchimp.md
+              - integrations/builtin/credentials/mailerlite.md
+              - integrations/builtin/credentials/mailgun.md
+              - integrations/builtin/credentials/mailjet.md
+              - integrations/builtin/credentials/malcore.md
+              - integrations/builtin/credentials/mandrill.md
+              - integrations/builtin/credentials/marketstack.md
+              - integrations/builtin/credentials/matrix.md
+              - integrations/builtin/credentials/mattermost.md
+              - integrations/builtin/credentials/mautic.md
+              - integrations/builtin/credentials/medium.md
+              - integrations/builtin/credentials/messagebird.md
+              - integrations/builtin/credentials/metabase.md
+              - integrations/builtin/credentials/microsoft.md
+              - integrations/builtin/credentials/microsoftazuremonitor.md
+              - integrations/builtin/credentials/microsoftentra.md
+              - integrations/builtin/credentials/microsoftsql.md
+              - integrations/builtin/credentials/microsoftagent365.md
+              - integrations/builtin/credentials/milvus.md
+              - integrations/builtin/credentials/mindee.md
+              - integrations/builtin/credentials/miro.md
+              - integrations/builtin/credentials/misp.md
+              - integrations/builtin/credentials/mist.md
+              - integrations/builtin/credentials/mistral.md
+              - integrations/builtin/credentials/mocean.md
+              - integrations/builtin/credentials/mondaycom.md
+              - integrations/builtin/credentials/mongodb.md
+              - integrations/builtin/credentials/monicacrm.md
+              - integrations/builtin/credentials/motorhead.md
+              - integrations/builtin/credentials/mqtt.md
+              - integrations/builtin/credentials/msg91.md
+              - integrations/builtin/credentials/mysql.md
+              - integrations/builtin/credentials/nasa.md
+              - integrations/builtin/credentials/netlify.md
+              - integrations/builtin/credentials/netscaleradc.md
+              - integrations/builtin/credentials/nextcloud.md
+              - integrations/builtin/credentials/nocodb.md
+              - integrations/builtin/credentials/notion.md
+              - integrations/builtin/credentials/npm.md
+              - integrations/builtin/credentials/odoo.md
+              - integrations/builtin/credentials/okta.md
+              - integrations/builtin/credentials/ollama.md
+              - integrations/builtin/credentials/onesimpleapi.md
+              - integrations/builtin/credentials/onfleet.md
+              - integrations/builtin/credentials/openai.md
+              - integrations/builtin/credentials/opencti.md
+              - integrations/builtin/credentials/openrouter.md
+              - integrations/builtin/credentials/openweathermap.md
+              - integrations/builtin/credentials/oracledb.md
+              - integrations/builtin/credentials/oura.md
+              - integrations/builtin/credentials/paddle.md
+              - integrations/builtin/credentials/pagerduty.md
+              - integrations/builtin/credentials/paypal.md
+              - integrations/builtin/credentials/peekalink.md
+              - integrations/builtin/credentials/perplexity.md
+              - integrations/builtin/credentials/phantombuster.md
+              - integrations/builtin/credentials/philipshue.md
+              - integrations/builtin/credentials/chroma.md
+              - integrations/builtin/credentials/pinecone.md
+              - integrations/builtin/credentials/pipedrive.md
+              - integrations/builtin/credentials/plivo.md
+              - integrations/builtin/credentials/postgres.md
+              - integrations/builtin/credentials/posthog.md
+              - integrations/builtin/credentials/postmark.md
+              - integrations/builtin/credentials/profitwell.md
+              - integrations/builtin/credentials/pushbullet.md
+              - integrations/builtin/credentials/pushcut.md
+              - integrations/builtin/credentials/pushover.md
+              - integrations/builtin/credentials/qradar.md
+              - integrations/builtin/credentials/qdrant.md
+              - integrations/builtin/credentials/qualys.md
+              - integrations/builtin/credentials/questdb.md
+              - integrations/builtin/credentials/quickbase.md
+              - integrations/builtin/credentials/quickbooks.md
+              - integrations/builtin/credentials/rabbitmq.md
+              - integrations/builtin/credentials/raindrop.md
+              - integrations/builtin/credentials/rapid7insightvm.md
+              - integrations/builtin/credentials/recordedfuture.md
+              - integrations/builtin/credentials/reddit.md
+              - integrations/builtin/credentials/redis.md
+              - integrations/builtin/credentials/rocketchat.md
+              - integrations/builtin/credentials/rundeck.md
+              - integrations/builtin/credentials/s3.md
+              - integrations/builtin/credentials/salesforce.md
+              - integrations/builtin/credentials/salesmate.md
+              - integrations/builtin/credentials/searxng.md
+              - integrations/builtin/credentials/seatable.md
+              - integrations/builtin/credentials/securityscorecard.md
+              - integrations/builtin/credentials/segment.md
+              - integrations/builtin/credentials/sekoia.md
+              - Send Email:
+                  - integrations/builtin/credentials/sendemail/index.md
+                  - integrations/builtin/credentials/sendemail/gmail.md
+                  - integrations/builtin/credentials/sendemail/outlook.md
+                  - integrations/builtin/credentials/sendemail/yahoo.md
+              - integrations/builtin/credentials/sendgrid.md
+              - integrations/builtin/credentials/sendy.md
+              - integrations/builtin/credentials/sentryio.md
+              - integrations/builtin/credentials/serp.md
+              - integrations/builtin/credentials/servicenow.md
+              - integrations/builtin/credentials/sms77.md
+              - integrations/builtin/credentials/shopify.md
+              - integrations/builtin/credentials/shuffler.md
+              - integrations/builtin/credentials/signl4.md
+              - integrations/builtin/credentials/slack.md
+              - integrations/builtin/credentials/snowflake.md
+              - integrations/builtin/credentials/solarwindsipam.md
+              - integrations/builtin/credentials/solarwindsobservability.md
+              - integrations/builtin/credentials/splunk.md
+              - integrations/builtin/credentials/spotify.md
+              - integrations/builtin/credentials/ssh.md
+              - integrations/builtin/credentials/stackby.md
+              - integrations/builtin/credentials/storyblok.md
+              - integrations/builtin/credentials/strapi.md
+              - integrations/builtin/credentials/strava.md
+              - integrations/builtin/credentials/stripe.md
+              - integrations/builtin/credentials/supabase.md
+              - integrations/builtin/credentials/surveymonkey.md
+              - integrations/builtin/credentials/syncromsp.md
+              - integrations/builtin/credentials/sysdig.md
+              - integrations/builtin/credentials/taiga.md
+              - integrations/builtin/credentials/tapfiliate.md
+              - integrations/builtin/credentials/telegram.md
+              - integrations/builtin/credentials/thehive.md
+              - integrations/builtin/credentials/thehive5.md
+              - integrations/builtin/credentials/timescaledb.md
+              - integrations/builtin/credentials/todoist.md
+              - integrations/builtin/credentials/toggl.md
+              - integrations/builtin/credentials/totp.md
+              - integrations/builtin/credentials/travisci.md
+              - integrations/builtin/credentials/trellixepo.md
+              - integrations/builtin/credentials/trello.md
+              - integrations/builtin/credentials/twake.md
+              - integrations/builtin/credentials/twilio.md
+              - integrations/builtin/credentials/twist.md
+              - integrations/builtin/credentials/typeform.md
+              - integrations/builtin/credentials/unleashedsoftware.md
+              - integrations/builtin/credentials/uplead.md
+              - integrations/builtin/credentials/uproc.md
+              - integrations/builtin/credentials/uptimerobot.md
+              - integrations/builtin/credentials/urlscanio.md
+              - integrations/builtin/credentials/venafitlsprotectcloud.md
+              - integrations/builtin/credentials/venafitlsprotectdatacenter.md
+              - integrations/builtin/credentials/vercel.md
+              - integrations/builtin/credentials/vero.md
+              - integrations/builtin/credentials/virustotal.md
+              - integrations/builtin/credentials/vonage.md
+              - integrations/builtin/credentials/weaviate.md
+              - integrations/builtin/credentials/ciscowebex.md
+              - integrations/builtin/credentials/webflow.md
+              - integrations/builtin/credentials/webhook.md
+              - integrations/builtin/credentials/wekan.md
+              - integrations/builtin/credentials/whatsapp.md
+              - integrations/builtin/credentials/wise.md
+              - integrations/builtin/credentials/wolframalpha.md
+              - integrations/builtin/credentials/woocommerce.md
+              - integrations/builtin/credentials/wordpress.md
+              - integrations/builtin/credentials/workable.md
+              - integrations/builtin/credentials/wufoo.md
+              - integrations/builtin/credentials/twitter.md
+              - integrations/builtin/credentials/xai.md
+              - integrations/builtin/credentials/xata.md
+              - integrations/builtin/credentials/xero.md
+              - integrations/builtin/credentials/yourls.md
+              - integrations/builtin/credentials/zabbix.md
+              - integrations/builtin/credentials/zammad.md
+              - integrations/builtin/credentials/zendesk.md
+              - integrations/builtin/credentials/zep.md
+              - integrations/builtin/credentials/zoho.md
+              - integrations/builtin/credentials/zoom.md
+              - integrations/builtin/credentials/zscalerzia.md
+              - integrations/builtin/credentials/zulip.md
+          - Custom API actions for existing nodes: integrations/custom-operations.md
+          - Handle rate limits: integrations/builtin/rate-limits.md
+      - Community nodes:
+          - Installation and management:
+              - integrations/community-nodes/installation/index.md
+              - Install verified community nodes: integrations/community-nodes/installation/verified-install.md
+              - GUI installation: integrations/community-nodes/installation/gui-install.md
+              - Manual installation: integrations/community-nodes/installation/manual-install.md
+          - Risks: integrations/community-nodes/risks.md
+          - Blocklist: integrations/community-nodes/blocklist.md
+          - Using community nodes: integrations/community-nodes/usage.md
+          - Troubleshooting: integrations/community-nodes/troubleshooting.md
+          - Building community nodes: integrations/community-nodes/build-community-nodes.md
+      - Creating nodes:
+          - Overview: integrations/creating-nodes/overview.md
+          - Plan your node:
+              - integrations/creating-nodes/plan/index.md
+              - Choose a node type: integrations/creating-nodes/plan/node-types.md
+              - Choose a node building style: integrations/creating-nodes/plan/choose-node-method.md
+              - Node UI design: integrations/creating-nodes/plan/node-ui-design.md
+              - Choose node file structure: integrations/creating-nodes/build/reference/node-file-structure.md
+          - Build your node:
+              - integrations/creating-nodes/build/index.md
+              - Set up your development environment: integrations/creating-nodes/build/node-development-environment.md
+              - Using the n8n-node tool: integrations/creating-nodes/build/n8n-node.md
+              - "Tutorial: Build a declarative-style node": integrations/creating-nodes/build/declarative-style-node.md
+              - "Tutorial: Build a programmatic-style node": integrations/creating-nodes/build/programmatic-style-node.md
+              - Reference:
+                  - integrations/creating-nodes/build/reference/index.md
+                  - Node UI elements: integrations/creating-nodes/build/reference/ui-elements.md
+                  - Code standards: integrations/creating-nodes/build/reference/code-standards.md
+                  - Error handling: integrations/creating-nodes/build/reference/error-handling.md
+                  - Versioning: integrations/creating-nodes/build/reference/node-versioning.md
+                  - File structure: integrations/creating-nodes/build/reference/node-file-structure.md
+                  - Base files:
+                      - integrations/creating-nodes/build/reference/node-base-files/index.md
+                      - Structure: integrations/creating-nodes/build/reference/node-base-files/structure.md
+                      - Standard parameters: integrations/creating-nodes/build/reference/node-base-files/standard-parameters.md
+                      - Declarative-style parameters: integrations/creating-nodes/build/reference/node-base-files/declarative-style-parameters.md
+                      - Programmatic-style parameters: integrations/creating-nodes/build/reference/node-base-files/programmatic-style-parameters.md
+                      - Programmatic-style execute method: integrations/creating-nodes/build/reference/node-base-files/programmatic-style-execute-method.md
+                  - Codex files: integrations/creating-nodes/build/reference/node-codex-files.md
+                  - Credentials files: integrations/creating-nodes/build/reference/credentials-files.md
+                  - HTTP request helpers: integrations/creating-nodes/build/reference/http-helpers.md
+                  - Item linking: integrations/creating-nodes/build/reference/paired-items.md
+                  - UX guidelines: integrations/creating-nodes/build/reference/ux-guidelines.md
+                  - Verification guidelines: integrations/creating-nodes/build/reference/verification-guidelines.md
+          - Test your node:
+              - integrations/creating-nodes/test/index.md
+              - Run your node locally: integrations/creating-nodes/test/run-node-locally.md
+              - Node linter: integrations/creating-nodes/test/node-linter.md
+              - Troubleshooting: integrations/creating-nodes/test/troubleshooting-node-development.md
+          - Deploy your node:
+              - integrations/creating-nodes/deploy/index.md
+              - Submit community nodes: integrations/creating-nodes/deploy/submit-community-nodes.md
+              - Install private nodes: integrations/creating-nodes/deploy/install-private-nodes.md
   - Hosting n8n:
-    - Overview: hosting/index.md
-    - Community vs Enterprise: hosting/community-edition-features.md
-    - Installation:
-      - npm: hosting/installation/npm.md
-      - Docker: hosting/installation/docker.md
-      - Server setups:
-        - hosting/installation/server-setups/index.md
-        - Digital Ocean: hosting/installation/server-setups/digital-ocean.md
-        - Heroku: hosting/installation/server-setups/heroku.md
-        - Hetzner: hosting/installation/server-setups/hetzner.md
-        - Amazon Web Services: hosting/installation/server-setups/aws.md
-        - Azure: hosting/installation/server-setups/azure.md
-        - Google Cloud Run: hosting/installation/server-setups/google-cloud-run.md
-        - Google Kubernetes Engine: hosting/installation/server-setups/google-kubernetes-engine.md
-        - OpenShift CRC: hosting/installation/server-setups/openshift-crc.md
-        - Docker Compose: hosting/installation/server-setups/docker-compose.md
-      - Updating: hosting/installation/updating.md
-    - Configuration:
-      - Environment variables:
-        - Environment variables overview : hosting/configuration/environment-variables/index.md
-        - AI Assistant: hosting/configuration/environment-variables/ai-assistant.md
-        - Binary data: hosting/configuration/environment-variables/binary-data.md
-        - Credentials: hosting/configuration/environment-variables/credentials.md
-        - Database: hosting/configuration/environment-variables/database.md
-        - Deployment: hosting/configuration/environment-variables/deployment.md
-        - Endpoints: hosting/configuration/environment-variables/endpoints.md
-        - Executions: hosting/configuration/environment-variables/executions.md
-        - External data storage: hosting/configuration/environment-variables/external-data-storage.md
-        - External hooks: hosting/configuration/environment-variables/external-hooks.md
-        - External secrets: hosting/configuration/environment-variables/external-secrets.md
-        - Insights: hosting/configuration/environment-variables/insights.md
-        - Logs: hosting/configuration/environment-variables/logs.md
-        - License: hosting/configuration/environment-variables/licenses.md
-        - Nodes: hosting/configuration/environment-variables/nodes.md
-        - Queue mode: hosting/configuration/environment-variables/queue-mode.md
-        - Security: hosting/configuration/environment-variables/security.md
-        - SSRF protection: hosting/configuration/environment-variables/ssrf-protection.md
-        - Source control: hosting/configuration/environment-variables/source-control.md
-        - Task runners: hosting/configuration/environment-variables/task-runners.md
-        - Timezone and localization: hosting/configuration/environment-variables/timezone-localization.md
-        - User management and 2FA: hosting/configuration/environment-variables/user-management-smtp-2fa.md
-        - Workflows: hosting/configuration/environment-variables/workflows.md
-        - Workflow history: hosting/configuration/environment-variables/workflow-history.md
-      - Configuration methods: hosting/configuration/configuration-methods.md
-      - Configuration examples:
-        - hosting/configuration/configuration-examples/index.md
-        - Isolate n8n: hosting/configuration/configuration-examples/isolation.md
-        - Configure the Base URL: hosting/configuration/configuration-examples/base-url.md
-        - Configure custom SSL certificate authorities: hosting/configuration/configuration-examples/custom-certificate-authority.md
-        - Set a custom encryption key: hosting/configuration/configuration-examples/encryption-key.md
-        - Configure workflow timeouts: hosting/configuration/configuration-examples/execution-timeout.md
-        - Specify custom nodes location: hosting/configuration/configuration-examples/custom-nodes-location.md
-        - Enable modules in Code node: hosting/configuration/configuration-examples/modules-in-code-node.md
-        - Set the timezone: hosting/configuration/configuration-examples/time-zone.md
-        - Specify user folder path: hosting/configuration/configuration-examples/user-folder.md
-        - Configure webhook URLs with reverse proxy: hosting/configuration/configuration-examples/webhook-url.md
-        - Enable Prometheus metrics: hosting/configuration/configuration-examples/prometheus.md
-        - Pre-configure Microsoft OAuth credentials: hosting/configuration/configuration-examples/microsoft-oauth-credential-overwrites.md
-        - Configure a custom workflow templates library: hosting/configuration/configuration-examples/custom-templates.md
-      - Supported databases and settings: hosting/configuration/supported-databases-settings.md
-      - Credential overwrites: hosting/configuration/credential-overwrites.md
-      - External hooks: hosting/configuration/external-hooks.md
-      - Task runners: hosting/configuration/task-runners.md
-      - User management: hosting/configuration/user-management-self-hosted.md
-    - Logging and monitoring:
-      - Logging: hosting/logging-monitoring/logging.md
-      - Monitoring: hosting/logging-monitoring/monitoring.md
-      - Security audit: hosting/securing/security-audit.md
-    - Scaling and performance:
-      - Overview: hosting/scaling/overview.md
-      - Performance and benchmarking: hosting/scaling/performance-benchmarking.md
-      - Configuring queue mode: hosting/scaling/queue-mode.md
-      - Concurrency control: hosting/scaling/concurrency-control.md
-      - Execution data: hosting/scaling/execution-data.md
-      - Binary data: hosting/scaling/binary-data.md
-      - External storage for binary data: hosting/scaling/external-storage.md
-      - Memory-related errors: hosting/scaling/memory-errors.md
-    - Securing n8n:
-      - Overview: hosting/securing/overview.md
-      - Set up SSL: hosting/securing/set-up-ssl.md
-      - Set up SSO: hosting/securing/set-up-sso.md
-      - Security audit: hosting/securing/security-audit.md
-      - Disable the API: hosting/securing/disable-public-api.md
-      - Opt out of data collection: hosting/securing/telemetry-opt-out.md
-      - Blocking nodes: hosting/securing/blocking-nodes.md
-      - Hardening task runners: hosting/securing/hardening-task-runners.md
-      - SSRF protection: hosting/securing/ssrf-protection.md
-      - Execution data redaction: workflows/executions/execution-data-redaction.md
-      - Restrict account registration to email-verified users: hosting/securing/restrict-by-email-verification.md
-    - Starter Kits:
-      - AI Starter Kit: hosting/starter-kits/ai-starter-kit.md
-    - OEM deployment:
-      - Overview: hosting/oem-deployment/index.md
-      - Prerequisites: hosting/oem-deployment/prerequisites.md
-      - Managing workflows: hosting/oem-deployment/managing-workflows.md
-    - Architecture:
-      - Overview: hosting/architecture/overview.md
-      - Database structure: hosting/architecture/database-structure.md
-    - Using the CLI:
-      - CLI commands: hosting/cli-commands.md
+      - Overview: hosting/index.md
+      - Community vs Enterprise: hosting/community-edition-features.md
+      - Installation:
+          - npm: hosting/installation/npm.md
+          - Docker: hosting/installation/docker.md
+          - Server setups:
+              - hosting/installation/server-setups/index.md
+              - Digital Ocean: hosting/installation/server-setups/digital-ocean.md
+              - Heroku: hosting/installation/server-setups/heroku.md
+              - Hetzner: hosting/installation/server-setups/hetzner.md
+              - Amazon Web Services: hosting/installation/server-setups/aws.md
+              - Azure: hosting/installation/server-setups/azure.md
+              - Google Cloud Run: hosting/installation/server-setups/google-cloud-run.md
+              - Google Kubernetes Engine: hosting/installation/server-setups/google-kubernetes-engine.md
+              - OpenShift CRC: hosting/installation/server-setups/openshift-crc.md
+              - Docker Compose: hosting/installation/server-setups/docker-compose.md
+          - Updating: hosting/installation/updating.md
+      - Configuration:
+          - Environment variables:
+              - Environment variables overview: hosting/configuration/environment-variables/index.md
+              - AI Assistant: hosting/configuration/environment-variables/ai-assistant.md
+              - Binary data: hosting/configuration/environment-variables/binary-data.md
+              - Credentials: hosting/configuration/environment-variables/credentials.md
+              - Database: hosting/configuration/environment-variables/database.md
+              - Deployment: hosting/configuration/environment-variables/deployment.md
+              - Endpoints: hosting/configuration/environment-variables/endpoints.md
+              - Executions: hosting/configuration/environment-variables/executions.md
+              - External data storage: hosting/configuration/environment-variables/external-data-storage.md
+              - External hooks: hosting/configuration/environment-variables/external-hooks.md
+              - External secrets: hosting/configuration/environment-variables/external-secrets.md
+              - Insights: hosting/configuration/environment-variables/insights.md
+              - Logs: hosting/configuration/environment-variables/logs.md
+              - License: hosting/configuration/environment-variables/licenses.md
+              - Nodes: hosting/configuration/environment-variables/nodes.md
+              - Queue mode: hosting/configuration/environment-variables/queue-mode.md
+              - Security: hosting/configuration/environment-variables/security.md
+              - SSRF protection: hosting/configuration/environment-variables/ssrf-protection.md
+              - Source control: hosting/configuration/environment-variables/source-control.md
+              - Task runners: hosting/configuration/environment-variables/task-runners.md
+              - Timezone and localization: hosting/configuration/environment-variables/timezone-localization.md
+              - User management and 2FA: hosting/configuration/environment-variables/user-management-smtp-2fa.md
+              - Workflows: hosting/configuration/environment-variables/workflows.md
+              - Workflow history: hosting/configuration/environment-variables/workflow-history.md
+          - Configuration methods: hosting/configuration/configuration-methods.md
+          - Configuration examples:
+              - hosting/configuration/configuration-examples/index.md
+              - Isolate n8n: hosting/configuration/configuration-examples/isolation.md
+              - Configure the Base URL: hosting/configuration/configuration-examples/base-url.md
+              - Configure custom SSL certificate authorities: hosting/configuration/configuration-examples/custom-certificate-authority.md
+              - Set a custom encryption key: hosting/configuration/configuration-examples/encryption-key.md
+              - Configure workflow timeouts: hosting/configuration/configuration-examples/execution-timeout.md
+              - Specify custom nodes location: hosting/configuration/configuration-examples/custom-nodes-location.md
+              - Enable modules in Code node: hosting/configuration/configuration-examples/modules-in-code-node.md
+              - Set the timezone: hosting/configuration/configuration-examples/time-zone.md
+              - Specify user folder path: hosting/configuration/configuration-examples/user-folder.md
+              - Configure webhook URLs with reverse proxy: hosting/configuration/configuration-examples/webhook-url.md
+              - Enable Prometheus metrics: hosting/configuration/configuration-examples/prometheus.md
+              - Pre-configure Microsoft OAuth credentials: hosting/configuration/configuration-examples/microsoft-oauth-credential-overwrites.md
+              - Configure a custom workflow templates library: hosting/configuration/configuration-examples/custom-templates.md
+          - Supported databases and settings: hosting/configuration/supported-databases-settings.md
+          - Credential overwrites: hosting/configuration/credential-overwrites.md
+          - External hooks: hosting/configuration/external-hooks.md
+          - Task runners: hosting/configuration/task-runners.md
+          - User management: hosting/configuration/user-management-self-hosted.md
+      - Logging and monitoring:
+          - Logging: hosting/logging-monitoring/logging.md
+          - Monitoring: hosting/logging-monitoring/monitoring.md
+          - Security audit: hosting/securing/security-audit.md
+      - Scaling and performance:
+          - Overview: hosting/scaling/overview.md
+          - Performance and benchmarking: hosting/scaling/performance-benchmarking.md
+          - Configuring queue mode: hosting/scaling/queue-mode.md
+          - Concurrency control: hosting/scaling/concurrency-control.md
+          - Execution data: hosting/scaling/execution-data.md
+          - Binary data: hosting/scaling/binary-data.md
+          - External storage for binary data: hosting/scaling/external-storage.md
+          - Memory-related errors: hosting/scaling/memory-errors.md
+      - Securing n8n:
+          - Overview: hosting/securing/overview.md
+          - Set up SSL: hosting/securing/set-up-ssl.md
+          - Set up SSO: hosting/securing/set-up-sso.md
+          - Security audit: hosting/securing/security-audit.md
+          - Disable the API: hosting/securing/disable-public-api.md
+          - Opt out of data collection: hosting/securing/telemetry-opt-out.md
+          - Blocking nodes: hosting/securing/blocking-nodes.md
+          - Hardening task runners: hosting/securing/hardening-task-runners.md
+          - SSRF protection: hosting/securing/ssrf-protection.md
+          - Execution data redaction: workflows/executions/execution-data-redaction.md
+          - Restrict account registration to email-verified users: hosting/securing/restrict-by-email-verification.md
+      - Starter Kits:
+          - AI Starter Kit: hosting/starter-kits/ai-starter-kit.md
+      - OEM deployment:
+          - Overview: hosting/oem-deployment/index.md
+          - Prerequisites: hosting/oem-deployment/prerequisites.md
+          - Managing workflows: hosting/oem-deployment/managing-workflows.md
+      - Architecture:
+          - Overview: hosting/architecture/overview.md
+          - Database structure: hosting/architecture/database-structure.md
+      - Using the CLI:
+          - CLI commands: hosting/cli-commands.md
   - Code in n8n:
       - code/index.md
       - Using the Code node: code/code-node.md
@@ -1349,7 +1349,9 @@ nav:
       - advanced-ai/index.md
       - "AI Workflow Builder": advanced-ai/ai-workflow-builder.md
       - "Chat Hub": advanced-ai/chat-hub.md
-      - "Set up and use n8n MCP server": advanced-ai/accessing-n8n-mcp-server.md
+      - Instance-level MCP server:
+          - "Set up and use n8n MCP server": advanced-ai/mcp/accessing-n8n-mcp-server.md
+          - "MCP server tools reference": advanced-ai/mcp/mcp_tools_reference.md
       - "Tutorial: Build an AI workflow in n8n": advanced-ai/intro-tutorial.md
       - RAG in n8n: advanced-ai/rag-in-n8n.md
       - LangChain in n8n:


### PR DESCRIPTION
- Move MCP markdown pages to a separate folder (`mcp`)
- Move MCP docs to a new section: `Instance-level MCP server` under `Advanced AI`
- Created new tools reference page - includes detailed reference for all MCP tools
- Removed `Executing workflows through MCP clients` section from the main page (details are now in the tool reference)
- Updated main page with a few more details and removed notice that API key connection needs latest Node.js 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorganized the instance-level MCP docs under Advanced AI, added a complete tools reference, and simplified the main page. Docs now clearly explain discovery, building/testing workflows, and data tables.

- New Features
  - Added `mcp_tools_reference.md` with full parameters and outputs for workflow management, builder, test tools, and data tables.

- Refactors
  - Moved MCP docs to `docs/advanced-ai/mcp/`, added the “Instance-level MCP server” nav group, and updated the release notes link path.
  - Streamlined the main page: new heading, moved execution details to the tools reference, clarified that `search_workflows` lists previews for all accessible workflows, and removed the Node.js requirement note.
  - Polished the tools reference: consistent casing, clearer `search_folders` notes, and an irreversible warning for `delete_data_table_column`.

<sup>Written for commit f61d0b51cd75b40e5b6e4aa3dd5dad8181cd7a6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

