### PR TITLE
Document the Reasoning Effort option for the Azure OpenAI Chat Model node

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatazureopenai.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatazureopenai.md
@@ -26,6 +26,7 @@ You can find authentication information for this node [here](/integrations/built
 * **Frequency Penalty**: Use this option to control the chances of the model repeating itself. Higher values reduce the chance of the model repeating itself.
 * **Maximum Number of Tokens**: Enter the maximum number of tokens used, which sets the completion length.
 * **Response Format**: Choose **Text** or **JSON**. **JSON** ensures the model returns valid JSON.
+* **Reasoning Effort**: Choose **Low**, **Medium**, or **High** to control how much reasoning the model does before responding. Higher effort can improve results on complex tasks but uses more tokens and increases response time. Only applies to reasoning-capable model deployments, such as the o-series or GPT-5.
 * **Presence Penalty**: Use this option to control the chances of the model talking about new topics. Higher values increase the chance of the model talking about new topics.
 * **Sampling Temperature**: Use this option to control the randomness of the sampling process. A higher temperature creates more diverse sampling, but increases the risk of hallucinations.
 * **Timeout**: Enter the maximum request time in milliseconds.


### PR DESCRIPTION
## What

Documents the new **Reasoning Effort** node option on the Azure OpenAI Chat Model node, in the **Node options** list of `n8n-nodes-langchain.lmchatazureopenai.md`.

## Why

The option was added to the node in the product repo (n8n-io/n8n#30553), in response to a community request. This page already documents every other node option, so adding this one keeps the reference complete and matches what users see in the editor.

## Notes

- Placed in code order: after **Response Format**, before **Presence Penalty**.
- Written to match the existing page style and the Microsoft Writing Style Guide (active voice, present tense, bold UI values).
- Single-line addition; no images or other files involved.

## Related

- Product PR that adds the option: https://github.com/n8n-io/n8n/pull/30553
- Community feature request: https://community.n8n.io/t/add-reasoning-effort-parameter-to-azure-openai-chat-model-node/162624

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Reasoning Effort option to the Azure OpenAI Chat Model node docs, with a short description of Low/Medium/High and when it applies. Keeps the node options list complete and aligned with the product update.

<sup>Written for commit db960ea4438c4edfc66b4561e12c7072dded4b6b. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4648?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

