### PR TITLE
docs: add MiniMax Chat Model node and credentials pages

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatminimax.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatminimax.md
@@ -1,0 +1,42 @@
+---
+title: MiniMax Chat Model node documentation
+description: Learn how to use the MiniMax Chat Model node in n8n. Follow technical documentation to integrate MiniMax Chat Model node into your workflows.
+contentType: [integration, reference]
+priority: medium
+---
+
+# MiniMax Chat Model node
+
+Use the MiniMax Chat Model node to use MiniMax's chat models with conversational [agents](/glossary.md#ai-agent).
+
+On this page, you'll find the node parameters for the MiniMax Chat Model node, and links to more resources.
+
+/// note | Credentials
+You can find authentication information for this node [here](/integrations/builtin/credentials/minimax.md).
+///
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/sub-node-expression-resolution.md"
+
+## Node parameters
+
+* **Model**: Select the model that generates the completion. Refer to [MiniMax's model documentation](https://platform.minimax.io/docs/guides/models-intro){:target="_blank" .external-link} for the available models.
+
+## Node options
+
+* **Hide Thinking**: When turned on (default), the node strips `<think>` tags from the model's response. Turn this off to include the model's reasoning in the output.
+* **Maximum Number of Tokens**: Enter the maximum number of tokens used, which sets the completion length.
+* **Sampling Temperature**: Use this option to control the randomness of the sampling process. A higher temperature creates more diverse sampling, but increases the risk of hallucinations.
+* **Timeout**: Enter the maximum request time in milliseconds.
+* **Max Retries**: Enter the maximum number of times to retry a request.
+* **Top P**: Use this option to set the probability the completion should use. Use a lower value to ignore less probable options.
+
+## Templates and examples
+
+<!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->
+[[ templatesWidget(page.title, 'minimax-chat-model') ]]
+
+## Related resources
+
+Refer to [MiniMax's documentation](https://platform.minimax.io/docs/guides/models-intro){:target="_blank" .external-link} for more information about the service.
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"

--- a/docs/integrations/builtin/credentials/minimax.md
+++ b/docs/integrations/builtin/credentials/minimax.md
@@ -1,0 +1,40 @@
+---
+title: MiniMax credentials
+description: Documentation for MiniMax credentials. Use these credentials to authenticate MiniMax in n8n, a workflow automation platform.
+contentType: [integration, reference]
+priority: medium
+---
+
+# MiniMax credentials
+
+You can use these credentials to authenticate the following nodes:
+
+* [MiniMax Chat Model](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatminimax.md)
+
+## Prerequisites
+
+Create a [MiniMax](https://platform.minimax.io/){:target="_blank" .external-link} account.
+
+## Supported authentication methods
+
+- API key
+
+## Related resources
+
+Refer to [MiniMax's API documentation](https://platform.minimax.io/docs/guides/models-intro){:target="_blank" .external-link} for more information about the service.
+
+--8<-- "_snippets/integrations/builtin/cluster-nodes/langchain-overview-link.md"
+
+## Using API key
+
+To configure this credential, you'll need:
+
+- A **Region**: Select **International** or **China** depending on your MiniMax account.
+- An **API Key**
+
+To get your API key:
+
+1. Log in to your [MiniMax account](https://platform.minimax.io/){:target="_blank" .external-link}.
+2. Go to **Account** > **API Keys**.
+3. Select **Create API Key**.
+4. Copy the key and enter it in your n8n credential.

--- a/nav.yml
+++ b/nav.yml
@@ -791,6 +791,7 @@ nav:
           - Google Vertex Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgooglevertex.md
           - Groq Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatgroq.md
           - Lemonade Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatlemonade.md
+          - MiniMax Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatminimax.md
           - Mistral Cloud Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatmistralcloud.md
           - Moonshot Kimi Chat Model: integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatmoonshot.md
           - Ollama Chat Model:
@@ -1017,6 +1018,7 @@ nav:
         - integrations/builtin/credentials/miro.md
         - integrations/builtin/credentials/misp.md
         - integrations/builtin/credentials/mist.md
+        - integrations/builtin/credentials/minimax.md
         - integrations/builtin/credentials/mistral.md
         - integrations/builtin/credentials/mocean.md
         - integrations/builtin/credentials/mondaycom.md


### PR DESCRIPTION
## Summary

- Adds MiniMax Chat Model node documentation page
- Adds MiniMax credentials documentation page
- Adds both entries to nav.yml in alphabetical position (node between Lemonade and Mistral, credentials between mist and mistral)

## Linear ticket

https://linear.app/n8n/issue/DOC-1811/docs-for-minimax-ai-agent-model-node

