### PR TITLE
docs: add doc for aliaba cloud nodes

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.n8n-nodes-langchain.alibabacloud.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.n8n-nodes-langchain.alibabacloud.md
@@ -24,11 +24,11 @@ Create a completion with a Qwen model.
 
 **Parameters**
 
-- **Model** (type: options, field: `modelId`): The model to use for generation (for example, qwen3.5-flash, qwen3-max).
+- **Model** (type: options, field: `modelId`): The model to use for generation (for example, Qwen3.5 Flash, Qwen3 Max).
 - **Messages** (type: fixedCollection, field: `messages`): One or more messages forming the conversation.
-    - messageValues:
+    - Message values:
         - **Content** (type: string, field: `content`): The content of the message.
-        - **Role** (type: options, field: `role`): The role of the message sender (user or assistant).
+        - **Role** (type: options, field: `role`): The role of the message sender (User or Assistant).
 - **Simplify Output** (type: boolean, field: `simplify`): Return a simplified version of the response instead of the full raw API output.
 
 **Options**
@@ -50,8 +50,8 @@ Take images as input and ask vision-language questions about them.
 
 **Parameters**
 
-- **Model** (type: options, field: `modelId`): Vision-language model to use (for example, qwen3-vl-flash).
-- **Input Type** (type: options, field: `inputType`): How to provide the image (`url` or `binary`).
+- **Model** (type: options, field: `modelId`): Vision-language model to use (for example, Qwen-VL Flash).
+- **Input Type** (type: options, field: `inputType`): How to provide the image (URL or binary data).
 - **Image URL** (type: string, field: `imageUrl`): The URL of the image to analyze (required when using URL input).
 - **Input Data Field Name** (type: string, field: `binaryPropertyName`): Binary field name to read the image from when using binary input.
 - **Question** (type: string, field: `question`): The question or instruction about the image.
@@ -68,7 +68,7 @@ Create an image from a text prompt.
 
 **Parameters**
 
-- **Model** (type: options, field: `modelId`): Image-generation model to use (for example, z-image-turbo).
+- **Model** (type: options, field: `modelId`): Image-generation model to use (for example, Z-Image Turbo).
 - **Prompt** (type: string, field: `prompt`): The text prompt describing the image to generate.
 - **Download Image** (type: boolean, field: `downloadImage`): When true, download the generated image as binary data; otherwise only the URL is returned.
 
@@ -83,11 +83,11 @@ Generate a short video from a text prompt.
 
 **Parameters**
 
-- **Model** (type: options, field: `modelId`): Text-to-video model to use (for example, wan2.6-t2v).
+- **Model** (type: options, field: `modelId`): Text-to-video model to use (for example, Wan 2.6 Text-to-Video).
 - **Prompt** (type: string, field: `prompt`): The text prompt to generate the video from.
 - **Resolution** (type: options, field: `resolution`): Resolution tier (720P or 1080P).
-- **Duration (Seconds)** (type: number, field: `duration`): Duration of the generated video in seconds (two–15).
-- **Shot Type** (type: options, field: `shotType`): Single or multi-shot narrative.
+- **Duration (Seconds)** (type: number, field: `duration`): Duration of the generated video in seconds (2–15).
+- **Shot Type** (type: options, field: `shotType`): Single or Multi (multi-shot narrative).
 - **Download Video** (type: boolean, field: `downloadVideo`): When true, download the generated video as binary data; otherwise only the URL is returned.
 - **Simplify Output** (type: boolean, field: `simplify`): Return a simplified response.
 
@@ -95,9 +95,9 @@ Generate a short video from a text prompt.
 
 - **Prompt Extend** (type: boolean, field: `promptExtend`): Automatically extend and enhance the prompt.
 - **Audio** (type: boolean, field: `audio`): Whether to generate audio for the video.
