### PR TITLE
docs: add managed auth note to Airtable OAuth2 credential (DOC-2013)

### DIFF
--- a/docs/integrations/builtin/credentials/airtable.md
+++ b/docs/integrations/builtin/credentials/airtable.md
@@ -52,7 +52,9 @@ Refer to Airtable's [Find/create PATs documentation](https://support.airtable.co
 
 ## Using OAuth2
 
-To configure this credential, you'll need:
+--8<-- "_snippets/integrations/builtin/credentials/cloud-oauth-button.md"
+
+If you're [self-hosting n8n](/hosting/index.md), you'll need:
 
 - An **OAuth Redirect URL**
 - A **Client ID**


### PR DESCRIPTION
## Summary

Adds the managed auth note to the Airtable OAuth2 credential docs. Airtable is now on n8n Cloud's managed-OAuth roster (CPSR-42), so Cloud users connect with the **Connect to Airtable** button without entering a Client ID/Secret.

## Changes

- Insert the shared `cloud-oauth-button.md` snippet under **Using OAuth2**.
- Reframe the Client ID/Secret setup steps as self-hosted-only ("If you're self-hosting n8n…"), matching the Slack/GitHub credential convention.

## Context

- Linear: DOC-2013
- Related: CPSR-42 (managed credentials for Airtable)

Verified on the latest stable n8n Cloud: the Airtable OAuth2 credential modal is button-only (no Client ID/Secret). Built locally with `mkdocs serve`; the snippet renders correctly.
