### PR TITLE
docs: Improve wording on import cli bug

### DIFF
--- a/docs/hosting/cli-commands.md
+++ b/docs/hosting/cli-commands.md
@@ -218,8 +218,11 @@ In this case, you can edit the names from the n8n interface and export again, or
 ### Workflows
 
 /// warning | Known issue: cron triggers keep running after import
-When importing a previously active workflow via `n8n import:workflow`, this then deactivated workflow's cron triggers will continue to run until you restart n8n.
-When running n8n in multi-main mode, all triggers will be deactivated as expected.
+The behaviour of importing a previously active workflow differs depending on the mode you are running. This is a known bug.
+
+On multi-main and queue-mode instances the previously active workflow's cron triggers are deactivated on import. 
+
+On non multi-main instances the previously active workflows cron triggers will remain running until you restart the n8n instance. 
 ///
 
 Import workflows from a specific file:

--- a/docs/log-streaming.md
+++ b/docs/log-streaming.md
@@ -60,7 +60,6 @@ The following events are available. You can choose which events to stream in **S
 	* User execution deleted
 	* Execution data revealed
 	* Execution data reveal failed
-	* Workflow executed
 	* Package installed
 	* Package updated
 	* Package deleted
@@ -72,6 +71,9 @@ The following events are available. You can choose which events to stream in **S
 	* Workflow activated
 	* Workflow deactivated
 	* Workflow version updated
+    * Workflow executed
+	* Workflow waiting
+	* Workflow resumed
 	* Variable created
 	* Variable updated
 	* Variable deleted


### PR DESCRIPTION
Updates the text of the import cli bug description according to https://linear.app/n8n/issue/LIGO-478/bug-scheduled-workflow-continues-running-after-cli-import#comment-e045b282

Also adds missing audit log stream events which were implemented in https://github.com/n8n-io/n8n/pull/28204

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the known bug for `n8n import:workflow` per LIGO-478: on multi‑main and queue‑mode, previously active workflow cron triggers are deactivated on import; on non‑multi‑main they keep running until restart. Adds missing audit log stream events: Workflow executed, Workflow waiting, Workflow resumed.

<sup>Written for commit ce423f2315ae0306b6c71fa1d31abbc9a9783fcd. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4544?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

