### PR TITLE
docs: fix auto-handle-on-label workflow

### DIFF
--- a/.github/workflows/auto-handle-on-label.yml
+++ b/.github/workflows/auto-handle-on-label.yml
@@ -12,7 +12,7 @@ on:
       - labeled
 jobs:
   handle-labels:
-    if: contains(fromJSON('["block", "scope:old-course", "quality:unusable", "quality:low-effort-usable", "status:duplicate", "status:dev-cancelled", "status:pending-dev", "status:in-next-release" ]'), github.event.label.name)
+    if: contains(fromJSON('["block", "scope:old-course", "quality:unusable", "quality:low-effort-usable", "quality:disruptive", "status:duplicate", "status:dev-cancelled", "status:pending-dev", "status:in-next-release" ]'), github.event.label.name)
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -21,6 +21,8 @@ jobs:
       - name: Set label config
         id: config
         run: |
+          # Webhook calls trigger an n8n workflow that tracks warnings per user.
+          # Once a user accumulates enough warnings, the workflow blocks them automatically.
           case "${{ github.event.label.name }}" in
             "block")
               echo "comment=@${{ env.AUTHOR }} Due to a violation of our contributing guidelines, you are now blocked. Please review n8n's [contributing](${{ env.CONTRIBUTING_LINK }}) guidelines." >> $GITHUB_OUTPUT
@@ -33,7 +35,16 @@ jobs:
               "https://api.github.com/orgs/${{ env.ORG_NAME }}/blocks/${{ env.AUTHOR }}"
               ;;
             "quality:unusable")
+              curl -s -X POST \
+              -u "${{ secrets.WEBHOOK_USER }}:${{ secrets.WEBHOOK_PASSWORD }}" \
+              -H "Content-Type: application/json" \
+              -d "$(printf '{"user": %s, "label": "quality:unusable"}' "$(printf '%s' "${{ env.AUTHOR }}" | jq -Rs .)")" \
+              "${{ secrets.WEBHOOK_URL }}"
               echo "comment=@${{ env.AUTHOR }} This contribution doesn't improve the doc, or meet our quality standards. Please review n8n's [contributing](${{ env.CONTRIBUTING_LINK }}) guidelines." >> $GITHUB_OUTPUT
+              echo "should_close=true" >> $GITHUB_OUTPUT
+              ;;
+            "quality:disruptive")
+              echo "comment=@${{ env.AUTHOR }} This contribution appears to be low-quality, AI-generated, or proposes changes that are disruptive or outside the scope of n8n's documentation. Please review n8n's [contributing](${{ env.CONTRIBUTING_LINK }}) guidelines." >> $GITHUB_OUTPUT
               echo "should_close=true" >> $GITHUB_OUTPUT
               curl -L \
               -X PUT \


### PR DESCRIPTION
This PR makes minor fixes to the auto-handle-on-label workflow, after recent label changes.

- Adds missing "quality:disruptive" label to if statement
- Adds comment to explain what the webhook does
- Uses webhook to add authors of quality:unusable PRs to the warn list via webhook, rather than block them
- Blocks and closes PRs of authors of quality:disruptive PRs