### PR TITLE
docs: Change Google Cloud Storage Node service account authentication support to true

### DIFF
--- a/docs/integrations/builtin/credentials/google/index.md
+++ b/docs/integrations/builtin/credentials/google/index.md
@@ -42,7 +42,7 @@ Once configured, you can use your credentials to authenticate the following node
 | [Google Books](/integrations/builtin/app-nodes/n8n-nodes-base.googlebooks.md) | :white_check_mark: | :white_check_mark: |
 | [Google Calendar](/integrations/builtin/app-nodes/n8n-nodes-base.googlecalendar/index.md) | :white_check_mark: | :x: |
 | [Google Chat](/integrations/builtin/app-nodes/n8n-nodes-base.googlechat.md) | :white_check_mark: | :white_check_mark: |
-| [Google Cloud Storage](/integrations/builtin/app-nodes/n8n-nodes-base.googlecloudstorage.md) | :white_check_mark: | :x: |
+| [Google Cloud Storage](/integrations/builtin/app-nodes/n8n-nodes-base.googlecloudstorage.md) | :white_check_mark: | :white_check_mark: |
 | [Google Contacts](/integrations/builtin/app-nodes/n8n-nodes-base.googlecontacts.md) | :white_check_mark: | :x: |
 | [Google Cloud Firestore](/integrations/builtin/app-nodes/n8n-nodes-base.googlecloudfirestore.md) | :white_check_mark: | :white_check_mark: |
 | [Google Cloud Natural Language](/integrations/builtin/app-nodes/n8n-nodes-base.googlecloudnaturallanguage.md) | :white_check_mark: | :x: |


### PR DESCRIPTION
Support for n8n service account authentication has been added in this PR:
https://github.com/n8n-io/n8n/pull/30928

Updates the documentation indicating support of service account authentication for Google Cloud Storage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Google credentials docs to mark `Google Cloud Storage` as supporting service account authentication. The support table now reflects the node’s new service account capability.

<sup>Written for commit 74d3964b0c164004be4cbc2394ee848360970d58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

