### PR TITLE
Add 'GetManyMembers of a group' to GSuiteAdmin (n8n-io/n8n#1718)

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.gsuiteadmin.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.gsuiteadmin.md
@@ -29,6 +29,7 @@ Refer to [Google credentials](/integrations/builtin/credentials/google/index.md)
     * Get a group
     * Get many groups
     * Update a group
+    * Get many members of a group
 * User
 	* Add an existing user to a group
     * Create a user


### PR DESCRIPTION
n8n-io/n8n#31718

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the new “Get many members of a group” operation to the G Suite Admin node docs under Group actions. This keeps the docs accurate and makes the bulk member retrieval feature easy to find.

<sup>Written for commit ee7ceb068bdf0ec4690560d6c65e3da979cc2c76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

