### PR TITLE
fix: update submodule configuration and build command in netlify.toml

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "_submodules/insiders"]
+	path = _submodules/insiders
+	url = git@github.com:n8n-io/mkdocs-material-insiders.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "_submodules/insiders"]
-	path = _submodules/insiders
-	url = git@github.com:n8n-io/mkdocs-material-insiders.git

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "pip install -r requirements.txt && mkdocs build --strict"
+  command = "pip install mkdocs-material && mkdocs build --strict"
   publish = "site"
 [[headers]]
   for = "/*"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the docs build to the public `mkdocs-material` to replace the deleted insiders submodule and restore Netlify builds (DOC-1926).
Update `netlify.toml` to run `pip install mkdocs-material && mkdocs build --strict`, and remove the insiders submodule from `.gitmodules`.

<sup>Written for commit bbea2813a091eb11c348d562d8b088d2a5e794f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

