### PR TITLE
docs: document Multiple Headers auth for MCP Client nodes

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md
@@ -9,7 +9,7 @@ contentType: [integration, reference]
 The MCP Client Tool node is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) client, allowing you to use the tools exposed by an external MCP server. You can connect the MCP Client Tool node to your models to call external tools with n8n agents.
 
 ///  note  | Credentials
-The MCP Client Tool node supports [Bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), and [OAuth2](/integrations/builtin/credentials/httprequest.md#using-oauth2) authentication methods.
+The MCP Client Tool node supports [Bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](/integrations/builtin/credentials/httprequest.md#using-oauth2) authentication methods.
 ///
 
 ## Node parameters
@@ -17,7 +17,8 @@ The MCP Client Tool node supports [Bearer](/integrations/builtin/credentials/htt
 Configure the node with the following parameters.
 
 * **SSE Endpoint**: The SSE endpoint for the MCP server you want to connect to.
-* **Authentication**: The authentication method for authentication to your MCP server. The MCP tool supports [bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), and [OAuth2](/integrations/builtin/credentials/httprequest.md#using-oauth2) authentication. Select **None** to attempt to connect without authentication.
+* **Authentication**: The authentication method for authentication to your MCP server. The MCP tool supports [bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](/integrations/builtin/credentials/httprequest.md#using-oauth2) authentication. Select **None** to attempt to connect without authentication.
+	* **Multiple Headers Auth**: Use this when your MCP server requires more than one header, for example an API key and a username. Add each header as a **Name** and **Value** pair in the credential. You can add as many headers as you need.
 * **Tools to Include**: Choose which tools you want to expose to the AI Agent:
 	* **All**: Expose all the tools given by the MCP server.
 	* **Selected**: Activates a **Tools to Include** parameter where you can select the tools you want to expose to the AI Agent.

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcpClient.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcpClient.md
@@ -13,7 +13,7 @@ You can use the MCP Client node to use MCP tools as regular steps in a workflow.
 If you want to use MCP tools as tools for an AI Agent, use the [MCP Client Tool node](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md) instead.
 
 ///  note  | Credentials
-The MCP Client node supports [Bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), and [OAuth2](/integrations/builtin/credentials/httprequest.md#using-oauth2) authentication methods.
+The MCP Client node supports [Bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](/integrations/builtin/credentials/httprequest.md#using-oauth2) authentication methods.
 ///
 
 ## Node parameters
@@ -22,7 +22,8 @@ Configure the node with the following parameters.
 
 * **Server Transport**: The transport protocol used by the MCP Server endpoint you want to connect to.
 * **MCP Endpoint URL**: The URL of the external MCP Server. For example, `https://mcp.notion.com/mcp`.
-* **Authentication**: The authentication method for authentication to your MCP server. The MCP Client node supports [bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), and [OAuth2](/integrations/builtin/credentials/httprequest.md#using-oauth2) authentication. Select **None** to attempt to connect without authentication.
+* **Authentication**: The authentication method for authentication to your MCP server. The MCP Client node supports [bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](/integrations/builtin/credentials/httprequest.md#using-oauth2) authentication. Select **None** to attempt to connect without authentication.
+	* **Multiple Headers Auth**: Use this when your MCP server requires more than one header, for example an API key and a username. Add each header as a **Name** and **Value** pair in the credential. You can add as many headers as you need.
 * **Tool**: Select the tool to use in the node. The list of tools is automatically fetched from the external MCP server.
 * **Input Mode**: 
 	* **Manual**: Specify each tool parameter manually.


### PR DESCRIPTION
## Summary

Documents the **Multiple Headers Auth** credential option on both the standalone **MCP Client** node and the **MCP Client Tool** node. This auth method shipped in [n8n#21435](https://github.com/n8n-io/n8n/pull/21435) (November 2025) but was never documented.

The option lets you add multiple custom HTTP headers as key-value pairs, for MCP servers that require more than one header (for example, an API key plus a username). It's configured through a credential, separate from the node's JSON input mode.

## Changes

- `n8n-nodes-langchain.mcpClient.md`: add multiple headers to the Credentials note and Authentication parameter, with an explanatory sub-bullet.
- `n8n-nodes-langchain.toolmcp.md`: same edits for the tool variant.

Scope note: documentation is kept strictly on the MCP node pages. The credential is technically selectable on the HTTP Request node (via `has:genericAuth`) but isn't implemented there, so it's intentionally not added to the HTTP Request credentials page.

## Linear

- Closes DOC-1676
- Implementation: NODE-3810