### PR TITLE
docs: document npm dist-tag support for community node installation

### DIFF
--- a/docs/integrations/community-nodes/installation/gui-install.md
+++ b/docs/integrations/community-nodes/installation/gui-install.md
@@ -22,6 +22,7 @@ To install a community node from npm:
 4. Enter the npm package name, and version number if required. For example, consider a community node designed to access a weather API called "Storms." The package name is n8n-node-storms, and it has three major versions.
     * To install the latest version of a package called n8n-node-weather: enter `n8n-nodes-storms` in **Enter npm package name**.
     * To install version 2.3: enter `n8n-node-storms@2.3` in **Enter npm package name**.
+    * To install using an npm dist-tag (for example `beta` or `next`): enter `n8n-node-storms@beta` in **Enter npm package name**.
     <!-- vale off -->
 5. Agree to the [risks](/integrations/community-nodes/risks.md) of using community nodes: select **I understand the risks of installing unverified code from a public source.**
     <!-- vale on -->


### PR DESCRIPTION
## Summary

- Adds dist-tag install example (`@beta`, `@next`) to the GUI install instructions for community nodes

## Related

- Linear: https://linear.app/n8n/issue/DOC-1810
- Implements docs for NODE-4653 / PR [#28067](https://github.com/n8n-io/n8n/pull/28067)

🤖 Generated with [Claude Code](https://claude.com/claude-code)