### PR TITLE
docs(mcp): Add missing MCP tools to the reference

### DIFF
--- a/docs/advanced-ai/mcp/mcp_tools_reference.md
+++ b/docs/advanced-ai/mcp/mcp_tools_reference.md
@@ -376,7 +376,7 @@ Search for workflow executions with optional filters. Returns execution metadata
 | `data[].id` | `string` | The unique identifier of the execution |
 | `data[].workflowId` | `string` | The workflow this execution belongs to |
 | `data[].status` | `string` | The execution status |
-| `data[].mode` | `string` | How the execution was triggered. One of: `"cli"`, `"error"`, `"integrated"`, `"internal"`, `"manual"`, `"retry"`, `"trigger"`, `"webhook"`, `"evaluation"`, `"chat"`, `"agent"` |
+| `data[].mode` | `string` | How the execution was triggered. One of: `"cli"`, `"error"`, `"integrated"`, `"internal"`, `"manual"`, `"retry"`, `"trigger"`, `"webhook"`, `"evaluation"`, `"chat"` |
 | `data[].startedAt` | `string | null` | ISO timestamp when the execution started |
 | `data[].stoppedAt` | `string | null` | ISO timestamp when the execution stopped |
 | `data[].waitTill` | `string | null` | ISO timestamp until when the execution is waiting |

--- a/docs/advanced-ai/mcp/mcp_tools_reference.md
+++ b/docs/advanced-ai/mcp/mcp_tools_reference.md
@@ -129,47 +129,6 @@ Execute a workflow by ID by mapping data from user prompt to trigger inputs. Ret
 
 ---
 
-### get_execution
-
-/// info | Available from n8n v2.12.0
-///
-
-Get execution details by execution ID and workflow ID. By default returns metadata only.
-
-#### Parameters
-
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `workflowId` | `string` | Yes | The ID of the workflow the execution belongs to |
-| `executionId` | `string` | Yes | The ID of the execution to retrieve |
-| `includeData` | `boolean` | No | Whether to include full execution result data. Defaults to false (metadata only). |
-| `nodeNames` | `string[]` | No | When `includeData` is true, return data only for these nodes. If omitted, data for all nodes is included. |
-| `truncateData` | `integer` | No | When `includeData` is true, limit the number of data items returned per node output. |
-
-#### Output
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `execution` | `object | null` | Execution metadata, or null if an error occurred |
-| `execution.id` | `string` | Execution ID |
-| `execution.workflowId` | `string` | Workflow ID |
-| `execution.mode` | `string` | Execution mode |
-| `execution.status` | `string` | Execution status |
-| `execution.startedAt` | `string | null` | ISO timestamp when the execution started |
-| `execution.stoppedAt` | `string | null` | ISO timestamp when the execution stopped |
-| `execution.retryOf` | `string | null` | ID of the execution this is a retry of |
-| `execution.retrySuccessId` | `string | null` | ID of the successful retry execution |
-| `execution.waitTill` | `string | null` | ISO timestamp the execution is waiting until |
-| `data` | `unknown` | Execution result data (only present when `includeData` is true) |
-| `error` | `string` | Error message if the request failed |
-
-#### Notes
-
-- Use lightweight metadata queries (default) when full execution data isn't needed.
-- Filtering by `nodeNames` and truncating via `truncateData` helps manage large result sets.
-
----
-
 ### test_workflow
 
 /// info | Available from n8n v2.15.0
@@ -345,6 +304,130 @@ Search for folders within a project.
 
 - Maximum result limit is 100.
 - This tool enables MCP clients to create workflows in a specific folder.
