### PR TITLE
docs: document insights compaction controls

### DIFF
--- a/docs/hosting/configuration/environment-variables/insights.md
+++ b/docs/hosting/configuration/environment-variables/insights.md
@@ -19,9 +19,16 @@ Insights gives instance owners and admins visibility into how workflows perform 
 `N8N_INSIGHTS_COMPACTION_HOURLY_TO_DAILY_THRESHOLD_DAYS` and `N8N_INSIGHTS_COMPACTION_DAILY_TO_WEEKLY_THRESHOLD_DAYS` set how many days n8n keeps high-resolution insights (metrics stored in one-hour buckets) before each compaction step (from the hour bucket to the day bucket, then from the day bucket to the week bucket). You configure those day counts on your instance.
 
 Raising the values delays compaction. That adds more rows to `insights_by_period` and increases database usage. For how this relates to retention, see [Insights](/insights.md#disable-or-configure-insights-metrics-collection).
-
-If you notice a high database load during compactions, use the batch, runtime and delay settings to limit the work n8n does in each compaction run. They don't change retention or the age thresholds for each compaction step.
 ///
+
+If you encounter database load issues during compaction, tune how often compaction runs and how much work n8n does in each run:
+
+- Decrease `N8N_INSIGHTS_COMPACTION_INTERVAL_MINUTES` to run compaction more often. This can reduce the amount of data that builds up between runs.
+- Increase `N8N_INSIGHTS_COMPACTION_BATCH_DELAY_MILLISECONDS` to wait longer between batches.
+- Decrease `N8N_INSIGHTS_COMPACTION_MAX_BATCHES_PER_RUN` to process fewer batches in each run.
+- Decrease `N8N_INSIGHTS_COMPACTION_MAX_RUNTIME_SECONDS` to stop each run sooner.
+
+These settings only control compaction workload and scheduling. They don't change retention or the age thresholds for each compaction step.
 
 <!-- vale from-write-good.Weasel = NO -->
 
@@ -29,12 +36,12 @@ If you notice a high database load during compactions, use the batch, runtime an
  |:---------------------------------------------------------|:-------|:--------|:----------------------------------------------------------------------------------------|
  | `N8N_DISABLED_MODULES`                                   | String | -       | Set to `insights` to disable the feature and metrics collection for an instance.        |
  | `N8N_INSIGHTS_COMPACTION_BATCH_SIZE`                     | Number | 500     | The number of raw insights data to compact in a single batch.                           |
- | `N8N_INSIGHTS_COMPACTION_BATCH_DELAY_MILLISECONDS`       | Number | 100     | Delay in milliseconds between full compaction batches. Set to `0` to skip the delay. |
+ | `N8N_INSIGHTS_COMPACTION_BATCH_DELAY_MILLISECONDS`       | Number | 100     | Delay in milliseconds between full compaction batches. Increase this to wait longer between batches. Set to `0` to skip the delay. |
  | `N8N_INSIGHTS_COMPACTION_DAILY_TO_WEEKLY_THRESHOLD_DAYS` | Number | 180     | Age in days after which n8n compacts daily insights rows to weekly. |
  | `N8N_INSIGHTS_COMPACTION_HOURLY_TO_DAILY_THRESHOLD_DAYS` | Number | 90      | Age in days after which n8n compacts hourly insights rows to daily. |
- | `N8N_INSIGHTS_COMPACTION_INTERVAL_MINUTES`               | Number | 60      | Interval (in minutes) at which compaction should run.                                   |
- | `N8N_INSIGHTS_COMPACTION_MAX_BATCHES_PER_RUN`            | Number | 1000    | Maximum number of compaction batches to process in one run. Set to `0` to disable this limit. |
- | `N8N_INSIGHTS_COMPACTION_MAX_RUNTIME_SECONDS`            | Number | 300     | Maximum runtime in seconds for one compaction run. Set to `0` to disable this limit. |
+ | `N8N_INSIGHTS_COMPACTION_INTERVAL_MINUTES`               | Number | 60      | Interval (in minutes) at which compaction should run. Decrease this to run compaction more often and reduce how much data builds up between runs. |
+ | `N8N_INSIGHTS_COMPACTION_MAX_BATCHES_PER_RUN`            | Number | 1000    | Maximum number of compaction batches to process in one run. Decrease this to process fewer batches per run. Set to `0` to disable this limit. |
+ | `N8N_INSIGHTS_COMPACTION_MAX_RUNTIME_SECONDS`            | Number | 300     | Maximum runtime in seconds for one compaction run. Decrease this to stop each run sooner. Set to `0` to disable this limit. |
  | `N8N_INSIGHTS_FLUSH_BATCH_SIZE`                          | Number | 1000    | The maximum number of insights data to keep in the buffer before flushing.              |
  | `N8N_INSIGHTS_FLUSH_INTERVAL_SECONDS`                    | Number | 30      | The interval (in seconds) at which n8n flushes insights data to the database. |
  | `N8N_INSIGHTS_MAX_AGE_DAYS`                              | Number | 365     | Number of days n8n keeps compacted insights data before pruning. The maximum value is 730 (two years). |

--- a/docs/hosting/configuration/environment-variables/insights.md
+++ b/docs/hosting/configuration/environment-variables/insights.md
@@ -19,6 +19,8 @@ Insights gives instance owners and admins visibility into how workflows perform 
 `N8N_INSIGHTS_COMPACTION_HOURLY_TO_DAILY_THRESHOLD_DAYS` and `N8N_INSIGHTS_COMPACTION_DAILY_TO_WEEKLY_THRESHOLD_DAYS` set how many days n8n keeps high-resolution insights (metrics stored in one-hour buckets) before each compaction step (from the hour bucket to the day bucket, then from the day bucket to the week bucket). You configure those day counts on your instance.
 
 Raising the values delays compaction. That adds more rows to `insights_by_period` and increases database usage. For how this relates to retention, see [Insights](/insights.md#disable-or-configure-insights-metrics-collection).
+
+If you notice a high database load during compactions, use the batch, runtime and delay settings to limit the work n8n does in each compaction run. They don't change retention or the age thresholds for each compaction step.
 ///
 
 <!-- vale from-write-good.Weasel = NO -->
@@ -27,9 +29,12 @@ Raising the values delays compaction. That adds more rows to `insights_by_period
  |:---------------------------------------------------------|:-------|:--------|:----------------------------------------------------------------------------------------|
  | `N8N_DISABLED_MODULES`                                   | String | -       | Set to `insights` to disable the feature and metrics collection for an instance.        |
  | `N8N_INSIGHTS_COMPACTION_BATCH_SIZE`                     | Number | 500     | The number of raw insights data to compact in a single batch.                           |
+ | `N8N_INSIGHTS_COMPACTION_BATCH_DELAY_MILLISECONDS`       | Number | 100     | Delay in milliseconds between full compaction batches. Set to `0` to skip the delay. |
  | `N8N_INSIGHTS_COMPACTION_DAILY_TO_WEEKLY_THRESHOLD_DAYS` | Number | 180     | Age in days after which n8n compacts daily insights rows to weekly. |
  | `N8N_INSIGHTS_COMPACTION_HOURLY_TO_DAILY_THRESHOLD_DAYS` | Number | 90      | Age in days after which n8n compacts hourly insights rows to daily. |
  | `N8N_INSIGHTS_COMPACTION_INTERVAL_MINUTES`               | Number | 60      | Interval (in minutes) at which compaction should run.                                   |
+ | `N8N_INSIGHTS_COMPACTION_MAX_BATCHES_PER_RUN`            | Number | 1000    | Maximum number of compaction batches to process in one run. Set to `0` to disable this limit. |
+ | `N8N_INSIGHTS_COMPACTION_MAX_RUNTIME_SECONDS`            | Number | 300     | Maximum runtime in seconds for one compaction run. Set to `0` to disable this limit. |
  | `N8N_INSIGHTS_FLUSH_BATCH_SIZE`                          | Number | 1000    | The maximum number of insights data to keep in the buffer before flushing.              |
  | `N8N_INSIGHTS_FLUSH_INTERVAL_SECONDS`                    | Number | 30      | The interval (in seconds) at which n8n flushes insights data to the database. |
  | `N8N_INSIGHTS_MAX_AGE_DAYS`                              | Number | 365     | Number of days n8n keeps compacted insights data before pruning. The maximum value is 730 (two years). |

--- a/docs/insights.md
+++ b/docs/insights.md
@@ -90,7 +90,7 @@ By default, n8n keeps compacted insights data for 365 days (`N8N_INSIGHTS_MAX_AG
 In older versions, pruning could follow license-driven defaults (commonly 180 days). `N8N_INSIGHTS_MAX_AGE_DAYS` now controls pruning (default 365). Set `N8N_INSIGHTS_MAX_AGE_DAYS=180` if you want a retention window like that previous default.
 ///
 
-n8n stores recent insights at one-hour granularity, then compacts older data into day-level and week-level summaries. Use [Insights environment variables](/hosting/configuration/environment-variables/insights.md) to control how long n8n waits before each compaction step.
+n8n stores recent insights at one-hour granularity, then compacts older data into day-level and week-level summaries. Use [Insights environment variables](/hosting/configuration/environment-variables/insights.md) to control compaction timing, batch limits, runtime, and delays.
 
 Raising those thresholds above the defaults keeps finer detail longer. That adds more rows to `insights_by_period` and uses more database space than extending `N8N_INSIGHTS_MAX_AGE_DAYS` alone. Increase `N8N_INSIGHTS_MAX_AGE_DAYS` first if you only need a longer retention window.
 


### PR DESCRIPTION
## Summary

* Document insights compaction batch delay, max batches, and max runtime environment variables
* Clarify that compaction controls affect timing and workload, not retention

## Linear

resolves [LIGO-577](https://linear.app/n8n/issue/LIGO-577/document-insight-compaction-control-env-vars) 

---

## Summary by cubic

Documented new Insights compaction controls so admins can limit database load during compaction, per [LIGO-577](https://linear.app/n8n/issue/LIGO-577/document-insight-compaction-control-env-vars). Added `N8N_INSIGHTS_COMPACTION_BATCH_DELAY_MILLISECONDS`, `N8N_INSIGHTS_COMPACTION_MAX_BATCHES_PER_RUN`, and `N8N_INSIGHTS_COMPACTION_MAX_RUNTIME_SECONDS`, and clarified these adjust timing and workload, not retention.

Written for commit 55690325ecd2dd30fdf231b55d7156084cdca78c. Summary will update on new commits. [Review in cubic](<https://cubic.dev/pr/n8n-io/n8n-docs/pull/4675?utm_source=github>)