### PR TITLE
docs(snippets): fix missing root directory in reusable snippet relative links

### DIFF
--- a/_snippets/examples-color-key.md
+++ b/_snippets/examples-color-key.md
@@ -2,7 +2,7 @@ To load the template into your n8n instance:
 
 1. Download the workflow JSON file.
 1. Open a new workflow in your n8n instance.
-1. Copy in the JSON, or select **Workflow menu** <span class="n8n-inline-image">![Workflow menu icon](/_images/common-icons/three-dots-horizontal.png){.off-glb}</span> > **Import from file...**.
+1. Copy in the JSON, or select **Workflow menu** <span class="n8n-inline-image">![Workflow menu icon](/docs/_images/common-icons/three-dots-horizontal.png){.off-glb}</span> > **Import from file...**.
 
 The example workflows use Sticky Notes to guide you:
 

--- a/_snippets/update-n8n.md
+++ b/_snippets/update-n8n.md
@@ -2,7 +2,7 @@
 
 The steps to update your n8n depend on which n8n platform you use. Refer to the documentation for your n8n:
 
-* [Cloud](/manage-cloud/update-cloud-version.md)
+* [Cloud](/docs/manage-cloud/update-cloud-version.md)
 * Self-hosted options:
-    * [npm](/hosting/installation/npm.md)
-    * [Docker](/hosting/installation/docker.md)
+    * [npm](/docs/hosting/installation/npm.md)
+    * [Docker](/docs/hosting/installation/docker.md)


### PR DESCRIPTION
# What does this PR do?
This PR resolves broken relative paths and asset rendering 404 errors inside two core reusable markdown snippets (`_snippets/`).

### The Bugs Fixed:
1. **`update-n8n.md`**: The links for Cloud, npm, and Docker were missing the `/docs/` root directory prefix, causing routing failures when resolved and rendered on live pages.
2. **`examples-color-key.md`**: The `three-dots-horizontal.png` workflow menu icon path was also missing the `/docs/` root directory prefix, breaking the image asset rendering on the documentation layouts.

### The Fix:
Added the missing `/docs/` prefix to all four relative paths, ensuring they resolve accurately to their true locations in the repository tree. Verified via the GitHub preview interface that all navigation paths and the 3-dot image asset now render perfectly without any "Error loading page" or 404 issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the missing `/docs/` prefix to Cloud/npm/Docker links in `_snippets/update-n8n.md` and the workflow menu icon path in `_snippets/examples-color-key.md`. All links and the icon now load without 404s.

<sup>Written for commit 6beef32d73b57948e8fbe15347ea937a57e86f74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

