### PR TITLE
docs: Enhance 'Choose your n8n' section

### DIFF
--- a/docs/choose-n8n.md
+++ b/docs/choose-n8n.md
@@ -5,41 +5,110 @@ contentType: overview
 
 # Choose your n8n
 
-This section contains information on n8n's range of platforms, pricing plans, and licenses.
+n8n offers two primary deployment options:
 
-## Platforms
+- **n8n Cloud**: A fully-managed hosted solution with no installation required
+- **Self-hosted**: Deploy n8n on your own infrastructure using npm, Docker, or server setups
 
-There are different ways to set up n8n depending on how you intend to use it:
+## Feature Comparison
 
-* [n8n Cloud](/manage-cloud/overview.md): hosted solution, no need to install anything.
-* [Self-host](/hosting/index.md): recommended method for production or customized use cases.
-	* [npm](/hosting/installation/npm.md)
-	* [Docker](/hosting/installation/docker.md)
-	* [Server setup guides](/hosting/installation/server-setups/index.md) for popular platforms
-* [OEM deployment](/hosting/oem-deployment/index.md): Surface n8n's interface inside your own product's UI. Requires an OEM agreement - [contact n8n](mailto:license@n8n.io) for details.
+### Self-hosted Community Edition
 
---8<-- "_snippets/self-hosting/warning.md"
+The Community Edition includes almost the complete feature set of n8n, **except** for these features:
 
+| Feature Category | Not Available in Community Edition | Available In |
+|-----------------|-----------------------------------|--------------|
+| **Variables & Configuration** | Custom Variables | Enterprise editions, some Cloud paid plans |
+| **Environments** | Environments | Enterprise editions, some Cloud paid plans |
+| **Secrets Management** | External secrets | Enterprise editions, some Cloud paid plans |
+| **Storage** | External storage for binary data | Enterprise editions |
+| **Logging** | Log streaming (standard logging IS included) | Enterprise editions |
+| **Scaling** | Multi-main mode (queue mode IS included) | Enterprise editions |
+| **Organization** | Projects | Enterprise editions, some Cloud paid plans |
+| **Authentication** | SSO (SAML, LDAP) | Enterprise editions |
+| **Collaboration** | Workflow and credential sharing** | Enterprise editions, some Cloud paid plans |
+| **Version Control** | Version control using Git | Enterprise editions, some Cloud paid plans |
 
-## Licenses
+\*\* In Community Edition, only the instance owner and the user who creates workflows/credentials can access them.
 
-n8n's [Sustainable Use License](https://github.com/n8n-io/n8n/blob/master/LICENSE.md) and [n8n Enterprise License](https://github.com/n8n-io/n8n/blob/master/LICENSE_EE.md) are based on the [fair-code](https://faircode.io/) model.
+### Self-hosted Registered Community Edition (Free)
 
-For a detailed explanation of the license, refer to [Sustainable Use License](/sustainable-use-license.md).
+By registering your Community Edition with your email, you unlock these additional features:
 
-## Free versions
+| Feature | Description |
+|---------|-------------|
+| Folders | Organize your workflows into folders |
+| Debug in editor | Copy and pin execution data when working on a workflow |
+| Custom execution data | Save, find, and annotate execution metadata |
 
-n8n offers the following free options:
+### n8n Cloud vs Self-hosted Enterprise
 
-* A free trial of Cloud
-* A free self-hosted community edition for self-hosted users
+Both n8n Cloud (Enterprise plan) and Self-hosted Enterprise editions include all the features listed above that are missing from the Community Edition.
 
