### PR TITLE
fix: add mkdocs-material to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+mkdocs-material>=9.7.0
 mkdocs-exclude==1.0.2
 mkdocs-glightbox
 mkdocs-llmstxt==0.3.1


### PR DESCRIPTION
## Summary

- Adds `mkdocs-material>=9.7.0` to `requirements.txt`

The private `n8n-io/mkdocs-material-insiders` repo was deleted on May 1, 2026 as part of the sunsetting of the MkDocs Material Insiders sponsorware model. All insiders features are now included in the public 9.7.0 release.

This change ensures `mkdocs-material` is explicitly installed via `requirements.txt`, unblocking builds once the submodule and build command changes from [#4568](https://github.com/n8n-io/n8n-docs/pull/4568) are merged.

Resolves [DOC-1928](https://linear.app/n8n/issue/DOC-1928/requirementstxt-change).

## Test plan
- [x] `mkdocs build --strict` passes locally with zero errors (mkdocs-material 9.7.6)
- [ ] Netlify deploy preview passes
- [ ] Cloudflare Pages build passes