### PR TITLE
fix: pin vale-action to v2.1.1 and add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: errata-ai/vale-action@reviewdog
+      - uses: errata-ai/vale-action@v2.1.1
         with:
           files: '["docs", "_snippets"]'


### PR DESCRIPTION
## Summary

- Pins `errata-ai/vale-action` from the floating `@reviewdog` tag to the stable `@v2.1.1` release, fixing the broken Vale lint check on all docs PRs
- Adds `.github/dependabot.yml` with weekly GitHub Actions updates so future version bumps arrive as reviewable PRs instead of silent breaking changes

## Linear ticket

DOC-1911

## Test plan

- [ ] Verify the Vale lint check passes on this PR
- [ ] Confirm Dependabot starts opening PRs for GitHub Actions updates on the weekly schedule