### PR TITLE
docs(mcp): Update Codex CLI instructions

### DIFF
--- a/docs/advanced-ai/mcp/accessing-n8n-mcp-server.md
+++ b/docs/advanced-ai/mcp/accessing-n8n-mcp-server.md
@@ -215,9 +215,9 @@ Here, replace:
 
 - `<your-n8n-domain>`: Your n8n base URL (shown on the **Instance-level MCP** page)
 
-### Connecting Claude Code to n8n MCP server
+#### Connecting Claude Code to n8n MCP server
 
-#### OPTION 1: Authenticate using OAuth2 (Recommended)
+##### OPTION 1: Authenticate using OAuth2 (Recommended)
 
 Use the following CLI command:
 
@@ -242,7 +242,7 @@ Here, replace:
 
 - `<your-n8n-domain>`: Your n8n base URL (shown on the **Instance-level MCP** page)
 
-#### OPTION 2: Authenticate using Access Token
+##### OPTION 2: Authenticate using Access Token
 
 Use the following CLI command:
 
@@ -274,10 +274,31 @@ Here, replace:
 
 ### Connecting Codex CLI to n8n MCP server
 
+##### OPTION 1: Authenticate using OAuth2 (Recommended)
+
+Use the following CLI command:
+
+```bash
+codex mcp add n8n-mcp --url https://<your-n8n-domain>/mcp-server/http
+```
+
+Alternatively, add the following entry to your `~/.codex/config.toml` file:
+
+```toml
+[mcp_servers.n8n-mcp]
+url = "http://localhost:5678/mcp-server/http"
+```
+
+Here, replace:
+
+- `<your-n8n-domain>`: Your n8n base URL (shown on the **Instance-level MCP** page)
+
+##### OPTION 2: Authenticate using Access Token
+
 Add the following entry to your `~/.codex/config.toml` file:
 
 ```toml
-[mcp_servers.n8n_mcp]
+[mcp_servers.n8n-mcp]
 url = "https://<your-n8n-domain>/mcp-server/http"
 http_headers = { "authorization" = "Bearer <YOUR_N8N_MCP_TOKEN>" }
 ```


### PR DESCRIPTION
- Update connection instructions for Codex CLI
- Get heading levels in order

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the n8n MCP docs with Codex CLI connection instructions for OAuth2 (recommended) and access token, including the `codex mcp add n8n-mcp` command and TOML examples. Also fixed heading levels and standardized the config section to `[mcp_servers.n8n-mcp]`.

- **Migration**
  - If you used `[mcp_servers.n8n_mcp]` in `~/.codex/config.toml`, update it to `[mcp_servers.n8n-mcp]`.

<sup>Written for commit b4a6546301f9fae14d5a32561b374d8b3347be0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

