### PR TITLE
docs: Document n8n API Base URL for node credential setup (DOC-1920)

### DIFF
--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -46,6 +46,17 @@ curl -X 'GET' \
   -H 'X-N8N-API-KEY: <your-api-key>'
 ```
 
+## Node configuration
+
+To call the n8n API from within a workflow, use the [n8n node](/integrations/builtin/core-nodes/n8n-nodes-base.n8n.md). When you create the credential, fill these fields:
+
+- **API Key**: paste the key you created in [Create an API key](#create-an-api-key).
+- **Base URL**: enter your instance's API root in one of these formats:
+	- Cloud: `https://<name>.app.n8n.cloud/api/v1`, where `<name>` is your Cloud subdomain.
+	- Self-hosted: `https://<your-instance-url>/api/v1`.
+
+For the available operations and parameters, refer to the [n8n node](/integrations/builtin/core-nodes/n8n-nodes-base.n8n.md) documentation.
+
 ## Delete an API key
 
 1. Log in to n8n.


### PR DESCRIPTION
## Summary

- Adds a **Node configuration** section to [docs/api/authentication.md](docs/api/authentication.md) covering the **Base URL** and **API Key** fields users see when setting up the n8n node credential.
- Documents both formats explicitly:
  - Cloud: `https://<name>.app.n8n.cloud/api/v1`
  - Self-hosted: `https://<your-instance-url>/api/v1`
- Cross-links to the [n8n core node](/integrations/builtin/core-nodes/n8n-nodes-base.n8n.md) page for the full operations reference. The n8n node page already links back to this page for credential info, so this completes the loop.

Closes [DOC-1920](https://linear.app/n8n/issue/DOC-1920).

## Test plan

- [ ] Preview `/api/authentication/` and confirm the new section renders between "Call the API using your key" and "Delete an API key".
- [ ] Confirm both Base URL formats render in code spans and the cross-link to the n8n node page resolves.
- [ ] In a running n8n instance, paste each Base URL format into the n8n node credential and verify a successful API call.