### PR TITLE
docs: Explain new --activeState=json flag for import:workflow

### DIFF
--- a/docs/hosting/cli-commands.md
+++ b/docs/hosting/cli-commands.md
@@ -206,6 +206,7 @@ Available flags:
 | --separate | Imports `*.json` files from directory provided by --input. |
 | --userId | Import the workflow or credential to the specified user. Can't be used with `--projectId`. |
 | --skipMigrationChecks | Skip migration validation checks. |
+| --activeState | Controls the active state of imported workflows. Accepts `false` (default, deactivates all imported workflows) or `fromJson` (uses the `active` field from each workflow's JSON; multi-main mode only). |
 
 /// note | Migrating to SQLite
 n8n limits workflow and credential names to 128 characters, but SQLite doesn't enforce size limits.
@@ -235,6 +236,12 @@ Import all the workflow files as JSON from the specified directory:
 
 ```bash
 n8n import:workflow --separate --input=backups/latest/
+```
+
+By default, `import:workflow` deactivates every imported workflow. To preserve the `active` field from each JSON file instead, pass `--activeState=fromJson` (only supported in multi-main & queue mode):
+
+```bash
+n8n import:workflow --separate --input=backups/latest/ --activeState=fromJson
 ```
 
 ### Credentials


### PR DESCRIPTION
Docs for new feature added in https://github.com/n8n-io/n8n/pull/29341

See update here: https://ligo-482-add-docs-for-active.n8n-docs-d9c.pages.dev/hosting/cli-commands/#workflows_1


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add docs for the new `--activeState` flag on `import:workflow` that controls activation on import: `false` (default) deactivates all, `fromJson` preserves each workflow’s `active` value. This completes LIGO-482 by enabling CLI imports without auto-deactivation in multi-main and queue modes.

<sup>Written for commit 74a6ed734183ad6fffa7f09a60a4824a3812d38a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



