### PR TITLE
docs: fix outdated programmatic node tutorial references (fixes #3206)

### DIFF
--- a/docs/integrations/creating-nodes/build/reference/node-base-files/standard-parameters.md
+++ b/docs/integrations/creating-nodes/build/reference/node-base-files/standard-parameters.md
@@ -80,14 +80,14 @@ When building a multi-input node, you can choose to force all preceding nodes on
 
 _Array of strings_ | _Required_
 
-Names the input connectors. Controls the number of connectors the node has on the input side. If you need only one connector, use `input: ['main']`.
+Names the input connectors. Controls the number of connectors the node has on the input side. If you need only one connector, use `inputs: [NodeConnectionType.Main]`.
 
 
 ## `outputs`
 
-_Array of strings_ | _Required_  
+_Array of strings_ | _Required_ 
 
-Names the output connectors. Controls the number of connectors the node has on the output side. If you need only one connector, use `output: ['main']`.
+Names the output connectors. Controls the number of connectors the node has on the output side. If you need only one connector, use `outputs: [NodeConnectionType.Main]`.
 
 ## `requiredInputs`
 

--- a/docs/integrations/creating-nodes/build/reference/node-base-files/structure.md
+++ b/docs/integrations/creating-nodes/build/reference/node-base-files/structure.md
@@ -37,8 +37,7 @@ Refer to [Standard parameters](/integrations/creating-nodes/build/reference/node
 This code snippet gives an outline of the node structure. 
 
 ```js
-import { IExecuteFunctions } from 'n8n-core';
-import { INodeExecutionData, INodeType, INodeTypeDescription } from 'n8n-workflow';
+import { IExecuteFunctions, INodeExecutionData, INodeType, INodeTypeDescription } from 'n8n-workflow';
 
 export class ExampleNode implements INodeType {
 	description: INodeTypeDescription = {


### PR DESCRIPTION
Fixes 3 outdated references in the programmatic node tutorial:

1. **IExecuteFunctions import** — Updated from `n8n-core` to `n8n-workflow` in `structure.md`
2. **inputs syntax** — Changed from `input: ['main']` to `inputs: [NodeConnectionType.Main]` in `standard-parameters.md`
3. **outputs syntax** — Changed from `output: ['main']` to `outputs: [NodeConnectionType.Main]` in `standard-parameters.md`

These changes address Issue #3206 where the custom programmatic node tutorial had incorrect/outdated code examples.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix outdated references in the programmatic node tutorial to match current APIs: import IExecuteFunctions from `n8n-workflow` instead of `n8n-core`, and update examples to use `inputs: [NodeConnectionType.Main]` and `outputs: [NodeConnectionType.Main]`. Resolves #3206.

<sup>Written for commit 98d68016660d8a52444af8ac1634db30383d1c2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

