### PR TITLE
Add per-workflow LangSmith tracing configuration docs

### DIFF
--- a/docs/advanced-ai/langchain/langsmith.md
+++ b/docs/advanced-ai/langchain/langsmith.md
@@ -40,4 +40,32 @@ Self-hosted n8n only.
 
 1. Restart n8n.
 
+## Per-workflow LangSmith configuration
+
+In addition to instance-wide environment variables, you can configure LangSmith tracing on a per-workflow basis. This lets you send traces from different workflows to different LangSmith projects or accounts without changing global settings.
+
+### Set up a LangSmith credential
+
+1. Go to **Settings** > **Credentials** and select **Add Credential**.
+2. Search for **LangSmith API** and select it.
+3. Enter your **API Key** from [LangSmith settings](https://smith.langchain.com/settings).
+4. Optionally change the **API URL** if you use a self-hosted LangSmith instance.
+5. Select **Save** to store the credential.
+
+### Configure a workflow to use LangSmith
+
+1. Open your workflow.
+2. Select the **three dots icon** <span class="n8n-inline-image">![three dots icon](/_images/common-icons/three-dots-horizontal.png){.off-glb}</span> in the upper-right corner.
+3. Select **Settings**.
+4. In the **LangSmith** section:
+   - **LangSmith Credential**: Select the LangSmith API credential to use for this workflow.
+   - **LangSmith Project**: Enter the project name where traces should appear. Defaults to `"default"` if left empty.
+5. Select **Save**.
+
+Once configured, all AI node executions in that workflow send traces to the specified LangSmith project. This overrides any instance-level `LANGCHAIN_PROJECT` environment variable for this workflow.
+
+/// note
+The per-workflow setting requires creating a LangSmith API credential. The credential stores the API key securely using n8n's credential encryption.
+///
+
 For information on using LangSmith, refer to [LangSmith's documentation](https://docs.smith.langchain.com/).

--- a/docs/advanced-ai/langchain/langsmith.md
+++ b/docs/advanced-ai/langchain/langsmith.md
@@ -49,8 +49,7 @@ In addition to instance-wide environment variables, you can configure LangSmith 
 1. Go to **Settings** > **Credentials** and select **Add Credential**.
 2. Search for **LangSmith API** and select it.
 3. Enter your **API Key** from [LangSmith settings](https://smith.langchain.com/settings).
-4. Optionally change the **API URL** if you use a self-hosted LangSmith instance.
-5. Select **Save** to store the credential.
+4. Select **Save** to store the credential.
 
 ### Configure a workflow to use LangSmith
 

--- a/docs/workflows/settings.md
+++ b/docs/workflows/settings.md
@@ -82,6 +82,15 @@ Controls whether n8n redacts execution data from manually triggered executions. 
 
 Refer to [Execution data redaction](/workflows/executions/execution-data-redaction.md) for details on redaction policies, revealing data, and permission requirements.
 
+### LangSmith tracing
+
+Configure [LangSmith](/advanced-ai/langchain/langsmith.md) tracing on a per-workflow basis to monitor AI node executions.
+
+- **LangSmith Credential**: Select a LangSmith API credential to enable tracing for this workflow.
+- **LangSmith Project**: The LangSmith project name where traces appear. Defaults to `"default"`.
+
+This overrides any instance-level LangSmith environment variables for the workflow. See [Use LangSmith with n8n](/advanced-ai/langchain/langsmith.md#per-workflow-langsmith-configuration) for setup instructions.
+
 ### Estimated time saved
 
 An estimate of the number of minutes each of execution of this workflow saves you.


### PR DESCRIPTION
## Summary
- Add documentation for the new per-workflow LangSmith tracing settings in workflow settings(Code Change PR:https://github.com/n8n-io/n8n/pull/29783)
- Documents the **LangSmith Credential** and **LangSmith Project** options that allow users to configure LangSmith tracing on individual workflows, overriding instance-level environment variables



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented per-workflow LangSmith tracing so you can route AI node traces from specific workflows to different projects or accounts without changing global settings. Added step-by-step setup for a `LangSmith API` credential (stored with n8n credential encryption) and updated Workflow Settings with a LangSmith section to select a credential and project (defaults to "default"); workflow-level settings override instance env vars like `LANGCHAIN_PROJECT`.

<sup>Written for commit ec5e25965e891d713845286dfe01a83f2691904a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





