### PR TITLE
docs: Update Microsoft Agent 365 Trigger node for GA changes

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.microsoftagent365trigger/index.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.microsoftagent365trigger/index.md
@@ -22,12 +22,12 @@ You can find authentication information for this node [here](/integrations/built
 The Microsoft Agent 365 Trigger node can connect to the following sub-nodes:
 
 - **Model**: Connect a language model (Chat model sub-node) to process incoming messages
-- **Memory**: Connect a memory sub-node to maintain conversation context
+- **Memory**: Connect a memory sub-node to maintain conversation context. A single n8n workflow powers multiple Agent instances on the Microsoft side, so multiple users will interact with the same workflow. Choose your session ID key carefully to scope conversations to individual Agent instances and prevent conversation history from bleeding between them.
 - **Tool**: Connect tool sub-nodes to give your agent additional capabilities
 
 ## Node options
 
-### Enable Microsoft MCP Tools
+### Enable Microsoft Work IQ Tools for A365
 
 Toggle this option to give your agent access to Microsoft 365 tools through the Model Context Protocol (MCP). Default: Off.
 
@@ -46,14 +46,8 @@ When enabled, select one of:
 
 We recommend following these resources to set up your Agent 365 integration:
 
-1. [n8n Sample Agent Documentation](https://github.com/microsoft/Agent365-Samples/tree/main/nodejs/n8n/sample-agent): Example n8n agent implementation with Microsoft Agent 365
-2. [Agent 365 CLI Documentation](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/agent-365-cli): Cross-platform command-line tool for deploying and managing Agent 365 applications on Azure
-
-## Known limitations
-
-### No conversation context in metadata
-
-Currently, incoming messages don't include metadata to link memory to a specific user or conversation context. This functionality is coming soon.
+1. [Microsoft Agent 365 developer documentation](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/){:target="_blank" .external-link}: Official documentation for building agents with Microsoft Agent 365
+2. [Agent 365 CLI Documentation](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/agent-365-cli){:target="_blank" .external-link}: Cross-platform command-line tool for deploying and managing Agent 365 applications on Azure
 
 ## Related resources
 

--- a/docs/integrations/builtin/credentials/microsoftagent365.md
+++ b/docs/integrations/builtin/credentials/microsoftagent365.md
@@ -43,4 +43,4 @@ To set up the credential:
 2. Open the [Microsoft Application Registration Portal](https://aka.ms/appregistrations) and follow the [custom client app registration guide](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/custom-client-app-registration) for Microsoft Agent 365. Once your custom client app is created, copy the Application (client) ID into n8n as the **Client ID**.
 3. Follow the [credentials guide](https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-credentials?tabs=client-secret) to generate a client secret and copy the **Secret** in the **Value** column and paste it into n8n as the **Client Secret**.
 
-We recommend using [Agent 365 CLI](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/agent-365-cli) to create your agent blueprint and manifest. You can find more details in the [n8n Sample Agent repository](https://github.com/microsoft/Agent365-Samples/tree/main/nodejs/n8n/sample-agent) for Microsoft Agent 365.
+We recommend using [Agent 365 CLI](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/agent-365-cli){:target="_blank" .external-link} to create your agent blueprint and manifest.


### PR DESCRIPTION
Rename MCP Tools option to Work IQ Tools for A365, add memory session-scoping guidance, remove resolved known limitation, and replace stale sample repo link with official Microsoft docs.