### PR TITLE
docs: Document custom telemetry tags

### DIFF
--- a/docs/hosting/logging-monitoring/opentelemetry.md
+++ b/docs/hosting/logging-monitoring/opentelemetry.md
@@ -100,8 +100,7 @@ You can add custom attributes to node spans from the node settings or from custo
 
 ### Add tags in the node settings
 
-/// info | Available from n8n@2.22.0
-Requires OpenTelemetry to be enabled.
+/// info | Available from n8n v2.22.0
 ///
 
 You can add custom telemetry tags to any node as follow:

--- a/docs/hosting/logging-monitoring/opentelemetry.md
+++ b/docs/hosting/logging-monitoring/opentelemetry.md
@@ -96,33 +96,22 @@ export N8N_OTEL_TRACES_INJECT_OUTBOUND=false
 
 ## Add custom attributes to node spans
 
-You can attach custom key-value pairs to any node's OpenTelemetry span. n8n exports these as `n8n.node.custom.<key>` attributes, letting you filter and group traces by dimensions like environment, tenant, or model name.
-
-These attributes only appear on node spans. They aren't exported when node spans are disabled with `N8N_OTEL_TRACES_INCLUDE_NODE_SPANS=false`.
+You can add custom attributes to node spans from the node settings or from custom node code. n8n exports them as `n8n.node.custom.<key>` attributes. They only appear on node spans and aren't exported when `N8N_OTEL_TRACES_INCLUDE_NODE_SPANS=false`.
 
 ### Add tags in the node settings
 
 /// info | Available from n8n@2.22.0
