### PR TITLE
docs: Document API key scopes (DOC-1957)

### DIFF
--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -191,7 +191,7 @@ The following tables list the scopes available when you create a scoped API key,
 | `user:read` | Retrieve a user. |
 | `user:list` | List users. |
 | `user:changeRole` | Change a user's global (instance-level) role. |
-| `user:enforceMfa` | Enforce two-factor authentication enrolment on a user. |
+| `user:enforceMfa` | Reserved scope. No `/api/v1/` endpoint currently consumes it, so selecting this scope on a Public API key has no public-facing effect. |
 | `user:delete` | Delete a user from the instance. |
 
 ### Variable scopes
@@ -211,9 +211,9 @@ The following tables list the scopes available when you create a scoped API key,
 | `workflow:read` | Retrieve a workflow and its details. |
 | `workflow:list` | List workflows. |
 | `workflow:update` | Update a workflow. |
-| `workflow:delete` | Delete a workflow. |
+| `workflow:delete` | Delete, archive, or unarchive a workflow. |
 | `workflow:move` | Transfer a workflow to another project. |
-| `workflow:activate` | Activate or deactivate a workflow. |
+| `workflow:activate` | Activate or deactivate a workflow. Also referred to as "publish/unpublish" in the public API (`/workflows/{id}/activate` and `/workflows/{id}/deactivate`). |
 
 ### Workflow tags scopes
 

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -117,7 +117,7 @@ The following tables list the scopes available when you create a scoped API key,
 | `dataTableRow:read` | Read rows from a data table. |
 | `dataTableRow:update` | Update existing rows in a data table. |
 | `dataTableRow:delete` | Delete rows from a data table. |
-| `dataTableRow:upsert` | Create or update rows in a data table in a single operation. |
+| `dataTableRow:upsert` | Update an existing row in a data table, or insert a new one if no row matches the filter conditions. |
 
 ### Execution scopes
 

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -11,19 +11,13 @@ n8n uses API keys to authenticate API calls.
 The n8n API isn't available during the free trial. Please upgrade to access this feature.
 ///
 
