### PR TITLE
fix: correct grammar in OpenTelemetry tracing introduction

### DIFF
--- a/docs/hosting/logging-monitoring/opentelemetry.md
+++ b/docs/hosting/logging-monitoring/opentelemetry.md
@@ -12,7 +12,7 @@ Agent telemetry and open telemetry formatted metrics will be coming soon
 n8n can emit [OpenTelemetry](https://opentelemetry.io/){:target="_blank" .external-link} traces for workflow and node executions. Use these traces to monitor execution latency, debug failures, and track requests across services in your observability stack.
 
 /// info | Feature availability
-OpenTelemetry workflow tracing requires environment variables are set so is available on self-hosted n8n only.
+OpenTelemetry workflow tracing requires environment variables to be set, so it's available on self-hosted n8n only.
 ///
 
 ## What you get


### PR DESCRIPTION
## Summary

- Fixes a grammar error in the Feature availability info block on the OpenTelemetry tracing page
- Before: "requires environment variables are set so is available on self-hosted n8n only"
- After: "requires environment variables to be set, so it's available on self-hosted n8n only"

## Linear ticket

https://linear.app/n8n/issue/DOC-1949