-Enable OpenTelemetry before using this setting. Set `N8N_OTEL_ENABLED=true` to use it. Refer to [Enable tracing](#enable-tracing) for setup instructions.
+Requires OpenTelemetry to be enabled.
 ///
 
 You can add custom telemetry tags to any node without writing code:
 
 1. Open the node and select the **Settings** tab.
 2. Under **Custom Telemetry Tags**, select **Add Tag**.
-3. Enter a **Key** (plain text, expressions aren't supported in keys).
-4. Enter a **Value**. You can use plain text or an [expression](/data/expressions.md) like `={{ $json.id }}`. n8n evaluates the expression at execution time.
+3. Enter a **Key**. Keys must be plain text.
+4. Enter a **Value**. Values can be plain text or expressions, such as `={{ $json.id }}`.
 
-For example, if you add two tags:
-
-| Key | Value |
-| :-- | :---- |
-| `environment` | `production` |
-| `item_id` | `={{ $json.id }}` |
-
-n8n exports the span attributes `n8n.node.custom.environment` and `n8n.node.custom.item_id`.
-
-Values must resolve to a string, number, or boolean. n8n skips tags with empty keys. It also skips values that resolve to `null`, `undefined`, objects, or arrays. If n8n can't resolve an expression, it skips the tag without blocking node execution.
+Values must resolve to a string, number, or boolean. n8n skips tags with empty keys, unsupported values (`null`, `undefined`, objects, or arrays), or expressions that can't be resolved.
 
 ### Add attributes programmatically in a custom node
 

--- a/docs/hosting/logging-monitoring/opentelemetry.md
+++ b/docs/hosting/logging-monitoring/opentelemetry.md
@@ -103,7 +103,7 @@ These attributes only appear on node spans. They aren't exported when node spans
 ### Add tags in the node settings
 
 /// info | Available from n8n@2.22.0
-This setting requires OpenTelemetry to be enabled. Set `N8N_OTEL_ENABLED=true` to use it. Refer to [Enable tracing](#enable-tracing) for setup instructions.
+Enable OpenTelemetry before using this setting. Set `N8N_OTEL_ENABLED=true` to use it. Refer to [Enable tracing](#enable-tracing) for setup instructions.
 ///
 
 You can add custom telemetry tags to any node without writing code:
@@ -122,7 +122,7 @@ For example, if you add two tags:
 
 n8n exports the span attributes `n8n.node.custom.environment` and `n8n.node.custom.item_id`.
 
-Values must resolve to a string, number, or boolean. n8n skips tags with empty keys, and silently skips values that resolve to `null`, `undefined`, objects, or arrays. If an expression fails to evaluate, n8n skips the tag without blocking the node execution.
+Values must resolve to a string, number, or boolean. n8n skips tags with empty keys. It also skips values that resolve to `null`, `undefined`, objects, or arrays. If n8n can't resolve an expression, it skips the tag without blocking node execution.
 
 ### Add attributes programmatically in a custom node
 
@@ -142,7 +142,7 @@ async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 }
 ```
 
-n8n prefixes each key with `n8n.node.custom.` on the exported span. Values must be strings, numbers, or booleans.
+n8n prefixes each key with `n8n.node.custom.` on the exported span. Values must be strings, numbers, or boolean.
 
 This API isn't available from the Code node. It's intended for node authors who want to enrich spans with domain-specific data.
 

--- a/docs/hosting/logging-monitoring/opentelemetry.md
+++ b/docs/hosting/logging-monitoring/opentelemetry.md
@@ -103,7 +103,7 @@ You can add custom attributes to node spans from the node settings or (if buildi
 /// info | Available from n8n v2.22.0
 ///
 
-You can add custom telemetry tags to any node as follow:
+You can add custom telemetry tags to any node as follows:
 
 1. Open the node and select the **Settings** tab.
 2. Under **Custom Telemetry Tags**, select **Add Tag**.

--- a/docs/hosting/logging-monitoring/opentelemetry.md
+++ b/docs/hosting/logging-monitoring/opentelemetry.md
@@ -104,7 +104,7 @@ You can add custom attributes to node spans from the node settings or from custo
 Requires OpenTelemetry to be enabled.
 ///
 
-You can add custom telemetry tags to any node without writing code:
+You can add custom telemetry tags to any node as follow:
 
 1. Open the node and select the **Settings** tab.
 2. Under **Custom Telemetry Tags**, select **Add Tag**.

--- a/docs/hosting/logging-monitoring/opentelemetry.md
+++ b/docs/hosting/logging-monitoring/opentelemetry.md
@@ -96,7 +96,37 @@ export N8N_OTEL_TRACES_INJECT_OUTBOUND=false
 
 ## Add custom attributes to node spans
 
-If you're [building a custom node](/integrations/creating-nodes/overview.md), you can attach custom key-value pairs to the node's span. Call `setMetadata` from the node's `execute` method:
+You can attach custom key-value pairs to any node's OpenTelemetry span. n8n exports these as `n8n.node.custom.<key>` attributes, letting you filter and group traces by dimensions like environment, tenant, or model name.
+
+These attributes only appear on node spans. They aren't exported when node spans are disabled with `N8N_OTEL_TRACES_INCLUDE_NODE_SPANS=false`.
+
+### Add tags in the node settings
+
+/// info | Available from n8n@2.22.0
+This setting requires OpenTelemetry to be enabled. Set `N8N_OTEL_ENABLED=true` to use it. Refer to [Enable tracing](#enable-tracing) for setup instructions.
+///
+
+You can add custom telemetry tags to any node without writing code:
+
+1. Open the node and select the **Settings** tab.
+2. Under **Custom Telemetry Tags**, select **Add Tag**.
+3. Enter a **Key** (plain text, expressions aren't supported in keys).
+4. Enter a **Value**. You can use plain text or an [expression](/data/expressions.md) like `={{ $json.id }}`. n8n evaluates the expression at execution time.
+
+For example, if you add two tags:
+
+| Key | Value |
+| :-- | :---- |
+| `environment` | `production` |
+| `item_id` | `={{ $json.id }}` |
+
+n8n exports the span attributes `n8n.node.custom.environment` and `n8n.node.custom.item_id`.
+
+Values must resolve to a string, number, or boolean. n8n skips tags with empty keys, and silently skips values that resolve to `null`, `undefined`, objects, or arrays. If an expression fails to evaluate, n8n skips the tag without blocking the node execution.
+
+### Add attributes programmatically in a custom node
+
+If you're [building a custom node](/integrations/creating-nodes/overview.md), you can attach custom key-value pairs from code. Call `setMetadata` from the node's `execute` method:
 
 ```typescript
 async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
@@ -112,9 +142,11 @@ async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 }
 ```
 
-n8n prefixes each key with `n8n.node.custom.` on the exported span. Values must be strings, numbers, or boolean.
+n8n prefixes each key with `n8n.node.custom.` on the exported span. Values must be strings, numbers, or booleans.
 
 This API isn't available from the Code node. It's intended for node authors who want to enrich spans with domain-specific data.
+
+If a node sets an attribute key here that's also configured as a [custom telemetry tag](#add-tags-in-the-node-settings), the programmatic value takes precedence.
 
 ## Try it out with Jaeger
 
@@ -177,7 +209,7 @@ Workflow and node spans include the following n8n-specific attributes.
 | `n8n.node.items.input` | Number of input items the node received. |
 | `n8n.node.items.output` | Number of output items the node produced. |
 | `n8n.node.termination_reason` | Why a node span ended without a normal completion (for example, `workflow_cancelled`). |
-| `n8n.node.custom.<key>` | Custom attributes set through `metadata.tracing` in the node output. |
+| `n8n.node.custom.<key>` | Custom attributes set through [custom telemetry tags](#add-tags-in-the-node-settings) in the node settings or `metadata.tracing` in custom node code. |
 
 When a node fails, n8n records an `exception` event on the span with the standard OpenTelemetry exception attributes (`exception.type`, `exception.message`, `exception.stacktrace`).
 

--- a/docs/hosting/logging-monitoring/opentelemetry.md
+++ b/docs/hosting/logging-monitoring/opentelemetry.md
@@ -96,7 +96,7 @@ export N8N_OTEL_TRACES_INJECT_OUTBOUND=false
 
 ## Add custom attributes to node spans
 
-You can add custom attributes to node spans from the node settings or from custom node code. n8n exports them as `n8n.node.custom.<key>` attributes. They only appear on node spans and aren't exported when `N8N_OTEL_TRACES_INCLUDE_NODE_SPANS=false`.
+You can add custom attributes to node spans from the node settings or (if building a custom node) from within the `execute` method. n8n exports them as `n8n.node.custom.<key>` attributes. They only appear on node spans and aren't exported when `N8N_OTEL_TRACES_INCLUDE_NODE_SPANS=false`.
 
 ### Add tags in the node settings
 

--- a/docs/workflows/components/nodes.md
+++ b/docs/workflows/components/nodes.md
@@ -73,6 +73,7 @@ When active or set, they do the following:
     - **Stop Workflow**: Halts the entire workflow when an error occurs, preventing further node execution.
     - **Continue**: Proceeds to the next node despite the error, using the last valid data.
     - **Continue (using error output)**: Continues workflow execution, passing error information to the next node for potential handling.
+* **Custom Telemetry Tags**: Add custom key-value pairs to a node's OpenTelemetry span. Keys are plain text, values support expressions, and this setting only appears when OpenTelemetry tracing is enabled. Refer to [Add custom attributes to node spans](/hosting/logging-monitoring/opentelemetry.md#add-custom-attributes-to-node-spans) for details.
 
 You can document your workflow using node notes:
 

--- a/docs/workflows/components/nodes.md
+++ b/docs/workflows/components/nodes.md
@@ -73,7 +73,7 @@ When active or set, they do the following:
     - **Stop Workflow**: Halts the entire workflow when an error occurs, preventing further node execution.
     - **Continue**: Proceeds to the next node despite the error, using the last valid data.
     - **Continue (using error output)**: Continues workflow execution, passing error information to the next node for potential handling.
-* **Custom Telemetry Tags**: Add custom key-value pairs to a node's OpenTelemetry span. Keys are plain text, values support expressions, and this setting only appears when OpenTelemetry tracing is enabled. Refer to [Add custom attributes to node spans](/hosting/logging-monitoring/opentelemetry.md#add-custom-attributes-to-node-spans) for details.
+* **Custom Telemetry Tags**: Add custom key-value pairs to a node's OpenTelemetry span. Keys are plain text, values support expressions, and this setting only appears when you enable OpenTelemetry tracing. Refer to [Add custom attributes to node spans](/hosting/logging-monitoring/opentelemetry.md#add-custom-attributes-to-node-spans) for details.
 
 You can document your workflow using node notes:
 

--- a/docs/workflows/components/nodes.md
+++ b/docs/workflows/components/nodes.md
@@ -73,7 +73,7 @@ When active or set, they do the following:
     - **Stop Workflow**: Halts the entire workflow when an error occurs, preventing further node execution.
     - **Continue**: Proceeds to the next node despite the error, using the last valid data.
     - **Continue (using error output)**: Continues workflow execution, passing error information to the next node for potential handling.
-   - **Custom Telemetry Tags**: Add custom key-value pairs to a node's OpenTelemetry span. Keys are plain text, values support expressions, and this setting only appears when you enable OpenTelemetry tracing. Refer to [Add custom attributes to node spans](/hosting/logging-monitoring/opentelemetry.md#add-custom-attributes-to-node-spans) for details.
+* **Custom Telemetry Tags**: Add custom key-value pairs to a node's OpenTelemetry span. Keys are plain text, values support expressions, and this setting only appears when you enable OpenTelemetry tracing. Refer to [Add custom attributes to node spans](/hosting/logging-monitoring/opentelemetry.md#add-custom-attributes-to-node-spans) for details.
 
 You can document your workflow using node notes:
 

--- a/docs/workflows/components/nodes.md
+++ b/docs/workflows/components/nodes.md
@@ -73,7 +73,7 @@ When active or set, they do the following:
     - **Stop Workflow**: Halts the entire workflow when an error occurs, preventing further node execution.
     - **Continue**: Proceeds to the next node despite the error, using the last valid data.
     - **Continue (using error output)**: Continues workflow execution, passing error information to the next node for potential handling.
-* **Custom Telemetry Tags**: Add custom key-value pairs to a node's OpenTelemetry span. Keys are plain text, values support expressions, and this setting only appears when you enable OpenTelemetry tracing. Refer to [Add custom attributes to node spans](/hosting/logging-monitoring/opentelemetry.md#add-custom-attributes-to-node-spans) for details.
+   - **Custom Telemetry Tags**: Add custom key-value pairs to a node's OpenTelemetry span. Keys are plain text, values support expressions, and this setting only appears when you enable OpenTelemetry tracing. Refer to [Add custom attributes to node spans](/hosting/logging-monitoring/opentelemetry.md#add-custom-attributes-to-node-spans) for details.
 
 You can document your workflow using node notes:
 


### PR DESCRIPTION
## Summary
- Document custom telemetry tags in node settings
- Clarify custom OpenTelemetry span attributes

## Related Linear tickets

https://linear.app/n8n/issue/LIGO-561



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented Custom Telemetry Tags in node settings and how to add custom OpenTelemetry attributes to node spans. Clarifies availability, behavior, and precedence so you can filter and group traces by environment, tenant, etc. (LIGO-561)

- Appears only when tracing is enabled (`N8N_OTEL_ENABLED=true`); node spans only and omitted if `N8N_OTEL_TRACES_INCLUDE_NODE_SPANS=false`.
- Keys are plain text; values can be expressions resolving to string/number/boolean; invalid or empty entries are skipped; exported as `n8n.node.custom.<key>`.
- Custom nodes can set attributes via `setMetadata` in `execute`; these override settings; not available in the Code node.
- Added UI steps, a “Custom Telemetry Tags” entry in node settings with cross-link, updated the attribute table row for `n8n.node.custom.<key>` to include both settings and `metadata.tracing`, and noted availability from n8n v2.22.0.

<sup>Written for commit b3ec48a4c3f553aa8a125a845a676a2c1f8f99a9. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4668?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