-## API Scopes
-
-Users of [enterprise instances](https://n8n.io/enterprise/) can limit which resources and actions a key can access with scopes. API key scopes allow you specify the exact level of access a key needs for its intended purpose.
-
-Non-enterprise API keys have full access to all the account's resources and capabilities.
-
 ## Create an API key
 
 1. Log in to n8n.
 1. Go to **Settings** > **n8n API**.
 1. Select **Create an API key**.
 1. Choose a **Label** and set an **Expiration** time for the key.
-1. If on an enterprise plan, choose the **Scopes** to give the key.
+1. If on an enterprise plan, choose the **Scopes** to give the key. Refer to [API Scopes](#api-scopes) for the full list of available scopes.
 1. Copy **My API Key** and use this key to authenticate your calls.
 
 ## Call the API using your key
@@ -63,3 +57,168 @@ For the available operations and parameters, refer to the [n8n node](/integratio
 2. Go to **Settings** > **n8n API**.
 3. Select **Delete** next to the key you want to delete.
 4. Confirm the delete by selecting **Delete Forever**.
+
+## API Scopes
+
+Users of [enterprise instances](https://n8n.io/enterprise/) can limit which resources and actions an API key can access with scopes. Choose the minimum scopes needed for the key's intended purpose.
+
+Non-enterprise API keys have full access to all the account's resources and capabilities.
+
+/// note | API key scopes vs. project role scopes
+API key scopes control what an API key can do at the instance level. They differ from the **project role scopes** used to define custom roles inside a project. For project role scopes, refer to [Custom project roles](/user-management/rbac/custom-roles.md).
+///
+
+The following tables list the scopes available when you create a scoped API key, grouped by resource.
+
+### Community package scopes
+
+| Scope | Description |
+|-------|-------------|
+| `communityPackage:install` | Install a community node package on the instance. |
+| `communityPackage:list` | List installed community node packages. |
+| `communityPackage:uninstall` | Uninstall a community node package. |
+| `communityPackage:update` | Update an installed community node package. |
+
+### Credential scopes
+
+| Scope | Description |
+|-------|-------------|
+| `credential:create` | Create credentials. |
+| `credential:read` | Retrieve a credential and its data schema. |
+| `credential:list` | List credentials. |
+| `credential:update` | Update a credential. |
+| `credential:delete` | Delete a credential. |
+| `credential:move` | Transfer a credential to another project. |
+
+### Data table scopes
+
+| Scope | Description |
+|-------|-------------|
+| `dataTable:create` | Create a data table. |
+| `dataTable:read` | Retrieve a data table. |
+| `dataTable:list` | List data tables. |
+| `dataTable:update` | Update a data table's metadata. |
+| `dataTable:delete` | Delete a data table. |
+
+### Data table column scopes
+
+| Scope | Description |
+|-------|-------------|
+| `dataTableColumn:create` | Add a column to a data table. |
+| `dataTableColumn:read` | Retrieve a data table column. |
+| `dataTableColumn:update` | Update a data table column. |
+| `dataTableColumn:delete` | Delete a data table column. |
+
+### Data table row scopes
+
+| Scope | Description |
+|-------|-------------|
+| `dataTableRow:create` | Insert rows into a data table. |
+| `dataTableRow:read` | Read rows from a data table. |
+| `dataTableRow:update` | Update existing rows in a data table. |
+| `dataTableRow:delete` | Delete rows from a data table. |
+| `dataTableRow:upsert` | Create or update rows in a data table in a single operation. |
+
+### Execution scopes
+
+| Scope | Description |
+|-------|-------------|
+| `execution:read` | Retrieve an execution and its details. |
+| `execution:list` | List executions. |
+| `execution:retry` | Retry a failed execution. |
+| `execution:stop` | Stop a running execution. |
+| `execution:delete` | Delete an execution. |
+
+### Execution tags scopes
+
+| Scope | Description |
+|-------|-------------|
+| `executionTags:list` | Read the annotation tags assigned to an execution. |
+| `executionTags:update` | Update the annotation tags assigned to an execution. |
+
+### Folder scopes
+
+| Scope | Description |
+|-------|-------------|
+| `folder:create` | Create a folder in a project. |
+| `folder:read` | Retrieve a folder. |
+| `folder:list` | List folders in a project. |
+| `folder:update` | Update a folder. |
+| `folder:delete` | Delete a folder. |
+
+### Insights scopes
+
+| Scope | Description |
+|-------|-------------|
+| `insights:read` | Read instance insights data, including execution counts, failure rates, time saved, and average run time. |
+
+### Project scopes
+
+| Scope | Description |
+|-------|-------------|
+| `project:create` | Create a project. |
+| `project:list` | List projects. |
+| `project:update` | Update a project. |
+| `project:delete` | Delete a project. |
+
+### Security audit scopes
+
+| Scope | Description |
+|-------|-------------|
+| `securityAudit:generate` | Generate a security audit report for the instance. |
+
+### Source control scopes
+
+| Scope | Description |
+|-------|-------------|
+| `sourceControl:pull` | Pull changes from the connected source control repository into the instance. |
+
+### Tag scopes
+
+| Scope | Description |
+|-------|-------------|
+| `tag:create` | Create a tag in the global tag registry. |
+| `tag:read` | Retrieve a tag. |
+| `tag:list` | List tags. |
+| `tag:update` | Update a tag. |
+| `tag:delete` | Delete a tag. |
+
+### User scopes
+
+| Scope | Description |
+|-------|-------------|
+| `user:create` | Invite or create users on the instance. |
+| `user:read` | Retrieve a user. |
+| `user:list` | List users. |
+| `user:changeRole` | Change a user's global (instance-level) role. |
+| `user:enforceMfa` | Enforce two-factor authentication enrolment on a user. |
+| `user:delete` | Delete a user from the instance. |
+
+### Variable scopes
+
+| Scope | Description |
+|-------|-------------|
+| `variable:create` | Create an instance variable. |
+| `variable:list` | List instance variables. |
+| `variable:update` | Update an instance variable. |
+| `variable:delete` | Delete an instance variable. |
+
+### Workflow scopes
+
+| Scope | Description |
+|-------|-------------|
+| `workflow:create` | Create a workflow. |
+| `workflow:read` | Retrieve a workflow and its details. |
+| `workflow:list` | List workflows. |
+| `workflow:update` | Update a workflow. |
+| `workflow:delete` | Delete a workflow. |
+| `workflow:move` | Transfer a workflow to another project. |
+| `workflow:activate` | Activate or deactivate a workflow. |
+
+### Workflow tags scopes
+
+| Scope | Description |
+|-------|-------------|
+| `workflowTags:list` | Read the tags assigned to a workflow. |
+| `workflowTags:update` | Update the tags assigned to a workflow. |
+

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -191,7 +191,7 @@ The following tables list the scopes available when you create a scoped API key,
 | `user:read` | Retrieve a user. |
 | `user:list` | List users. |
 | `user:changeRole` | Change a user's global (instance-level) role. |
-| `user:enforceMfa` | Reserved scope. No `/api/v1/` endpoint currently consumes it, so selecting this scope on a Public API key has no public-facing effect. |
+| `user:enforceMfa` | Reserved scope. No `/api/v1/` endpoint consumes it, so selecting this scope on a Public API key has no public-facing effect. |
 | `user:delete` | Delete a user from the instance. |
 
 ### Variable scopes


### PR DESCRIPTION
## Summary

- Expand the **API Scopes** section on [/api/authentication/](https://docs.n8n.io/api/authentication/#api-scopes) from a 4-line stub to a full reference covering **all 67 scopes across 17 resource groups** (community packages, credentials, data tables, executions, folders, insights, projects, security audits, source control, tags, users, variables, workflows, plus row/column/tag sub-resources).
- Move the section to the bottom of the page so the create → use → configure → delete how-to flow stays uninterrupted.
- Cross-link from step 5 of "Create an API key" to the new reference, and add a `/// note` distinguishing API key scopes from [project role scopes](https://docs.n8n.io/user-management/rbac/custom-roles/).

Closes [DOC-1957](https://linear.app/n8n/issue/DOC-1957).

## Source of the scope list

Captured from the API key creation modal in n8n cloud 2.20.7. Scope-to-endpoint mapping derived from `docs/api/v1/openapi.yml` (operation IDs, tags, and endpoint summaries), supplemented with kapa.ai queries for endpoints lacking inline descriptions.

Re-checking the spec confirmed several descriptions directly, so the remaining IAM ask is narrower than the original list.

## Asking IAM for review

Three things I couldn't resolve from the spec alone:

- **`user:enforceMfa`** — written as "Enforce two-factor authentication enrolment on a user." **No public endpoint exists for this in `docs/api/v1/openapi.yml`**, so the behaviour is inferred from the scope name. Does this scope grant per-user MFA enforcement, or instance-wide enforcement toggling?
- **`workflow:activate` — terminology mismatch.** The endpoint `/workflows/{id}/activate` is titled "Publish a workflow" with the note *"In n8n v1, this action was termed activating a workflow."* The UI scope is still named `workflow:activate`, and my description reflects the UI ("Activate or deactivate a workflow"). Should the docs also mention that this is now called "publish/unpublish" in the API?
- **Archive endpoints have no matching scope.** `/workflows/{id}/archive` and `/workflows/{id}/unarchive` exist in the spec, but there's no `workflow:archive` scope in the UI. Are archive operations covered by `workflow:update`, `workflow:delete`, or neither?

Any other corrections welcome.

## Test plan

- [ ] Preview `/api/authentication/#api-scopes` and confirm all 17 H3 sub-sections render with their tables.
- [ ] Confirm the right-hand on-page TOC populates with the 17 resource-group headings.
- [ ] Confirm the cross-links work: step 5 of "Create an API key" → `#api-scopes`, and the note → `/user-management/rbac/custom-roles/`.
- [ ] IAM engineer reviews the three open questions above.