### PR TITLE
docs: document Microsoft Agent 365 Trigger webhook authentication (DOC-1968)

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.microsoftagent365trigger.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.microsoftagent365trigger.md
@@ -60,6 +60,12 @@ When enabled, select one of:
 	- Word
 	- and more
 
+## Webhook authentication <a href="#webhook-authentication" id="webhook-authentication"></a>
+
+From n8n version 2.25.7 and 2.26.2, the Microsoft Agent 365 Trigger node validates every incoming request before it runs your workflow. The node checks the Bot Framework token that Microsoft sends with each request and confirms Microsoft issued it for your agent. The node rejects any request without a valid token, so others can't inject forged activities even if they know your webhook URL.
+
+This validation uses the **Client ID** from your [Microsoft Agent 365 credential](../../credentials/microsoftagent365.md). The Client ID must match the application (client) ID of your agent's app registration. If it doesn't, the node rejects legitimate requests from Microsoft.
+
 ## Getting started <a href="#getting-started" id="getting-started"></a>
 
 We recommend following these resources to set up your Agent 365 integration:

--- a/docs/integrations/builtin/credentials/microsoftagent365.md
+++ b/docs/integrations/builtin/credentials/microsoftagent365.md
@@ -56,4 +56,10 @@ To set up the credential:
 2. Open the [Microsoft Application Registration Portal](https://aka.ms/appregistrations) and follow the [custom client app registration guide](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/custom-client-app-registration) for Microsoft Agent 365. Once your custom client app is created, copy the Application (client) ID into n8n as the **Client ID**.
 3. Follow the [credentials guide](https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-credentials?tabs=client-secret) to generate a client secret and copy the **Secret** in the **Value** column and paste it into n8n as the **Client Secret**.
 
+{% hint style="info" %}
+**Incoming request validation**
+
+The Microsoft Agent 365 Trigger node also uses your **Client ID** to validate incoming webhook requests, so it must match the application (client) ID of your agent's app registration. Refer to [Webhook authentication](../cluster-nodes/root-nodes/n8n-nodes-langchain.microsoftagent365trigger.md#webhook-authentication).
+{% endhint %}
+
 We recommend using [Agent 365 CLI](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/agent-365-cli) to create your agent blueprint and manifest.


### PR DESCRIPTION
## Summary

Documents the security fix from AI-2525 (n8n#142, "Validate inbound Bot Framework request tokens"). The Microsoft Agent 365 Trigger node now validates the inbound Bot Framework token on every webhook request, closing an authentication bypass where anyone who knew the webhook URL could inject forged activities.

## Changes

- **Trigger node page**: new `## Webhook authentication` section explaining that the node validates incoming requests, rejects any without a valid token, and that validation relies on the credential's **Client ID** matching the agent's app registration.
- **Credentials page**: short note tying the Client ID to inbound request validation, cross-linked to the trigger section.

Follows the Slack Trigger docs convention for incoming-webhook verification.

## Notes

- Labeled `status:in-next-release`: the fix (n8n#142) is merged but unreleased. Hold until it ships, then we can add a "From version X.Y.Z" note.
