### PR TITLE
docs: Describe known bug on cron triggers when using workflow:import CLI

### DIFF
--- a/docs/hosting/cli-commands.md
+++ b/docs/hosting/cli-commands.md
@@ -217,6 +217,11 @@ In this case, you can edit the names from the n8n interface and export again, or
 
 ### Workflows
 
+/// warning | Known issue: cron triggers keep running after import
+When importing a previously active workflow via `n8n import:workflow`, this then deactivated workflow's cron triggers will continue to run until you restart n8n.
+When running n8n in multi-main mode, all triggers will be deactivated as expected.
+///
+
 Import workflows from a specific file:
 
 ```bash


### PR DESCRIPTION
Docs for the bug that was discovered in https://github.com/n8n-io/n8n/pull/29079

Added warning note:
<img width="811" height="499" alt="image" src="https://github.com/user-attachments/assets/4e9aab7b-66d5-44c4-bec5-324d48db6b0d" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a warning to the CLI docs: after importing a previously active workflow via `n8n import:workflow`, its cron triggers may keep running until n8n restarts; multi‑main mode deactivates them as expected. This relates to Linear LIGO-482 (import behavior), clarifying the current deactivation-on-import caveat.

<sup>Written for commit 9b6f6ab87df33bded3c96bd986026c663a05f34a. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4522?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