-## Paid versions
+For specific details on which features are available on Cloud Starter, Pro, and Business self-hosted plans, see the [pricing page](https://n8n.io/pricing/).
 
-n8n has two paid versions:
+## Pros and Cons Comparison
 
-* n8n Cloud: choose from a range of paid plans to suit your usage and feature needs.
-* Self-hosted: there are both free and paid versions of self-hosted.
+| Aspect | n8n Cloud | Self-hosted |
+|--------|-----------|-------------|
+| **Setup & Deployment** |
+| Installation | ✅ No installation needed | ❌ Requires setup (npm, Docker, or server) |
+| Technical expertise | ✅ None required | ❌ Required for installation and configuration |
+| **Infrastructure Management** |
+| Hosting | ✅ Fully hosted by n8n | ❌ You must provide and manage infrastructure |
+| Maintenance | ✅ Handled by n8n | ❌ Your responsibility |
+| **Control & Customization** |
+| Deployment control | ❌ Managed by n8n | ✅ Full control over deployment |
+| Customization | ❌ Limited to available options | ✅ Recommended for customized use cases |
+| **Cost** |
+| Free option | ⚠️ Free trial available | ✅ Free Community Edition with most features |
+| Paid options | ✅ Range of paid plans | ✅ Paid Enterprise option available |
+| **Features** |
+| Core features | ✅ Included | ✅ Included in free Community Edition |
+| Enterprise features | ❌ Requires paid plans | ❌ Requires Enterprise license (free Community limited) |
+| **Use Cases** |
+| Quick start | ✅ Ideal for getting started | ⚠️ Takes longer to set up |
+| Production use | ✅ Supported | ✅ Recommended for production |
+| Custom requirements | ⚠️ Limited customization | ✅ Recommended for customized use cases |
 
-For details of the Cloud plans and contact details for Enterprise Self-hosted, refer to [Pricing](https://n8n.io/pricing/) on the n8n website.
+**Legend**: ✅ Advantage | ❌ Disadvantage | ⚠️ Mixed/depends on needs
 
+For detailed pricing and plan comparisons, see the [pricing page](https://n8n.io/pricing/).
+
+## Decision Guide
+
+| Your Situation | Recommended Option | Reason |
+|----------------|-------------------|---------|
+| Want to start quickly | **n8n Cloud** | No installation needed |
+| Don't have technical expertise | **n8n Cloud** | Hosted solution, no setup required |
+| Need production-ready deployment | **Both options work** | Both Cloud and self-hosted support production use |
+| Have customized use cases | **Self-hosted** | Recommended for customization |
+| Want most features for free | **Self-hosted Community Edition** | Free with almost complete feature set |
+| Need folders and debugging features for free | **Registered Community Edition** | Free registration unlocks these features |
+| Need enterprise features (SSO, environments, projects, etc.) | **Cloud (paid) or Self-hosted Enterprise** | These features require paid plans |
+| Have infrastructure and technical resources | **Self-hosted** | Can manage your own deployment |
+
+For specific feature availability across different Cloud and self-hosted plans, see the [pricing page](https://n8n.io/pricing/).
+
+## Getting Started
+
+### n8n Cloud
+
+Visit [n8n Cloud](https://n8n.io/cloud/) to sign up for a free trial.
+
+### Self-hosted
+
+Refer to the [hosting documentation](/hosting/index.md) for installation options:
+
+- [npm installation](/hosting/installation/npm.md)
+- [Docker installation](/hosting/installation/docker.md)
+- [Server setup guides](/hosting/installation/server-setups/index.md)
+
+To register a Community Edition instance for additional features, go to **Settings > Usage and plan** and select **Unlock**.
+
+## Additional Resources
+
+- [Pricing details](https://n8n.io/pricing/)
+- [Sustainable Use License](/sustainable-use-license.md)
+- [Community Edition features](/hosting/community-edition-features.md)
+- [Choose your n8n](/choose-n8n.md)

--- a/docs/choose-n8n.md
+++ b/docs/choose-n8n.md
@@ -14,7 +14,7 @@ n8n offers two primary deployment options:
 
 ### Self-hosted Community Edition
 
-The Community Edition includes almost the complete feature set of n8n, **except** for these features:
+n8n's Community Edition is the free, self-hosted version of n8n that you can run on your own infrastructure. The Community Edition includes almost the complete feature set of n8n, **except** for these features:
 
 | Feature Category | Not Available in Community Edition | Available In |
 |-----------------|-----------------------------------|--------------|

--- a/docs/choose-n8n.md
+++ b/docs/choose-n8n.md
@@ -10,44 +10,7 @@ n8n offers two primary deployment options:
 - **n8n Cloud**: A fully-managed hosted solution with no installation required
 - **Self-hosted**: Deploy n8n on your own infrastructure using npm, Docker, or server setups
 
-## Feature Comparison
-
-### Self-hosted Community Edition
-
-n8n's Community Edition is the free, self-hosted version of n8n that you can run on your own infrastructure. The Community Edition includes almost the complete feature set of n8n, **except** for these features:
-
-| Feature Category | Not Available in Community Edition | Available In |
-|-----------------|-----------------------------------|--------------|
-| **Variables & Configuration** | Custom Variables | Enterprise editions, some Cloud paid plans |
-| **Environments** | Environments | Enterprise editions, some Cloud paid plans |
-| **Secrets Management** | External secrets | Enterprise editions, some Cloud paid plans |
-| **Storage** | External storage for binary data | Enterprise editions |
-| **Logging** | Log streaming (standard logging IS included) | Enterprise editions |
-| **Scaling** | Multi-main mode (queue mode IS included) | Enterprise editions |
-| **Organization** | Projects | Enterprise editions, some Cloud paid plans |
-| **Authentication** | SSO (SAML, LDAP) | Enterprise editions |
-| **Collaboration** | Workflow and credential sharing** | Enterprise editions, some Cloud paid plans |
-| **Version Control** | Version control using Git | Enterprise editions, some Cloud paid plans |
-
-\*\* In Community Edition, only the instance owner and the user who creates workflows/credentials can access them.
-
-### Self-hosted Registered Community Edition (Free)
-
-By registering your Community Edition with your email, you unlock these additional features:
-
-| Feature | Description |
-|---------|-------------|
-| Folders | Organize your workflows into folders |
-| Debug in editor | Copy and pin execution data when working on a workflow |
-| Custom execution data | Save, find, and annotate execution metadata |
-
-### n8n Cloud vs Self-hosted Enterprise
-
-Both n8n Cloud (Enterprise plan) and Self-hosted Enterprise editions include all the features listed above that are missing from the Community Edition.
-
-For specific details on which features are available on Cloud Starter, Pro, and Business self-hosted plans, see the [pricing page](https://n8n.io/pricing/).
-
-## Pros and Cons Comparison
+## Pros and cons comparison
 
 | Aspect | n8n Cloud | Self-hosted |
 |--------|-----------|-------------|
@@ -75,9 +38,46 @@ For specific details on which features are available on Cloud Starter, Pro, and 
 
 For detailed pricing and plan comparisons, see the [pricing page](https://n8n.io/pricing/).
 
-## Decision Guide
+## Feature comparison
 
-| Your Situation | Recommended Option | Reason |
+### Self-hosted Community Edition
+
+n8n's Community Edition is the free, self-hosted version of n8n that you can run on your own infrastructure. 
+
+| Feature | Not available in Community Edition | Available in |
+|-----------------|-----------------------------------|--------------|
+| **Variables & Configuration** | Custom variables | Enterprise editions, some Cloud paid plans |
+| **Environments** | Environments | Enterprise editions, some Cloud paid plans |
+| **Secrets Management** | External secrets | Enterprise editions, some Cloud paid plans |
+| **Storage** | External storage for binary data | Enterprise editions |
+| **Logging** | Log streaming (standard logging IS included) | Enterprise editions |
+| **Scaling** | Multi-main mode (queue mode IS included) | Enterprise editions |
+| **Organization** | Projects | Enterprise editions, some Cloud paid plans |
+| **Authentication** | SSO (SAML, LDAP) | Enterprise editions |
+| **Collaboration** | Workflow and credential sharing** | Enterprise editions, some Cloud paid plans |
+| **Version Control** | Version control using Git | Enterprise editions, some Cloud paid plans |
+
+In Community Edition, only the instance owner and the user who creates workflows or credentials can access them.
+
+### Self-hosted registered Community Edition (Free)
+
+By registering your Community Edition with your email, you unlock these additional features:
+
+| Feature | Description |
+|---------|-------------|
+| Folders | Organize your workflows into folders |
+| Debug in editor | Copy and pin execution data when working on a workflow |
+| Custom execution data | Save, find, and annotate execution metadata |
+
+### n8n Cloud vs Self-hosted Enterprise
+
+Both n8n Cloud (Enterprise plan) and Self-hosted Enterprise editions include all the features listed above that are missing from the Community Edition.
+
+For specific details on which features are available on Cloud Starter, Pro, and Business self-hosted plans, see the [pricing page](https://n8n.io/pricing/).
+
+## Decision guide
+
+| Your situation | Recommended option | Reason |
 |----------------|-------------------|---------|
 | Want to start quickly | **n8n Cloud** | No installation needed |
 | Don't have technical expertise | **n8n Cloud** | Hosted solution, no setup required |

--- a/docs/courses/level-one/chapter-1.md
+++ b/docs/courses/level-one/chapter-1.md
@@ -22,7 +22,7 @@ We recommend starting with [n8n Cloud](https://app.n8n.cloud/register), a hosted
 If n8n Cloud isn't a good option for you, you can [self-host with Docker](/hosting/installation/docker.md). This is an advanced option recommended only for technical users familiar with hosting services, Docker, and the command line.
 ///
 
-For more details on the different ways to set up n8n, see our [platforms documentation](/choose-n8n.md#platforms).
+For more details on the different ways to set up n8n, see [Choose your n8n](/choose-n8n.md).
 
 Once you have n8n running, open the Editor UI in a browser window. Log in to your n8n instance. Select **Overview** and then **Create Workflow** to view the main canvas.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Revamped the “Choose your n8n” page with a Cloud vs self‑hosted pros/cons table, a Community vs Enterprise feature matrix (variables, environments, secrets, storage, logging, scaling, projects, SSO, sharing, Git), and a simple decision guide with links to plan details.

Added Cloud/self‑hosted getting‑started steps (including how to register CE to unlock folders, debug in editor, and custom execution data), clarified CE access limits (only owners/creators can access workflows and credentials), and updated the Level One course to link to this page.

<sup>Written for commit c63812289f6bf7caea4f783df34296c445c4683c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



