### PR TITLE
revert: restore lychee.toml exclude_path placeholder values

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -133,7 +133,7 @@ exclude = [
   ]
 
 # Exclude these filesystem paths from getting checked.
-exclude_path = ["docs/integrations/builtin/deprecated-and-versioned-nodes.md"]
+exclude_path = ["file/path/to/Ignore", "./other/file/path/to/Ignore"]
 
 # URLs to check (supports regex). Has preference over all excludes.
 # include = ['gist\.github\.com.*']


### PR DESCRIPTION
## Summary

- Restores the original `exclude_path` placeholder values in `lychee.toml`
- PR #4539 replaced them with `deprecated-and-versioned-nodes.md` as an attempted fix for Lychee failing on pages with no external links — the fix didn't work and the team decided to merge as-is, so this cleans up the misleading config

## Linear ticket

DOC-1919