-- **Audio Input Type** (type: options, field: `audioInputType`): How to provide audio, for example, `url`.
-- **Audio URL** (type: string, field: `audioUrl`): URL of the audio file to use.
-- **Audio Data Field Name** (type: string, field: `audioBinaryPropertyName`): Binary field name for audio input.
+- **Audio Input Type** (type: options, field: `audioInputType`): Must be specified when the **Audio** option is activated. It defines how to provide audio, via an audio URL, or a binary file.
+- **Audio URL** (type: string, field: `audioUrl`): Must be specified when **Audio Input Type** is set to URL. Defines the URL of the audio file to use.
+- **Audio Data Field Name** (type: string, field: `audioBinaryPropertyName`): Must be specified when **Audio Input Type** is set to **Binary File**. Defines the binary field name for audio input.
 
 ### Generate video from image
 
@@ -105,13 +105,13 @@ Generate a video from one or more images using Wan models.
 
 **Parameters**
 
-- **Model** (type: options, field: `modelId`): Image-to-video model to use (for example, wan2.6-i2v-flash).
-- **Input Type** (type: options, field: `inputType`): How to provide the image (`url` or `binary`).
+- **Model** (type: options, field: `modelId`): Image-to-video model to use (for example, Wan 2.6 Image-to-Video Flash).
+- **Input Type** (type: options, field: `inputType`):  Defines how to provide the image, via an image URL, or a binary file.
 - **Image URL** (type: string, field: `imgUrl`): URL of the first-frame image to generate video from.
 - **Input Data Field Name** (type: string, field: `binaryPropertyName`): Binary field name to read the image from when using binary input.
 - **Prompt** (type: string, field: `prompt`): Optional text describing desired content and visual characteristics.
 - **Resolution** (type: options, field: `resolution`): Resolution tier (720P or 1080P).
-- **Duration (Seconds)** (type: number, field: `duration`): Duration in seconds (two–15).
+- **Duration (Seconds)** (type: number, field: `duration`): Duration in seconds (2–15).
 - **Shot Type** (type: options, field: `shotType`): Single or multi-shot narrative.
 - **Download Video** (type: boolean, field: `downloadVideo`): When true, download the generated video as binary data; otherwise only the URL is returned.
 - **Simplify Output** (type: boolean, field: `simplify`): Return a simplified response.
@@ -120,9 +120,9 @@ Generate a video from one or more images using Wan models.
 
 - **Prompt Extend** (type: boolean, field: `promptExtend`): Automatically extend and enhance the prompt.
 - **Audio** (type: boolean, field: `audio`): Whether to generate audio for the video.
