### PR TITLE
Adds information for event log file

### DIFF
--- a/docs/hosting/configuration/environment-variables/logs.md
+++ b/docs/hosting/configuration/environment-variables/logs.md
@@ -44,7 +44,9 @@ Refer to [Log streaming](/log-streaming.md) for more information on this feature
 | `N8N_EVENTBUS_LOGWRITER_SYNCFILEACCESS` | Boolean | `false` | Whether all file access happens synchronously within the thread (true) or not (false). |
 | `N8N_EVENTBUS_LOGWRITER_KEEPLOGCOUNT` | Number | `3` | Number of event log files to keep. |
 | `N8N_EVENTBUS_LOGWRITER_MAXFILESIZEINKB` | Number | `10240` | Maximum size (in kilo-bytes) of an event log file before a new one starts. |
-| `N8N_EVENTBUS_LOGWRITER_LOGBASENAME` | String | `n8nEventLog` | Basename of the event log file. |
+| `N8N_EVENTBUS_LOGWRITER_LOGBASENAME` | String | `n8nEventLog` | Basename of the event log file. Ignored when `N8N_EVENTBUS_LOGWRITER_LOGFULLPATH` is set. |
+| `N8N_EVENTBUS_LOGWRITER_LOGFULLPATH` | String | `''` | Absolute path to the event log file. Must end in `.log`. When set, this path is used verbatim and overrides `N8N_EVENTBUS_LOGWRITER_LOGBASENAME` and the default per-process suffix. Use this to give each n8n process a unique event log path when multiple processes share a writable filesystem. Refer to [Per-process event log files](/log-streaming.md#per-process-event-log-files) for details. |
+| `N8N_EVENTBUS_LOGWRITER_MAXTOTALMESSAGESPERFILE` | Number | `500000` | Maximum number of lines parsed from a single event log file during recovery. Bounds memory use when an event log file contains many invalid lines. |
 
 ### Manage log streaming destinations from environment variables
 

--- a/docs/hosting/scaling/queue-mode.md
+++ b/docs/hosting/scaling/queue-mode.md
@@ -36,6 +36,10 @@ This is the process flow:
 
 Workers are n8n instances that do the actual work. They receive information from the main n8n process about the workflows that have to get executed, execute the workflows, and update the status after each execution is complete.
 
+/// note | Per-process event log files
+If your workers share a writable filesystem, give each worker process a unique event log path. Refer to [Per-process event log files](/log-streaming.md#per-process-event-log-files) for details.
+///
+
 ### Set encryption key
 
 n8n automatically generates an encryption key upon first startup. You can also provide your own custom key using [environment variable](/hosting/configuration/environment-variables/index.md) if desired.

--- a/docs/log-streaming.md
+++ b/docs/log-streaming.md
@@ -25,6 +25,27 @@ To use log streaming, you have to add a streaming destination.
 /// note | Self-hosted users
 If you self-host n8n, you can configure additional log streaming behavior using [Environment variables](/hosting/configuration/environment-variables/logs.md#log-streaming). You can also manage destinations from environment variables, see [Configure log streaming destinations using environment variables](#configure-using-environment-variables).
 ///
+
+## Per-process event log files
+
+n8n persists each emitted event to a local log file before forwarding it to streaming destinations. The file survives restarts and lets n8n re-emit events that weren't yet delivered.
+
+By default, n8n writes the event log to `<n8n-user-folder>/n8nEventLog.log`, with a `-worker` or `-webhook-processor` suffix on those processes. When a single n8n process owns the file, this default works as expected.
+
+/// warning | Shared writable filesystems
+If multiple n8n processes share one writable volume, for example [queue mode](/hosting/scaling/queue-mode.md) workers backed by a shared persistent volume on NFS or EFS, they must not write to the same event log file. Concurrent appends from multiple processes can interleave or corrupt the file, leading to recovery failures and lost events.
+///
+
+To avoid this, set [`N8N_EVENTBUS_LOGWRITER_LOGFULLPATH`](/hosting/configuration/environment-variables/logs.md#log-streaming) on each process to a unique absolute path that ends in `.log`. n8n uses the configured path verbatim and doesn't append a process-type suffix, so your orchestrator owns uniqueness across processes. On Kubernetes, one common pattern is to inject the pod name through the [Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/){:target="_blank" .external-link} and combine it with `subPathExpr: $(POD_NAME)` on the volume mount, but any mechanism that produces a unique path per process works.
+
+The companion variable [`N8N_EVENTBUS_LOGWRITER_MAXTOTALMESSAGESPERFILE`](/hosting/configuration/environment-variables/logs.md#log-streaming) bounds how many lines n8n parses from a single event log file during recovery, so a corrupted file can't exhaust process memory.
+
+Notes:
+
+* Default behavior is unchanged when `N8N_EVENTBUS_LOGWRITER_LOGFULLPATH` isn't set.
+* When the variable is set, n8n doesn't auto-suffix the path. Each process must receive its own value.
+* If a shared `n8nEventLog-worker.log` file already exists from a previous deployment, quarantine it manually before opting in. n8n doesn't auto-delete legacy files.
+
 ## Events
 
 The following events are available. You can choose which events to stream in **Settings** > **Log Streaming** > **Events**.

--- a/docs/log-streaming.md
+++ b/docs/log-streaming.md
@@ -36,7 +36,7 @@ By default, n8n writes the event log to `<n8n-user-folder>/n8nEventLog.log`, wit
 If multiple n8n processes share one writable volume, for example [queue mode](/hosting/scaling/queue-mode.md) workers backed by a shared persistent volume on NFS or EFS, they must not write to the same event log file. Concurrent appends from multiple processes can interleave or corrupt the file, leading to recovery failures and lost events.
 ///
 
-To avoid this, set [`N8N_EVENTBUS_LOGWRITER_LOGFULLPATH`](/hosting/configuration/environment-variables/logs.md#log-streaming) on each process to a unique absolute path that ends in `.log`. n8n uses the configured path verbatim and doesn't append a process-type suffix, so your orchestrator owns uniqueness across processes. On Kubernetes, one common pattern is to inject the pod name through the [Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/){:target="_blank" .external-link} and combine it with `subPathExpr: $(POD_NAME)` on the volume mount, but any mechanism that produces a unique path per process works.
+To avoid this, set [`N8N_EVENTBUS_LOGWRITER_LOGFULLPATH`](/hosting/configuration/environment-variables/logs.md#log-streaming) on each process to a unique absolute path that ends in `.log`. n8n uses the configured path verbatim and doesn't append a process-type suffix, so your orchestrator owns uniqueness across processes.
 
 The companion variable [`N8N_EVENTBUS_LOGWRITER_MAXTOTALMESSAGESPERFILE`](/hosting/configuration/environment-variables/logs.md#log-streaming) bounds how many lines n8n parses from a single event log file during recovery, so a corrupted file can't exhaust process memory.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds docs for per‑process event log files on shared writable filesystems, with a new “Per‑process event log files” section in `log-streaming.md` and cross‑links from env‑var and queue‑mode docs to prevent shared‑volume corruption. Meets Linear IAM‑580 by documenting `N8N_EVENTBUS_LOGWRITER_LOGFULLPATH` (absolute `.log`, used verbatim; overrides `N8N_EVENTBUS_LOGWRITER_LOGBASENAME` and disables the default suffix) and `N8N_EVENTBUS_LOGWRITER_MAXTOTALMESSAGESPERFILE`; clarifies that `N8N_EVENTBUS_LOGWRITER_LOGBASENAME` is ignored when a full path is set.

- **Migration**
  - Set `N8N_EVENTBUS_LOGWRITER_LOGFULLPATH` to a unique `.log` per process; no auto‑suffix is added and the basename is ignored.
  - Quarantine any shared `n8nEventLog-worker.log` before opting in.

<sup>Written for commit b46c63cc94b60cc9612c24910774bd6d60dddf1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

