### PR TITLE
docs: document Gumroad OAuth2 credential with managed auth note (DOC-2013)

### DIFF
--- a/docs/integrations/builtin/credentials/gumroad.md
+++ b/docs/integrations/builtin/credentials/gumroad.md
@@ -17,6 +17,7 @@ Create a [Gumroad](https://gumroad.com/) account.
 ## Supported authentication methods
 
 - API access token
+- OAuth2
 
 ## Related resources
 
@@ -26,5 +27,24 @@ Refer to [Gumroad's API documentation](https://app.gumroad.com/api) for more inf
 
 To configure this credential, you'll need:
 
-- An API **Access Token**: Create an application to generate an access token. Refer to the [Gumroad Create an application for the API documentation](https://help.gumroad.com/article/280-create-application-api) for detailed instructions on creating a new application and generating an access token.
+- An API **Access Token**: Create an application to generate an access token. Refer to the [Gumroad Create an application for the API documentation](https://gumroad.com/help/article/280-create-application-api) for detailed instructions on creating a new application and generating an access token.
+
+## Using OAuth2
+
+--8<-- "_snippets/integrations/builtin/credentials/cloud-oauth-button.md"
+
+If you're [self-hosting n8n](/hosting/index.md), you'll need:
+
+- An **OAuth Redirect URL**
+- A **Client ID**
+- A **Client Secret**
+
+To get this information, create a Gumroad application:
+
+1. In Gumroad, go to **Settings > Advanced**. Refer to the [Gumroad Create an application for the API documentation](https://gumroad.com/help/article/280-create-application-api) for detailed instructions.
+2. Copy the **OAuth Redirect URL** from your n8n credential and enter it as the **Redirect URI** when you create the application in Gumroad.
+3. Create the application. Gumroad generates an **Application ID** and **Application Secret**.
+4. Copy the **Application ID** and paste it into the **Client ID** in your n8n credential.
+5. Copy the **Application Secret** and paste it into the **Client Secret** in your n8n credential.
+6. To request scopes beyond the default `view_sales`, enable **Custom Scopes** in your n8n credential and enter the scopes you need. Otherwise, leave it off.
 


### PR DESCRIPTION
## Summary

Documents the new Gumroad OAuth2 credential. Gumroad now has a `Gumroad OAuth2 API` credential type alongside the existing access-token credential, and it's on n8n Cloud's managed-OAuth roster (CE-1044 / CE-900), so Cloud users connect with the **Connect to Gumroad** button without entering a Client ID/Secret.

## Changes

- Add **OAuth2** to **Supported authentication methods**.
- Add a **Using OAuth2** section with the shared `cloud-oauth-button.md` managed-auth snippet, plus self-hosted setup steps (register a Gumroad application in Settings > Advanced, map Application ID/Secret to Client ID/Secret, optional Custom Scopes beyond the default `view_sales`), matching the Slack/GitHub credential convention.
- Update the Gumroad help-article links to the canonical `gumroad.com/help/article/280-create-application-api` URL.

## Context

- Linear: DOC-2013
- Related: CE-1044 (Gumroad managed OAuth), CE-900 (Gumroad OAuth2 support)

Verified on the latest stable n8n Cloud: the Gumroad OAuth2 credential modal is button-only (no Client ID/Secret). Built locally with `mkdocs serve`; the snippet and section render correctly.