-- **Audio Input Type** (type: options, field: `audioInputType`): How to provide audio, for example, `url`.
-- **Audio URL** (type: string, field: `audioUrl`): URL of the audio file to use.
-- **Audio Data Field Name** (type: string, field: `audioBinaryPropertyName`): Binary field name for audio input.
+- **Audio Input Type** (type: options, field: `audioInputType`): Defines how to provide audio, via an audio URL, or a binary file.
+- **Audio URL** (type: string, field: `audioUrl`): URL of the audio file to use, when **Audio Input Type** is set to URL.
+- **Audio Data Field Name** (type: string, field: `audioBinaryPropertyName`): Binary field name for audio input, when **Audio Input Type** is set to binary data.
 
 ## Templates and examples
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.n8n-nodes-langchain.alibabacloud.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.n8n-nodes-langchain.alibabacloud.md
@@ -1,0 +1,133 @@
+---
+title: Alibaba Cloud Model Studio node documentation
+description: Interact with Alibaba Cloud Qwen models via Model Studio. This page explains how to use the node in n8n workflows to: generate text completions, analyze or generate images, and create videos from text or images.
+contentType: [integration, reference]
+---
+
+# Alibaba Cloud Model Studio node
+
+The Alibaba Cloud Model Studio node lets you call Alibaba Cloud Qwen models (text, vision, and media models) from n8n. Use it to generate completions, analyze or create images, and produce short videos from text or images.
+
+/// note | Credentials
+You can find authentication information for this node [here](/integrations/builtin/credentials/alibaba.md).
+///
+
+## Resources and operations
+
+- **Text**: Message a model to create text completions and agent-like responses.
+- **Image**: Analyze images with vision-language models or generate images from prompts.
+- **Video**: Generate short videos from text or from one or more images.
+
+### Message a model
+
+Create a completion with a Qwen model.
+
+**Parameters**
+
+- **Model** (type: options, field: `modelId`): The model to use for generation (for example, qwen3.5-flash, qwen3-max).
+- **Messages** (type: fixedCollection, field: `messages`): One or more messages forming the conversation.
+    - messageValues:
+        - **Content** (type: string, field: `content`): The content of the message.
+        - **Role** (type: options, field: `role`): The role of the message sender (user or assistant).
+- **Simplify Output** (type: boolean, field: `simplify`): Return a simplified version of the response instead of the full raw API output.
+
+**Options**
+
+- **Enable Search** (type: boolean, field: `enableSearch`): Enable web search for up-to-date information.
+- **Max Tokens** (type: number, field: `maxTokens`): Maximum number of tokens to generate.
+- **Max Tools Iterations** (type: number, field: `maxToolsIterations`): Maximum number of tool-calling iterations before stopping. Set to zero for unlimited.
+- **Repetition Penalty** (type: number, field: `repetitionPenalty`): Penalty for token repetition. Higher values reduce repetition.
+- **Seed** (type: number, field: `seed`): Random seed for reproducible outputs.
+- **Stop Sequences** (type: string, field: `stop`): Comma-separated list of sequences where the API will stop generating.
+- **System Message** (type: string, field: `system`): System instruction for the model.
+- **Temperature** (type: number, field: `temperature`): Controls randomness. Lower = more deterministic.
+- **Top K** (type: number, field: `topK`): Limits sampling pool to top K tokens.
+- **Top P** (type: number, field: `topP`): Nucleus sampling parameter.
+
+### Analyze image
+
+Take images as input and ask vision-language questions about them.
+
+**Parameters**
+
+- **Model** (type: options, field: `modelId`): Vision-language model to use (for example, qwen3-vl-flash).
+- **Input Type** (type: options, field: `inputType`): How to provide the image (`url` or `binary`).
+- **Image URL** (type: string, field: `imageUrl`): The URL of the image to analyze (required when using URL input).
+- **Input Data Field Name** (type: string, field: `binaryPropertyName`): Binary field name to read the image from when using binary input.
+- **Question** (type: string, field: `question`): The question or instruction about the image.
+- **Simplify Output** (type: boolean, field: `simplify`): Return a simplified version of the response.
+
+**Options**
+
+- **Temperature** (type: number, field: `temperature`): Controls randomness for the vision model.
+- **Max Tokens** (type: number, field: `maxTokens`): Maximum number of tokens for the vision model output.
+
+### Generate an image
+
+Create an image from a text prompt.
+
+**Parameters**
+
+- **Model** (type: options, field: `modelId`): Image-generation model to use (for example, z-image-turbo).
+- **Prompt** (type: string, field: `prompt`): The text prompt describing the image to generate.
+- **Download Image** (type: boolean, field: `downloadImage`): When true, download the generated image as binary data; otherwise only the URL is returned.
+
+**Options**
+
+- **Size** (type: options, field: `size`): The size of the generated image (for example, 1024*1024, 1664*928).
+- **Prompt Extend** (type: boolean, field: `promptExtend`): Automatically extend and enhance the prompt.
+
+### Generate video from text
+
+Generate a short video from a text prompt.
+
+**Parameters**
+
+- **Model** (type: options, field: `modelId`): Text-to-video model to use (for example, wan2.6-t2v).
+- **Prompt** (type: string, field: `prompt`): The text prompt to generate the video from.
+- **Resolution** (type: options, field: `resolution`): Resolution tier (720P or 1080P).
+- **Duration (Seconds)** (type: number, field: `duration`): Duration of the generated video in seconds (two–15).
+- **Shot Type** (type: options, field: `shotType`): Single or multi-shot narrative.
+- **Download Video** (type: boolean, field: `downloadVideo`): When true, download the generated video as binary data; otherwise only the URL is returned.
+- **Simplify Output** (type: boolean, field: `simplify`): Return a simplified response.
+
+**Options**
+
+- **Prompt Extend** (type: boolean, field: `promptExtend`): Automatically extend and enhance the prompt.
+- **Audio** (type: boolean, field: `audio`): Whether to generate audio for the video.
+- **Audio Input Type** (type: options, field: `audioInputType`): How to provide audio, for example, `url`.
+- **Audio URL** (type: string, field: `audioUrl`): URL of the audio file to use.
+- **Audio Data Field Name** (type: string, field: `audioBinaryPropertyName`): Binary field name for audio input.
+
+### Generate video from image
+
+Generate a video from one or more images using Wan models.
+
+**Parameters**
+
+- **Model** (type: options, field: `modelId`): Image-to-video model to use (for example, wan2.6-i2v-flash).
+- **Input Type** (type: options, field: `inputType`): How to provide the image (`url` or `binary`).
+- **Image URL** (type: string, field: `imgUrl`): URL of the first-frame image to generate video from.
+- **Input Data Field Name** (type: string, field: `binaryPropertyName`): Binary field name to read the image from when using binary input.
+- **Prompt** (type: string, field: `prompt`): Optional text describing desired content and visual characteristics.
+- **Resolution** (type: options, field: `resolution`): Resolution tier (720P or 1080P).
+- **Duration (Seconds)** (type: number, field: `duration`): Duration in seconds (two–15).
+- **Shot Type** (type: options, field: `shotType`): Single or multi-shot narrative.
+- **Download Video** (type: boolean, field: `downloadVideo`): When true, download the generated video as binary data; otherwise only the URL is returned.
+- **Simplify Output** (type: boolean, field: `simplify`): Return a simplified response.
+
+**Options**
+
+- **Prompt Extend** (type: boolean, field: `promptExtend`): Automatically extend and enhance the prompt.
+- **Audio** (type: boolean, field: `audio`): Whether to generate audio for the video.
+- **Audio Input Type** (type: options, field: `audioInputType`): How to provide audio, for example, `url`.
+- **Audio URL** (type: string, field: `audioUrl`): URL of the audio file to use.
+- **Audio Data Field Name** (type: string, field: `audioBinaryPropertyName`): Binary field name for audio input.
+
+## Templates and examples
+
+[[ templatesWidget(page.title, 'alibaba-cloud-model-studio') ]]
+
+## Related resources
+
+Refer to [Alibaba Cloud Model Studio documentation](https://www.alibabacloud.com/product/qwen){:target=\"_blank\" .external-link} for more information about available models and API behavior.

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatalibabacloud.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatalibabacloud.md
@@ -1,0 +1,42 @@
+---
+title: Alibaba Cloud Chat Model node documentation
+description: The Alibaba Cloud Chat Model node sends prompts to Alibaba Cloud's conversational models (for advanced AI chains). This page explains how to configure the node in n8n workflows and covers common uses such as generating chat responses, tweaking sampling parameters (temperature, top_p), and limiting output length.
+contentType: [integration, reference]
+---
+
+# Alibaba Cloud chat model node
+
+The Alibaba Cloud Chat Model node sends chat prompts to Alibaba Cloud's conversational models, for advanced AI chains and LangChain integrations. Use it to generate conversational responses, integrate model outputs into workflows, or run prompts with custom sampling, retry, and timeout settings.
+
+/// note | Credentials
+You can find authentication information for this node [here](/integrations/builtin/credentials/alibaba.md).
+///
+
+## Operations
+
+### Generate chat response
+
+Generate a chat-style response from the selected Alibaba Cloud model.
+
+**Parameters**
+
+- **Model** (type: _options_, field: `model`): The model that generates the completion. Learn more about available models on Alibaba Cloud: [Alibaba Cloud Model Studio — Models](https://www.alibabacloud.com/help/en/model-studio/getting-started/models){:target="_blank" .external-link}.
+
+**Options**
+
+- **Frequency Penalty** (type: _number_, field: `frequencyPenalty`): Positive values penalize new tokens based on how often they appear so far, decreasing the model's likelihood to repeat the same line verbatim. Default: zero.
+- **Maximum Number of Tokens** (type: _number_, field: `maxTokens`): The maximum number of tokens to generate in the completion. The limit depends on the selected model. A value of minus one uses the model's default limit. Default: minus one.
+- **Response Format** (type: _options_, field: `responseFormat`): The output format returned by the node, for example plain text or structured formats. Default: text.
+- **Presence Penalty** (type: _number_, field: `presencePenalty`): Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to discuss new topics. Default: zero.
+- **Sampling Temperature** (type: _number_, field: `temperature`): Control randomness. Lower values make output less random, near zero is deterministic. Default: zero point seven.
+- **Timeout** (type: _number_, field: `timeout`): Maximum time (in milliseconds) allowed for a request before it's aborted. Default: 360000.
+- **Max Retries** (type: _number_, field: `maxRetries`): Maximum number of retry attempts for failed requests. Default: two.
+- **Top P** (type: _number_, field: `topP`): Nucleus sampling parameter that controls diversity. Zero point five means half of the probability mass is considered. Adjust **Top P** or **Sampling Temperature**, but not both. Default: one.
+
+## Templates and examples
+
+[[ templatesWidget(page.title, 'alibaba-cloud-chat-model') ]]
+
+## Related resources
+
+Refer to [Alibaba Cloud Model Studio — Models](https://www.alibabacloud.com/help/en/model-studio/getting-started/models){:target="_blank" .external-link} for more information about available models and their capabilities.

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatalibabacloud.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatalibabacloud.md
@@ -13,6 +13,7 @@ You can find authentication information for this node [here](/integrations/built
 ///
 
 --8<-- "_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
+
 ## Operations
 
 ### Generate chat response

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatalibabacloud.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatalibabacloud.md
@@ -12,6 +12,7 @@ The Alibaba Cloud Chat Model node sends chat prompts to Alibaba Cloud's conversa
 You can find authentication information for this node [here](/integrations/builtin/credentials/alibaba.md).
 ///
 
+--8<-- "_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
 ## Operations
 
 ### Generate chat response

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatalibabacloud.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatalibabacloud.md
@@ -24,14 +24,14 @@ Generate a chat-style response from the selected Alibaba Cloud model.
 
 **Options**
 
-- **Frequency Penalty** (type: _number_, field: `frequencyPenalty`): Positive values penalize new tokens based on how often they appear so far, decreasing the model's likelihood to repeat the same line verbatim. Default: zero.
-- **Maximum Number of Tokens** (type: _number_, field: `maxTokens`): The maximum number of tokens to generate in the completion. The limit depends on the selected model. A value of minus one uses the model's default limit. Default: minus one.
+- **Frequency Penalty** (type: _number_, field: `frequencyPenalty`): Positive values penalize new tokens based on how often they appear so far, decreasing the model's likelihood to repeat the same line verbatim. Default: `0`.
+- **Maximum Number of Tokens** (type: _number_, field: `maxTokens`): The maximum number of tokens to generate in the completion. The limit depends on the selected model. A value of minus one uses the model's default limit. Default: `-1`.
 - **Response Format** (type: _options_, field: `responseFormat`): The output format returned by the node, for example plain text or structured formats. Default: text.
-- **Presence Penalty** (type: _number_, field: `presencePenalty`): Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to discuss new topics. Default: zero.
-- **Sampling Temperature** (type: _number_, field: `temperature`): Control randomness. Lower values make output less random, near zero is deterministic. Default: zero point seven.
-- **Timeout** (type: _number_, field: `timeout`): Maximum time (in milliseconds) allowed for a request before it's aborted. Default: 360000.
-- **Max Retries** (type: _number_, field: `maxRetries`): Maximum number of retry attempts for failed requests. Default: two.
-- **Top P** (type: _number_, field: `topP`): Nucleus sampling parameter that controls diversity. Zero point five means half of the probability mass is considered. Adjust **Top P** or **Sampling Temperature**, but not both. Default: one.
+- **Presence Penalty** (type: _number_, field: `presencePenalty`): Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to discuss new topics. Default: `0`.
+- **Sampling Temperature** (type: _number_, field: `temperature`): Control randomness. Lower values make output less random, near zero is deterministic. Default: `0.7`.
+- **Timeout** (type: _number_, field: `timeout`): Maximum time (in milliseconds) allowed for a request before it's aborted. Default: `360000`.
+- **Max Retries** (type: _number_, field: `maxRetries`): Maximum number of retry attempts for failed requests. Default: `2`.
+- **Top P** (type: _number_, field: `topP`): Nucleus sampling parameter that controls diversity. 0.5 means half of the probability mass is considered. Adjust **Top P** or **Sampling Temperature**, but not both. Default: `1`.
 
 ## Templates and examples
 

--- a/docs/integrations/builtin/credentials/alibaba.md
+++ b/docs/integrations/builtin/credentials/alibaba.md
@@ -1,0 +1,43 @@
+---
+title: Alibaba Cloud credentials
+description: Documentation for Alibaba Cloud credentials. Use these credentials to authenticate Alibaba Cloud in n8n, a workflow automation platform.
+contentType: [integration, reference]
+priority: medium
+---
+
+# Alibaba Cloud credentials
+
+You can use these credentials to authenticate the following nodes:
+
+- [Alibaba Cloud Model Studio](/integrations/builtin/app-nodes/n8n-nodes-langchain.n8n-nodes-langchain.alibabacloud.md)
+- [Alibaba Cloud Chat Model](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatalibabacloud.md)
+
+## Prerequisites
+
+Create an [Alibaba Cloud](https://www.alibabacloud.com/){:target="_blank" .external-link} account and activate [Model Studio](https://www.alibabacloud.com/en/product/modelstudio){:target="_blank" .external-link}.
+
+## Supported authentication methods
+
+- API key
+
+## Related resources
+
+Refer to [Alibaba Cloud Model Studio's documentation](https://www.alibabacloud.com/help/en/model-studio/){:target="_blank" .external-link} for more information about the service.
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
+
+## Using API key
+
+To configure this credential, you'll need:
+
+- An **API Key**
+
+1. Sign in to the [Alibaba Cloud Model Studio console](https://modelstudio.console.alibabacloud.com/){:target="_blank" .external-link}.
+2. In the top right of the screen, select your target region.
+3. In the top menu, select **Dashboard**, then in the side menu, **API Key**.
+4. Select **Create API Key**.
+5. In the dialog box, select a workspace and key description, then select **OK**.
+6. Copy the API key (it displays only once), and enter it in your n8n credential.
+7. Ensure the region of your n8n credential matches the region you selected in the Alibaba Cloud Model Studio console.
+
+Refer to [Alibaba Cloud's API key documentation](https://www.alibabacloud.com/help/en/model-studio/developer-reference/get-api-key){:target="_blank" .external-link} for more information.

--- a/nav.yml
+++ b/nav.yml
@@ -306,6 +306,7 @@ nav:
           - Airtable: integrations/builtin/app-nodes/n8n-nodes-base.airtable/index.md
           - Common issues: integrations/builtin/app-nodes/n8n-nodes-base.airtable/common-issues.md
         - Airtop: integrations/builtin/app-nodes/n8n-nodes-base.airtop.md
+        - Alibaba Cloud Model Studio: integrations/builtin/app-nodes/n8n-nodes-langchain.n8n-nodes-langchain.alibabacloud.md
         - AMQP Sender: integrations/builtin/app-nodes/n8n-nodes-base.amqp.md
         - Anthropic: integrations/builtin/app-nodes/n8n-nodes-langchain.anthropic.md
         - APITemplate.io: integrations/builtin/app-nodes/n8n-nodes-base.apitemplateio.md
@@ -780,6 +781,7 @@ nav:
           - Embeddings Mistral Cloud: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsmistralcloud.md
           - Embeddings Ollama: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsollama.md
           - Embeddings OpenAI: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsopenai.md
+          - Alibaba Cloud Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatalibabacloud.md
           - Anthropic Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatanthropic.md
           - AWS Bedrock Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatawsbedrock.md
           - Azure OpenAI Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatazureopenai.md
@@ -851,6 +853,7 @@ nav:
         - integrations/builtin/credentials/agilecrm.md
         - integrations/builtin/credentials/airtable.md
         - integrations/builtin/credentials/airtop.md
+        - integrations/builtin/credentials/alibaba.md
         - integrations/builtin/credentials/alienvault.md
         - integrations/builtin/credentials/amqp.md
         - integrations/builtin/credentials/anthropic.md


### PR DESCRIPTION
Adds documentation for two new Alibaba Cloud nodes:

- **Alibaba Cloud Model Studio** app node - covers text, vision, and media operations using Alibaba Cloud Qwen models
- **Alibaba Cloud Chat Model** sub-node - covers chat completions for use in AI chains and LangChain workflows
- **Alibaba Cloud credentials** - API key setup for both nodes
- Adds all three pages to the nav