### PR TITLE
docs: clarify self-hosted owner email changes

### DIFF
--- a/_snippets/self-hosting/configuration/environment-variables/settings-env-vars/instance-owner.md
+++ b/_snippets/self-hosting/configuration/environment-variables/settings-env-vars/instance-owner.md
@@ -6,4 +6,7 @@
 | `N8N_INSTANCE_OWNER_LAST_NAME` | String | - | Last name for the instance owner. |
 | `N8N_INSTANCE_OWNER_PASSWORD_HASH` | String | - | Bcrypt hash of the instance owner's password. Setting a plaintext password breaks login. |
 
+/// note | Owner email must be unique
+`N8N_INSTANCE_OWNER_EMAIL` must not already belong to another user on the instance. This setting updates the existing instance owner account; it doesn't transfer ownership to another existing user or merge user accounts. To use an email address that already belongs to another user, change or delete that user first so the email becomes available.
+///
 

--- a/_snippets/self-hosting/configuration/environment-variables/settings-env-vars/instance-owner.md
+++ b/_snippets/self-hosting/configuration/environment-variables/settings-env-vars/instance-owner.md
@@ -6,6 +6,6 @@
 | `N8N_INSTANCE_OWNER_LAST_NAME` | String | - | Last name for the instance owner. |
 | `N8N_INSTANCE_OWNER_PASSWORD_HASH` | String | - | Bcrypt hash of the instance owner's password. Setting a plaintext password breaks login. |
 
-/// note | Owner email must be unique
+/// warning | Owner email must be unique
 `N8N_INSTANCE_OWNER_EMAIL` must not already belong to another user on the instance. This setting updates the existing instance owner account; it doesn't transfer ownership to another existing user or merge user accounts. To use an email address that already belongs to another user, change or delete that user first so the email becomes available.
 ///

--- a/_snippets/self-hosting/configuration/environment-variables/settings-env-vars/instance-owner.md
+++ b/_snippets/self-hosting/configuration/environment-variables/settings-env-vars/instance-owner.md
@@ -9,4 +9,3 @@
 /// note | Owner email must be unique
 `N8N_INSTANCE_OWNER_EMAIL` must not already belong to another user on the instance. This setting updates the existing instance owner account; it doesn't transfer ownership to another existing user or merge user accounts. To use an email address that already belongs to another user, change or delete that user first so the email becomes available.
 ///
-

--- a/docs/hosting/configuration/change-instance-owner-email.md
+++ b/docs/hosting/configuration/change-instance-owner-email.md
@@ -6,7 +6,7 @@ contentType: howto
 
 # Change the instance owner email for self-hosted n8n
 
-You can change the instance owner email from the UI, or from environment variables if you manage the instance owner declaratively.
+You can change the instance owner email from the UI, or from environment variables if you manage the instance owner that way.
 
 /// note | Owner email must be unique
 The owner email must not already belong to another user on the instance. If the email you want is already used by another user, change or delete that user first so the email becomes available.

--- a/docs/hosting/configuration/change-instance-owner-email.md
+++ b/docs/hosting/configuration/change-instance-owner-email.md
@@ -1,6 +1,6 @@
 ---
 title: Change the instance owner email for self-hosted n8n
-description: Change the owner email for a self-hosted n8n instance using the UI or environment variables.
+description: Change the owner email address for a self-hosted n8n instance using the UI or environment variables.
 contentType: howto
 ---
 
@@ -30,7 +30,7 @@ If you manage the instance owner using environment variables:
 3. Keep `N8N_INSTANCE_OWNER_FIRST_NAME`, `N8N_INSTANCE_OWNER_LAST_NAME`, and `N8N_INSTANCE_OWNER_PASSWORD_HASH` set.
 4. Restart n8n.
 
