### PR TITLE
fix: exclude deprecated-and-versioned-nodes page from Lychee link check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -133,7 +133,7 @@ exclude = [
   ]
 
 # Exclude these filesystem paths from getting checked.
-exclude_path = ["file/path/to/Ignore", "./other/file/path/to/Ignore"]
+exclude_path = ["docs/integrations/builtin/deprecated-and-versioned-nodes.md"]
 
 # URLs to check (supports regex). Has preference over all excludes.
 # include = ['gist\.github\.com.*']


### PR DESCRIPTION
## Summary

- Adds `docs/integrations/builtin/deprecated-and-versioned-nodes.md` to the `exclude_path` list in `lychee.toml`
- The page contains no external links (pure reference tables), causing Lychee to exit with code 1 due to `failIfEmpty: true`

## Linear ticket

DOC-1918