### PR TITLE
docs: add Max Emails per Poll parameter to Gmail Trigger node

### DIFF
--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/index.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/index.md
@@ -29,6 +29,7 @@ Configure the node with these parameters:
 * **Poll Times**: Select a poll **Mode** to set how often to trigger the poll. Your **Mode** selection will add or remove relevant fields. Refer to [Poll Mode options](/integrations/builtin/trigger-nodes/n8n-nodes-base.gmailtrigger/poll-mode-options.md) to configure the parameters for each mode type.
 * **Simplify**: Choose whether to return a simplified version of the response (turned on, default) or the raw data (turned off).
     * The simplified version returns email message IDs, labels, and email headers, including: From, To, CC, BCC, and Subject.
+* **Max Emails per Poll**: Enter the maximum number of emails the node fetches per poll cycle. The default is 10, with a maximum of 50. If there are more unread emails than the limit, the node queues the remaining emails and fetches them in the next poll cycle.
 
 ## Node filters
 


### PR DESCRIPTION
## Summary

- Documents the new **Max Emails per Poll** parameter added to the Gmail Trigger node in n8n 2.19.0
- Default: 10, maximum: 50
- Queues remaining emails for the next poll cycle when the limit is reached

## Linear ticket

DOC-1821

## Related

- Feature PR: n8n-io/n8n#28470