### PR TITLE
Update mcp_tools_reference.mdn8nNedimVarrak-f3d

### DIFF
--- a/docs/advanced-ai/mcp/mcp_tools_reference.md
+++ b/docs/advanced-ai/mcp/mcp_tools_reference.md
@@ -1,4 +1,4 @@
----
+n8n ---
 title: n8n MCP server tools reference
 description: Complete reference for all tools exposed by the n8n MCP server, including workflow management, workflow builder, and data table tools.
 ---


### PR DESCRIPTION
نشر مقطع فيديو مضحك

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the docs front matter for the MCP tools reference page by prefixing the opening delimiter with `n8n` (changed `---` to `n8n ---`). Content stays the same; only the page header metadata line was adjusted.

<sup>Written for commit f7d8b4b1852db32e8c2ab3f4430eca10710c3fef. Summary will update on new commits. <a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4711?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

