### PR TITLE
fix(docs): use backticks for HTML tags in attribute restrictions list

### DIFF
--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
@@ -166,11 +166,11 @@ The following tags are automatically removed for security: `<script>`, `<style>`
 
 Only specific attributes are allowed on certain tags:
 
-* Links (<a>): `href`, `target`, `rel`
-* Images (<img>): `src`, `alt`, `width`, `height`
-* Videos (<video>): `controls`, `autoplay`, `loop`, `muted`, `poster`, `width`, `height`
-* Iframes (<iframe>): `src`, `width`, `height`, `frameborder`, `allow`, `allowfullscreen`, `referrerpolicy` (automatically sandboxed)
-* Table cells (<td>, <th>): `colspan`, `rowspan`, `scope`, `headers`
+* Links (`<a>`): `href`, `target`, `rel`
+* Images (`<img>`): `src`, `alt`, `width`, `height`
+* Videos (`<video>`): `controls`, `autoplay`, `loop`, `muted`, `poster`, `width`, `height`
+* Iframes (`<iframe>`): `src`, `width`, `height`, `frameborder`, `allow`, `allowfullscreen`, `referrerpolicy` (automatically sandboxed)
+* Table cells (`<td>`, `<th>`): `colspan`, `rowspan`, `scope`, `headers`
 
 All other attributes are removed during sanitization. Only `http://` and `https://` URL schemes are permitted.
 


### PR DESCRIPTION
HTML tags in the attribute restrictions list were not wrapped in backticks, causing them to be rendered as actual HTML elements in Markdown clients.

https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger/#attribute-restrictions

<img width="819" height="661" alt="image" src="https://github.com/user-attachments/assets/1d9eb774-c87a-4f65-9f0a-341dc6256e5d" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrapped HTML tags (`<a>`, `<img>`, `<video>`, `<iframe>`, `<td>`, `<th>`) in the Form Trigger docs attribute restrictions list in backticks so they render as code instead of HTML in Markdown clients.

<sup>Written for commit b1268aab5146bc184234489591ff1b1bd7d3720e. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4545?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

