### PR TITLE
Update index.md

### DIFF
--- a/docs/integrations/builtin/credentials/index.md
+++ b/docs/integrations/builtin/credentials/index.md
@@ -1,4 +1,4 @@
----
+k---
 contentType: overview
 ---
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the frontmatter opening delimiter in `docs/integrations/builtin/credentials/index.md`, changing `----` to `k---` for the credentials overview page.

<sup>Written for commit e795bad36c5260b7db32033cf76e88021e03b4ab. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4531?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

