### PR TITLE
chore: add Context7 library claim file

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/n8n-io/n8n-docs",
+  "public_key": "pk_njsfwAcAgfpxvLdUf5R7h"
+}


### PR DESCRIPTION
## Summary

Adds `context7.json` to the repository root to claim the n8n-docs library on Context7. Context7 indexes our documentation and makes it available as context for AI tools and LLM integrations.

## Linear ticket

DOC-1945