+
+---
+
+## Execution management
+
+### get_execution
+
+/// info | Available from n8n v2.12.0
+///
+
+Get execution details by execution ID and workflow ID. By default returns metadata only.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `workflowId` | `string` | Yes | The ID of the workflow the execution belongs to |
+| `executionId` | `string` | Yes | The ID of the execution to retrieve |
+| `includeData` | `boolean` | No | Whether to include full execution result data. Defaults to false (metadata only). |
+| `nodeNames` | `string[]` | No | When `includeData` is true, return data only for these nodes. If omitted, data for all nodes is included. |
+| `truncateData` | `integer` | No | When `includeData` is true, limit the number of data items returned per node output. |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `execution` | `object | null` | Execution metadata, or null if an error occurred |
+| `execution.id` | `string` | Execution ID |
+| `execution.workflowId` | `string` | Workflow ID |
+| `execution.mode` | `string` | Execution mode |
+| `execution.status` | `string` | Execution status |
+| `execution.startedAt` | `string | null` | ISO timestamp when the execution started |
+| `execution.stoppedAt` | `string | null` | ISO timestamp when the execution stopped |
+| `execution.retryOf` | `string | null` | ID of the execution this is a retry of |
+| `execution.retrySuccessId` | `string | null` | ID of the successful retry execution |
+| `execution.waitTill` | `string | null` | ISO timestamp the execution is waiting until |
+| `data` | `unknown` | Execution result data (only present when `includeData` is true) |
+| `error` | `string` | Error message if the request failed |
+
+#### Notes
+
+- Use lightweight metadata queries (default) when full execution data isn't needed.
+- Filtering by `nodeNames` and truncating via `truncateData` helps manage large result sets.
+
+---
+
+### search_executions
+
+/// info | Available from n8n v2.20.0
+///
+
+Search for workflow executions with optional filters. Returns execution metadata including status, timing, and workflow ID.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `workflowId` | `string` | No | Filter executions by workflow ID |
+| `status` | `string[]` | No | Filter by execution statuses. Values: `"canceled"`, `"crashed"`, `"error"`, `"new"`, `"running"`, `"success"`, `"unknown"`, `"waiting"` |
+| `startedAfter` | `string` | No | ISO 8601 timestamp. Only return executions that started after this time. |
+| `startedBefore` | `string` | No | ISO 8601 timestamp. Only return executions that started before this time. |
+| `limit` | `integer` | No | Limit the number of results (max 200) |
+| `lastId` | `string` | No | Cursor for pagination. Pass the last execution ID from the previous page. |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data` | `array` | List of executions matching the query |
+| `data[].id` | `string` | The unique identifier of the execution |
+| `data[].workflowId` | `string` | The workflow this execution belongs to |
+| `data[].status` | `string` | The execution status |
+| `data[].mode` | `string` | How the execution was triggered. One of: `"cli"`, `"error"`, `"integrated"`, `"internal"`, `"manual"`, `"retry"`, `"trigger"`, `"webhook"`, `"evaluation"`, `"chat"`, `"agent"` |
+| `data[].startedAt` | `string | null` | ISO timestamp when the execution started |
+| `data[].stoppedAt` | `string | null` | ISO timestamp when the execution stopped |
+| `data[].waitTill` | `string | null` | ISO timestamp until when the execution is waiting |
+| `count` | `integer` | Total matching executions, or `-1` if the count is unavailable |
+| `estimated` | `boolean` | Whether the count is an estimate for large datasets |
+| `error` | `string` | Error message if the query failed |
+
+---
+
+## Credential management
+
+### list_credentials
+
+/// info | Available from n8n v2.21.0
+///
+
+List credentials the current user can access. Use this to find a credential ID before referencing it from a workflow node. Never returns credential secret data.
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `limit` | `integer` | No | Limit the number of results (max 200) |
+| `query` | `string` | No | Filter credentials by name (partial match) |
+| `type` | `string` | No | Filter by credential type, for example `"slackApi"` or `"httpHeaderAuth"` (partial match) |
+| `projectId` | `string` | No | Restrict results to credentials belonging to this project |
+| `onlySharedWithMe` | `boolean` | No | Only return credentials shared directly with the current user. Defaults to false. |
+
+#### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data` | `array` | List of credentials accessible to the current user |
+| `data[].id` | `string` | The unique identifier of the credential |
+| `data[].name` | `string` | The name of the credential |
+| `data[].type` | `string` | The credential type, for example `"slackApi"` |
+| `data[].scopes` | `string[]` | User permissions for this credential, for example `"credential:read"` |
+| `data[].isManaged` | `boolean` | Whether the credential is managed by n8n and can't be edited by the user |
+| `data[].isGlobal` | `boolean` | Whether the credential is available to all users |
+| `data[].homeProject` | `object | null` | The project that owns the credential, if available |
+| `data[].homeProject.id` | `string` | The unique identifier of the project |
+| `data[].homeProject.name` | `string` | The name of the project |
+| `data[].homeProject.type` | `string` | The project type. `"personal"` is a user's private project; `"team"` is a shared project accessible to multiple users. |
+| `count` | `integer` | Number of credentials returned |
+| `error` | `string` | Error message if the request failed |
+
+#### Notes
+
+- Maximum result limit is 200.
+- Credential secret data is never returned.
+- By default, global credentials are included. Set `onlySharedWithMe` to true to exclude global credentials and only return credentials shared directly with the current user.
 
 ---
 


### PR DESCRIPTION
Documenting missing MCP tools:
- `list_credentials`
- `search_executions`
Added a new section - `Execution management` and moved `get_execution` tool to it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing MCP tools to the reference and reorganizes the docs for easier discovery. Documents `list_credentials` and `search_executions`, and groups execution tools under a new Execution management section.

- **New Features**
  - Documented `search_executions` with filters, cursor pagination (`lastId`), status/mode enums, and count/estimate fields.
  - Documented `list_credentials` with name/type filters, project scoping, `onlySharedWithMe`, and no-secret guarantees.

- **Refactors**
  - Added Execution management and Credential management sections.
  - Moved `get_execution` into Execution management and clarified parameters, outputs, and usage notes.

<sup>Written for commit 84c0cf5b0be224c764a9cf825688a663fd59f249. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4693?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

