### PR TITLE
docs: document Base URL field and OpenAI-compatible provider usage in OpenAI credentials

### DIFF
--- a/docs/integrations/builtin/credentials/openai.md
+++ b/docs/integrations/builtin/credentials/openai.md
@@ -32,6 +32,8 @@ To configure this credential, you'll need:
 
 - An **API Key**
 - An **Organization ID**: Required if you belong to multiple organizations; otherwise, leave this blank.
+- A **Base URL**: Override the default OpenAI API URL. Defaults to `https://api.openai.com/v1`. Use this to connect to OpenAI-compatible providers.
+- **Add Custom Header**: Toggle to add a custom HTTP header to all API requests.
 
 To generate your API Key:
 
@@ -49,3 +51,17 @@ To find your Organization ID:
 
 Refer to [Setting up your organization](https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization) for more information. Note that API requests made using an Organization ID will count toward the organization's subscription quota.
 
+## Using with OpenAI-compatible providers
+
+The **Base URL** field lets you connect to any provider that offers an OpenAI-compatible API. This includes AI gateways and inference providers such as [FuturMix](https://futurmix.ai){:target="_blank" .external-link}, [LiteLLM](https://www.litellm.ai){:target="_blank" .external-link}, and self-hosted solutions like [vLLM](https://docs.vllm.ai){:target="_blank" .external-link} or [Ollama](https://ollama.ai){:target="_blank" .external-link}.
+
+To use a third-party provider:
+
+1. Create a new **OpenAI** credential in n8n.
+2. Enter the **API Key** from your provider.
+3. Set the **Base URL** to your provider's OpenAI-compatible endpoint, for example `https://futurmix.ai/v1`.
+4. Leave the **Organization ID** blank unless your provider requires it.
+
+/// note | Model availability
+When using a custom Base URL, the model dropdown in the OpenAI Chat Model node dynamically loads models from the configured provider's `/models` endpoint. You'll only see models available through that provider.
+///


### PR DESCRIPTION
## Summary

The OpenAI credential has a **Base URL** field and an **Add Custom Header** toggle, but neither is mentioned in the current documentation. This PR adds:

- Documentation for the **Base URL** and **Add Custom Header** fields in the credential parameter list
- A new "Using with OpenAI-compatible providers" section explaining how to use the Base URL field to connect to third-party providers that implement the OpenAI API format

This addresses a documentation gap — users may not realize they can point the OpenAI nodes at alternative providers without needing a dedicated node for each one.

## Changes

- `docs/integrations/builtin/credentials/openai.md`: Added Base URL and Add Custom Header to the parameter list, plus a section on using OpenAI-compatible providers with step-by-step instructions.

## Test plan

- [ ] Verify the new section renders correctly in the docs preview
- [ ] Confirm the admonition syntax (`/// note`) follows existing patterns
- [ ] Verify external links use the `{:target="_blank" .external-link}` format per style guide

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the OpenAI credential’s Base URL and Add Custom Header fields, and added guidance for using OpenAI‑compatible providers. This lets users point OpenAI nodes to third‑party endpoints; the model list now loads from the provider’s /models endpoint.

<sup>Written for commit 09c19db09efa4858f745e459dd8e5a0535361a9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

