### PR TITLE
docs: Document OpenAI account authentication

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai/index.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai/index.md
@@ -19,11 +19,20 @@ You can find authentication information for this node [here](/integrations/built
 
 ## Node parameters
 
+### Authentication
+
+Choose how to authenticate with OpenAI.
+
+- **API Key**: Use an OpenAI API key.
+- **OpenAI Account**: Connect a ChatGPT or OpenAI account without entering an API key. n8n uses an OpenAI device code login flow for this option.
+
 ### Model
 
 Select the model to use to generate the completion.
 
 n8n dynamically loads models from OpenAI, and you'll only see the models available to your account.
+
+When you use **OpenAI Account**, n8n loads the models available through your ChatGPT or OpenAI account. The default model is `gpt-5.4-mini`.
 
 ### Use Responses API
 OpenAI provides two endpoints for generating output from a model:
@@ -121,5 +130,3 @@ Refer to [OpenAI documentation](https://platform.openai.com/docs/api-reference/r
 ## Common issues
 
 For common questions or issues and suggested solutions, refer to [Common issues](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai/common-issues.md).
-
-

--- a/docs/integrations/builtin/credentials/openai.md
+++ b/docs/integrations/builtin/credentials/openai.md
@@ -21,10 +21,24 @@ Create an [OpenAI](https://platform.openai.com/signup/) account.
 ## Supported authentication methods
 
 - API key
+- OpenAI Account (ChatGPT)
 
 ## Related resources
 
 Refer to [OpenAI's API documentation](https://platform.openai.com/docs/introduction) for more information about the service.
+
+## Using OpenAI Account (ChatGPT)
+
+Use this method to connect the [OpenAI Chat Model](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatopenai/index.md) node with your ChatGPT or OpenAI account, without entering an API key.
+
+To configure this credential:
+
+1. In the OpenAI Chat Model node, set **Authentication** to **OpenAI Account**.
+2. Create or select an **OpenAI Account (ChatGPT)** credential.
+3. Select **Connect**.
+4. Open the OpenAI login page shown by n8n.
+5. Enter the code shown in n8n on the OpenAI login page.
+6. Return to n8n to finish connecting the credential.
 
 ## Using API key
 
@@ -48,4 +62,3 @@ To find your Organization ID:
 2. Copy your Organization ID and add it as the **Organization ID** in n8n.
 
 Refer to [Setting up your organization](https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization) for more information. Note that API requests made using an Organization ID will count toward the organization's subscription quota.
-


### PR DESCRIPTION
## Summary

Documents the new OpenAI Account authentication option for the OpenAI credential and the OpenAI Chat Model node.

This covers:

- the new **OpenAI Account (ChatGPT)** credential option
- the device code login steps
- the OpenAI Chat Model **Authentication** parameter
- the default model used with OpenAI Account authentication

## Dependency

This PR depends on n8n-io/n8n#29184. It should merge after the code PR that adds OpenAI Account authentication support.

Closes #4526.

## Validation

- `git diff --check`

I couldn't run the local MkDocs preview because `mkdocs` isn't installed in this checkout.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the new OpenAI Account (ChatGPT) authentication for the OpenAI credential and the OpenAI Chat Model node. Added device code login steps, clarified the Authentication parameter options, and noted that account auth loads models from your ChatGPT/OpenAI account with `gpt-5.4-mini` as the default.

<sup>Written for commit 2edc3bc1eb1e02ceeb5dfb6718ccc54758c1fd6a. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4527?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

