### PR TITLE
Support PRs: Multiple-mixed prs

### DIFF
--- a/docs/hosting/configuration/environment-variables/task-runners.md
+++ b/docs/hosting/configuration/environment-variables/task-runners.md
@@ -32,7 +32,7 @@ Unlike the main n8n image, you CANNOT use file-based configuration for secrets i
 | `N8N_RUNNERS_TASK_TIMEOUT` | Number | `300` | The maximum time, in seconds, a task can run before the runner stops it and restarts. This value must be greater than 0. |
 | `N8N_RUNNERS_HEARTBEAT_INTERVAL` | Number | `30` | The interval, in seconds, at which the runner must send a heartbeat to the broker. If the runner doesn't send a heartbeat in time, the task stops and the runner restarts. This value must be greater than 0. |
 | `N8N_RUNNERS_INSECURE_MODE` | Boolean | `false` | Whether to disable all security measures in the task runner, for compatibility with modules that rely on insecure JS features. **Discouraged for production use.** |
-| `N8N_RUNNERS_TASK_REQUEST_TIMEOUT` | Number | `20` | How long (in seconds) a task request can wait for a runner to become available before timing out. This prevents workflows from hanging indefinitely when no runners are available. Must be greater than 0. |
+| `N8N_RUNNERS_TASK_REQUEST_TIMEOUT` | Number | `60` | How long (in seconds) a task request can wait for a runner to become available before timing out. This prevents workflows from hanging indefinitely when no runners are available. Must be greater than 0. |
 
 ## Task runner launcher environment variables
 

--- a/docs/hosting/scaling/external-storage.md
+++ b/docs/hosting/scaling/external-storage.md
@@ -64,14 +64,16 @@ export N8N_EXTERNAL_STORAGE_S3_ACCESS_SECRET=...
 If your provider doesn't require a region, you can set `N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION` to `'auto'`.
 ///
 
-## Important update: S3 bucket region validation and upgrade guidelines
+## Validate and update your S3 bucket region format (v2.6.4 onward)
 
-Starting from **n8n version 2.6.4**, the AWS SDK used for S3 storage enforces stricter validation of the value provided in `N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION`. The region value:
+Starting from n8n v2.6.4, the value of the environment variable `N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION` must meet these conditions:
 
-- Must only contain alphanumeric characters (`a-z`, `A-Z`, `0-9`) and hyphens (`-`).
-- Underscores (`_`) or other special characters are **not allowed**, and will cause n8n to fail startup with connection errors, even if the storage endpoint is reachable and was previously working in older versions.
+- Only contain alphanumeric characters (`a-z`, `A-Z`, `0-9`) and hyphens (`-`).
+- Not contain underscores (`_`) or other special characters.
 
-If you experience connection failures to S3 immediately after upgrading to 2.6.4 or later, verify and update your region value to comply with this format and redeploy n8n.
+If these conditions are not met, n8n will fail startup with connection errors even if the storage endpoint is reachable and was previously working in older versions.
+
+If S3 connection fails after upgrading n8n to v2.6.4, verify your region value matches these conditions and redeploy n8n.
 
 Tell n8n to store binary data in S3:
 
@@ -101,12 +103,12 @@ If you store binary data in S3 and later switch to filesystem mode, the instance
 
 --8<-- "_snippets/self-hosting/scaling/binary-data-pruning.md"
 
-### Upgrade best practices for S3 binary data storage
+### Upgrade best practices for S3 storage
 
-To ensure smooth upgrades when using S3 or S3-compatible storage:
+When using S3 or S3-compatible storage:
 
-1. Upgrade **all** n8n components (main, worker, runner) to the exact same version simultaneously to avoid protocol incompatibilities.
-2. When using on-premise or S3-compatible storage over HTTP, set `N8N_EXTERNAL_STORAGE_S3_PROTOCOL=http` and include the protocol explicitly in the host configuration.
-3. Use only supported environment variable names as documented; for access key, use `N8N_EXTERNAL_STORAGE_S3_ACCESS_KEY`.
+1. Upgrade all n8n components (main, worker, runner) to the same version simultaneously to avoid protocol incompatibilities.
+2. For on-premise or S3-compatible storage over HTTP, set `N8N_EXTERNAL_STORAGE_S3_PROTOCOL=http` and include the protocol in the host configuration.
+3. Use only supported environment variable names: for access key, use `N8N_EXTERNAL_STORAGE_S3_ACCESS_KEY`.
 
-These requirements arise from stricter validation and improved protocol handling in newer n8n releases, and older configurations might require adjustments following upgrades.
+Newer n8n versions have stricter validation and protocol handling. Older configurations may need updates after upgrading.

--- a/docs/hosting/scaling/external-storage.md
+++ b/docs/hosting/scaling/external-storage.md
@@ -63,6 +63,16 @@ export N8N_EXTERNAL_STORAGE_S3_ACCESS_SECRET=...
 /// note | No region
 If your provider doesn't require a region, you can set `N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION` to `'auto'`.
 ///