-When `N8N_INSTANCE_OWNER_MANAGED_BY_ENV` is `true`, n8n reapplies the owner details on every startup. The matching UI controls become read-only, and n8n rejects API writes to that user.
+When `N8N_INSTANCE_OWNER_MANAGED_BY_ENV` is `true`, n8n reapplies the owner details on every startup. The matching UI controls become read-only.
 
 /// warning | `N8N_INSTANCE_OWNER_PASSWORD_HASH` must be a bcrypt hash
 This variable expects a pre-hashed bcrypt value. Setting a plaintext password breaks login.

--- a/docs/hosting/configuration/change-instance-owner-email.md
+++ b/docs/hosting/configuration/change-instance-owner-email.md
@@ -1,0 +1,39 @@
+---
+title: Change the instance owner email for self-hosted n8n
+description: Change the owner email for a self-hosted n8n instance using the UI or environment variables.
+contentType: howto
+---
+
+# Change the instance owner email for self-hosted n8n
+
+You can change the instance owner email from the UI, or from environment variables if you manage the instance owner declaratively.
+
+/// note | Owner email must be unique
+The owner email must not already belong to another user on the instance. If the email you want is already used by another user, change or delete that user first so the email becomes available.
+///
+
+Changing the owner email updates the existing instance owner account. It doesn't transfer ownership to another existing user or merge user accounts.
+
+## Change the owner email in the UI
+
+1. Log in as the instance owner.
+2. Go to **Settings** > **Personal**.
+3. Update the **Email** field.
+4. Select **Save**.
+
+## Change the owner email using environment variables
+
+If you manage the instance owner using environment variables:
+
+1. Set `N8N_INSTANCE_OWNER_MANAGED_BY_ENV` to `true`.
+2. Set `N8N_INSTANCE_OWNER_EMAIL` to the new owner email.
+3. Keep `N8N_INSTANCE_OWNER_FIRST_NAME`, `N8N_INSTANCE_OWNER_LAST_NAME`, and `N8N_INSTANCE_OWNER_PASSWORD_HASH` set.
+4. Restart n8n.
+
+When `N8N_INSTANCE_OWNER_MANAGED_BY_ENV` is `true`, n8n reapplies the owner details on every startup. The matching UI controls become read-only, and n8n rejects API writes to that user.
+
+/// warning | `N8N_INSTANCE_OWNER_PASSWORD_HASH` must be a bcrypt hash
+This variable expects a pre-hashed bcrypt value. Setting a plaintext password breaks login.
+///
+
+For more information, see [Manage instance settings using environment variables](/hosting/configuration/settings-env-vars.md#instance-owner).

--- a/docs/hosting/configuration/environment-variables/user-management-smtp-2fa.md
+++ b/docs/hosting/configuration/environment-variables/user-management-smtp-2fa.md
@@ -43,4 +43,6 @@ Refer to [User management](/hosting/configuration/user-management-self-hosted.md
 
 Set `N8N_INSTANCE_OWNER_MANAGED_BY_ENV` to `true` to pre-provision the instance owner from environment variables. See [Manage instance settings using environment variables](/hosting/configuration/settings-env-vars.md) for how the activation pattern works.
 
+For steps to update the owner email, see [Change the instance owner email for self-hosted n8n](/hosting/configuration/change-instance-owner-email.md).
+
 --8<-- "_snippets/self-hosting/configuration/environment-variables/settings-env-vars/instance-owner.md"

--- a/docs/hosting/configuration/environment-variables/user-management-smtp-2fa.md
+++ b/docs/hosting/configuration/environment-variables/user-management-smtp-2fa.md
@@ -43,6 +43,4 @@ Refer to [User management](/hosting/configuration/user-management-self-hosted.md
 
 Set `N8N_INSTANCE_OWNER_MANAGED_BY_ENV` to `true` to pre-provision the instance owner from environment variables. See [Manage instance settings using environment variables](/hosting/configuration/settings-env-vars.md) for how the activation pattern works.
 
-For steps to update the owner email, see [Change the instance owner email for self-hosted n8n](/hosting/configuration/change-instance-owner-email.md).
-
 --8<-- "_snippets/self-hosting/configuration/environment-variables/settings-env-vars/instance-owner.md"

--- a/docs/hosting/configuration/settings-env-vars.md
+++ b/docs/hosting/configuration/settings-env-vars.md
@@ -45,7 +45,7 @@ The other environment variables for an area have no effect unless `<AREA>_MANAGE
 /// info | Available from n8n v2.17.0
 ///
 
-Pre-provision the [instance owner](/hosting/configuration/user-management-self-hosted.md) from environment variables instead of going through the in-app setup.
+Pre-provision the [instance owner](/hosting/configuration/user-management-self-hosted.md) from environment variables instead of going through the in-app setup. To change the owner email after setup, see [Change the instance owner email for self-hosted n8n](/hosting/configuration/change-instance-owner-email.md).
 
 /// warning | `N8N_INSTANCE_OWNER_PASSWORD_HASH` must be a bcrypt hash
 This variable expects a pre-hashed bcrypt value. Setting a plaintext password breaks login.

--- a/docs/hosting/configuration/user-management-self-hosted.md
+++ b/docs/hosting/configuration/user-management-self-hosted.md
@@ -87,6 +87,8 @@ If you're not familiar with SMTP, this [blog post by SendGrid](https://sendgrid.
 
 You can pre-provision the instance owner from environment variables instead of going through the in-app setup. Set `N8N_INSTANCE_OWNER_MANAGED_BY_ENV` to `true` and provide the owner details. See [Manage instance settings using environment variables](/hosting/configuration/settings-env-vars.md) for how the activation pattern works.
 
+To change the owner email after setup, see [Change the instance owner email for self-hosted n8n](/hosting/configuration/change-instance-owner-email.md).
+
 /// warning | `N8N_INSTANCE_OWNER_PASSWORD_HASH` must be a bcrypt hash
 This variable expects a pre-hashed bcrypt value. Setting a plaintext password breaks login.
 ///

--- a/docs/manage-cloud/change-ownership-or-username.md
+++ b/docs/manage-cloud/change-ownership-or-username.md
@@ -7,7 +7,7 @@ contentType: howto
 ## Change instance ownership
 
 You can change the ownership of an instance by navigating to the **Settings > Personal** page in the owner's account and editing the **Email** field. After making the changes, scroll down and press **Save**.
-Note that for the change to be effective, the new email address must not be associated with any other n8n account, as each instance can have only one **unique owner email**. If the intended email is already linked to an existing user, that user must be deleted before proceeding.
+Note that for the change to be effective, the new email address must not be associated with any other n8n account, as each instance can have only one **unique owner email**. If the intended email is already linked to an existing user, change or delete that user first so the email becomes available.
 
 Changing emails will change the owner of the instance, the email you log in with, and the email your invoices and general communication gets sent to.
 

--- a/nav.yml
+++ b/nav.yml
@@ -1295,6 +1295,7 @@ nav:
       - External hooks: hosting/configuration/external-hooks.md
       - Task runners: hosting/configuration/task-runners.md
       - User management: hosting/configuration/user-management-self-hosted.md
+      - Change instance owner email: hosting/configuration/change-instance-owner-email.md
       - Manage settings using environment variables: hosting/configuration/settings-env-vars.md
     - Logging and monitoring:
       - Logging: hosting/logging-monitoring/logging.md


### PR DESCRIPTION
## Summary
- Add a self-hosted guide for changing the instance owner email
- Clarify that owner emails must be unique when managed with environment variables
- Link the new guidance from related self-hosting and environment variable docs

## Testing
- Not run; docs-only change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a self-hosted guide with UI and env-var steps to change the instance owner email, and warns that the owner email must be unique to avoid LIGO-545 boot crashes when using `N8N_INSTANCE_OWNER_MANAGED_BY_ENV`/`N8N_INSTANCE_OWNER_EMAIL`.
Clarifies this updates the existing owner only (no transfer/merge), notes env-managed owners make UI controls read-only, cross-links related docs and nav, aligns Cloud docs to say you can change or delete the conflicting user, and removes a duplicate link.

<sup>Written for commit cdea8a963ce6f166a842e99f703f230171740385. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4657?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

