### PR TITLE
docs: Explain new production workflow behaviour for otel traces

### DIFF
--- a/docs/hosting/configuration/environment-variables/opentelemetry.md
+++ b/docs/hosting/configuration/environment-variables/opentelemetry.md
@@ -24,5 +24,6 @@ n8n can export workflow and node execution traces over OTLP to an OpenTelemetry 
 | `N8N_OTEL_EXPORTER_SERVICE_NAME` | String | `n8n` | Value of the `service.name` resource attribute on exported spans. | 2.19.0 |
 | `N8N_OTEL_TRACES_SAMPLE_RATE` | Number | `1.0` | Fraction of traces to export, between `0` and `1`. n8n uses a trace ID ratio sampler, so all spans in a trace are either sampled or dropped together. | 2.19.0 |
 | `N8N_OTEL_TRACES_INCLUDE_NODE_SPANS` | Boolean | `true` | Whether to emit a `node.execute` span for each node execution. Set to `false` to export workflow-level spans only. | 2.19.0 |
+| `N8N_OTEL_TRACES_PRODUCTION_ONLY` | Boolean | `true` | Whether to export traces for [production executions](/workflows/executions/manual-partial-and-production-executions.md) only. Set to `false` to export traces for all workflow executions. | 2.25.2 |
 | `N8N_OTEL_TRACES_INJECT_OUTBOUND` | Boolean | `true` | Whether to inject the W3C `traceparent`/`tracesstate` headers into outbound HTTP requests made by nodes that use n8n's HTTP helpers. | 2.19.0 |
 | `N8N_OTEL_STARTUP_CONNECTIVITY_TIMEOUT_MS` | Number | `2000` | Timeout (in milliseconds) for the startup connectivity check against the OTLP endpoint. n8n logs a warning if the endpoint isn't reachable within this period. | 2.19.0 |

--- a/docs/hosting/logging-monitoring/opentelemetry.md
+++ b/docs/hosting/logging-monitoring/opentelemetry.md
@@ -77,7 +77,7 @@ export N8N_OTEL_TRACES_SAMPLE_RATE=0.1
 n8n uses a trace ID ratio sampler, so the same trace ID is either fully sampled or fully dropped across all spans in the trace.
 
 /// note
-By default, n8n only exports traces for [production executions](/workflows/executions/manual-partial-and-production-executions.md). To also export traces for all workflow executions, set `N8N_OTEL_TRACES_PRODUCTION_ONLY=false`.
+By default, n8n only outputs traces for [production executions](/workflows/executions/manual-partial-and-production-executions.md). To output traces for all workflow executions, set `N8N_OTEL_TRACES_PRODUCTION_ONLY=false`.
 ///
 
 ## Reduce span volume

--- a/docs/hosting/logging-monitoring/opentelemetry.md
+++ b/docs/hosting/logging-monitoring/opentelemetry.md
@@ -77,7 +77,7 @@ export N8N_OTEL_TRACES_SAMPLE_RATE=0.1
 n8n uses a trace ID ratio sampler, so the same trace ID is either fully sampled or fully dropped across all spans in the trace.
 
 /// note
-By default, n8n only exports traces for [production executions](/workflows/executions/manual-partial-and-production-executions.md). To also export traces all workflow executions, set `N8N_OTEL_TRACES_PRODUCTION_ONLY=false`.
+By default, n8n only exports traces for [production executions](/workflows/executions/manual-partial-and-production-executions.md). To also export traces for all workflow executions, set `N8N_OTEL_TRACES_PRODUCTION_ONLY=false`.
 ///
 
 ## Reduce span volume

--- a/docs/hosting/logging-monitoring/opentelemetry.md
+++ b/docs/hosting/logging-monitoring/opentelemetry.md
@@ -76,8 +76,8 @@ export N8N_OTEL_TRACES_SAMPLE_RATE=0.1
 
 n8n uses a trace ID ratio sampler, so the same trace ID is either fully sampled or fully dropped across all spans in the trace.
 
-/// note | 
-n8n will output a trace for every workflow execution - this includes published workflows, unpublished workflows and test executions - In a future release a toggle will be available to track only published workflows 
+/// note
+By default, n8n only exports traces for [production executions](/workflows/executions/manual-partial-and-production-executions.md). To also export traces all workflow executions, set `N8N_OTEL_TRACES_PRODUCTION_ONLY=false`.
 ///
 
 ## Reduce span volume


### PR DESCRIPTION
We've changed the default for which executions output traces.
This PR documents this.
Not considered a breaking change since otel is still so new.

Preview deployment links to edited pages:
- https://ligo-655-docs-add-docs-for-p.n8n-docs-d9c.pages.dev/hosting/logging-monitoring/opentelemetry/#sampling:~:text=N8N_OTEL_TRACES_PRODUCTION_ONLY
- https://ligo-655-docs-add-docs-for-p.n8n-docs-d9c.pages.dev/hosting/configuration/environment-variables/opentelemetry/


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update OpenTelemetry docs to reflect the new default: n8n exports traces only for production executions. Added `N8N_OTEL_TRACES_PRODUCTION_ONLY` (default `true` since 2.25.2) to the env var table and clarified how to export traces for all executions, aligning with LIGO-655.

<sup>Written for commit 4cc3b09f6a3bc49d934287807ee2dab166e1beec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