+
+## Important update: S3 bucket region validation and upgrade guidelines
+
+Starting from **n8n version 2.6.4**, the AWS SDK used for S3 storage enforces stricter validation of the value provided in `N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION`. The region value:
+
+- Must only contain alphanumeric characters (`a-z`, `A-Z`, `0-9`) and hyphens (`-`).
+- Underscores (`_`) or other special characters are **not allowed**, and will cause n8n to fail startup with connection errors, even if the storage endpoint is reachable and was previously working in older versions.
+
+If you experience connection failures to S3 immediately after upgrading to 2.6.4 or later, verify and update your region value to comply with this format and redeploy n8n.
+
 Tell n8n to store binary data in S3:
 
 ```sh
@@ -90,3 +100,13 @@ n8n continues to read older binary data stored in the filesystem from the filesy
 If you store binary data in S3 and later switch to filesystem mode, the instance continues to read any data stored in S3, as long as `s3` remains listed in `N8N_AVAILABLE_BINARY_DATA_MODES` and your S3 credentials remain valid.
 
 --8<-- "_snippets/self-hosting/scaling/binary-data-pruning.md"
+
+### Upgrade best practices for S3 binary data storage
+
+To ensure smooth upgrades when using S3 or S3-compatible storage:
+
+1. Upgrade **all** n8n components (main, worker, runner) to the exact same version simultaneously to avoid protocol incompatibilities.
+2. When using on-premise or S3-compatible storage over HTTP, set `N8N_EXTERNAL_STORAGE_S3_PROTOCOL=http` and include the protocol explicitly in the host configuration.
+3. Use only supported environment variable names as documented; for access key, use `N8N_EXTERNAL_STORAGE_S3_ACCESS_KEY`.
+
+These requirements arise from stricter validation and improved protocol handling in newer n8n releases, and older configurations might require adjustments following upgrades.

--- a/docs/user-management/saml/azuread.md
+++ b/docs/user-management/saml/azuread.md
@@ -93,6 +93,21 @@ Conditions are evaluated in order. Place the most privileged group (owners) at t
 
 * Check condition order (most privileged group should be last).
 
+## Assigning Multiple Project Roles Using App Roles Instead of Group-based Claims
+
+Using Azure AD group-based claim conditions for assigning multiple project roles to users often results in only the first matching group claim being sent in the SAML assertion. This means users may see access to only one project despite belonging to several groups.
+
+To reliably assign multiple projects with their respective roles, use **App Roles** defined in the App Registration instead of group-based claims:
+
+1. In the **App Registration** for your n8n SAML app, define App Roles representing each project and permission combination (e.g., `<projectId>:<role>`).
+2. Save the updated App Manifest.
+3. In the **Enterprise Application**, assign users or groups to these App Roles under **Users and groups**.
+4. Update the `n8n_projects` SAML claim in **Single sign-on > Attributes & Claims** to source from `user.assignedroles`. This emits all assigned roles as an array in the SAML response.
+
+This setup ensures n8n receives all project assignments correctly, enabling appropriate access across multiple projects. While defining App Roles adds initial administrative overhead, it simplifies ongoing user-role management and guarantees complete project role sync.
+
+When migrating from group-based claims to App Roles, adjust your role definitions and claims mapping accordingly to prevent incomplete project access.
+
 ## References
 
 * [n8n SAML Setup](https://docs.n8n.io/user-management/saml/setup/)

--- a/docs/user-management/saml/azuread.md
+++ b/docs/user-management/saml/azuread.md
@@ -93,13 +93,13 @@ Conditions are evaluated in order. Place the most privileged group (owners) at t
 
 * Check condition order (most privileged group should be last).
 
-## Assigning Multiple Project Roles Using App Roles Instead of Group-based Claims
+## Assigning multiple project roles using app roles instead of group-based claims
 
 Using Azure AD group-based claim conditions for assigning multiple project roles to users often results in only the first matching group claim being sent in the SAML assertion. This means users may see access to only one project despite belonging to several groups.
 
 To reliably assign multiple projects with their respective roles, use **App Roles** defined in the App Registration instead of group-based claims:
 
-1. In the **App Registration** for your n8n SAML app, define App Roles representing each project and permission combination (e.g., `<projectId>:<role>`).
+1. In the **App Registration** for your n8n SAML app, define App Roles representing each project and permission combination (for example, `<projectId>:<role>`).
 2. Save the updated App Manifest.
 3. In the **Enterprise Application**, assign users or groups to these App Roles under **Users and groups**.
 4. Update the `n8n_projects` SAML claim in **Single sign-on > Attributes & Claims** to source from `user.assignedroles`. This emits all assigned roles as an array in the SAML response.


### PR DESCRIPTION
- Fixed wrong default value for N8N_RUNNERS_TASK_REQUEST_TIMEOUT: It was 20, but we can see [here] that the correct one is 60. (https://github.com/n8n-io/n8n/blob/46739a5bc464af81ebf5145d2ae37fd3bfbb5fa8/packages/%40n8n/config/src/configs/runners.config.ts#L61) 
- S3 Binary Data storage region validation and upgrade compatibility.
-  Assigning multiple projects with their respective roles using App roles instead of group-based claims.