### PR TITLE
docs: document instance-level execution data redaction enforcement (ENT-25)

### DIFF
--- a/docs/security-settings.md
+++ b/docs/security-settings.md
@@ -69,6 +69,33 @@ When you disable publishing:
 - Currently published workflows remain published. The setting only affects new publish actions.
 - The number of currently published personal workflows is displayed below the toggle.
 
+## Enforce execution data redaction
+
+You can enforce [execution data redaction](/workflows/executions/execution-data-redaction.md) for all workflows on the instance. Enforcement sets an instance-wide minimum redaction policy that individual workflow settings can't weaken.
+
+/// info | Feature availability
+Data redaction enforcement is available on Enterprise Self-hosted and Enterprise Cloud plans.
+
+**Available from:** n8n version 2.26.0
+///
+
+To enforce data redaction:
+
+1. Navigate to **Settings** > **Security**.
+2. In the **Data redaction** section, toggle **Enforce data redaction** on.
+3. Under **Redact executions**, select the enforcement scope:
+	- **Production executions (Recommended)**: n8n redacts data from production executions in all workflows.
+	- **Manual and production executions**: n8n redacts data from both manual and production executions in all workflows.
+4. Confirm your choice in the dialog.
+
+When you enable enforcement:
+
+- n8n redacts execution data for all workflows within the selected scope, including workflows that don't have redaction enabled in their own settings.
+- Workflow-level redaction settings can't be set weaker than the enforced scope. Workflows can still opt into stricter redaction, for example redacting manual executions when only production enforcement is active.
+- New workflows start with the enforced scope as their redaction policy.
+
+Redaction enforcement requires an Enterprise license with the data redaction feature. For details on what redaction covers, revealing data, and permissions, refer to [Execution data redaction](/workflows/executions/execution-data-redaction.md).
+
 ## Configure security policy with environment variables
 
 You can also manage security policy settings from environment variables instead of through the UI. Available from n8n v2.18.0. Set `N8N_SECURITY_POLICY_MANAGED_BY_ENV` to `true` and provide the variables below. See [Manage instance settings using environment variables](/hosting/configuration/settings-env-vars.md) for how the activation pattern works.

--- a/docs/security-settings.md
+++ b/docs/security-settings.md
@@ -91,7 +91,7 @@ To enforce data redaction:
 When you enable enforcement:
 
 - n8n redacts execution data for all workflows within the selected scope, including workflows that don't have redaction enabled in their own settings.
-- Workflow-level redaction settings can't be set weaker than the enforced scope. Workflows can still opt into stricter redaction, for example redacting manual executions when only production enforcement is active.
+- Users can't set workflow-level redaction settings weaker than the enforced scope. Workflows can still opt into stricter redaction, for example redacting manual executions when only production enforcement is active.
 - New workflows start with the enforced scope as their redaction policy.
 
 Redaction enforcement requires an Enterprise license with the data redaction feature. For details on what redaction covers, revealing data, and permissions, refer to [Execution data redaction](/workflows/executions/execution-data-redaction.md).

--- a/docs/workflows/executions/execution-data-redaction.md
+++ b/docs/workflows/executions/execution-data-redaction.md
@@ -42,7 +42,7 @@ To configure redaction:
 6. Select **Save**.
 
 /// note | Settings locked by instance enforcement
-When [instance-level enforcement](#instance-level-enforcement) is active, the settings covered by the enforced scope are locked to **Redact** and can't be turned off at the workflow level.
+When [instance-level enforcement](#instance-level-enforcement) is active, n8n locks the settings covered by the enforced scope to **Redact**. You can't turn them off at the workflow level.
 ///
 
 ### Redaction settings explained
@@ -74,7 +74,7 @@ The enforcement scope controls which executions n8n redacts across the instance:
 - **Enforcement applies when execution data is read.** n8n redacts data covered by the enforcement scope whenever anyone views an execution, including executions from workflows that don't have redaction enabled in their own settings.
 - **Workflow settings can't be weaker than the enforced scope.** The workflow settings UI locks the affected redaction toggles, and the [public API](/api/index.md) rejects attempts to create or update a workflow with a redaction policy below the floor. Workflows can still opt into stricter redaction than the floor.
 - **New workflows start at the floor.** When you create a workflow while enforcement is active, its redaction policy defaults to the enforced scope. If you create a workflow through the public API without specifying a redaction policy, n8n sets it to the floor.
-- **Existing workflow settings aren't rewritten.** Enabling enforcement doesn't modify the stored settings of existing workflows. Their execution data is still redacted at the enforced scope, and if you later disable enforcement, each workflow returns to its own settings.
+- **Existing workflow settings stay as they are.** Enabling enforcement doesn't change the stored settings of existing workflows. Their execution data is still redacted at the enforced scope, and if you later disable enforcement, each workflow returns to its own settings.
 
 ## What gets redacted
 
@@ -82,7 +82,7 @@ When n8n redacts an execution, it redacts:
 
 - **Item JSON data**: n8n replaces all input and output data (`item.json`) for each node with an empty object.
 - **Binary data**: n8n removes binary data (`item.binary`) such as files and images.
-- **Declared sensitive fields**: fields that node authors mark as sensitive (using `sensitiveOutputFields`) are always redacted and can't be revealed, even by users with reveal access.
+- **Declared sensitive fields**: n8n always redacts fields that node authors mark as sensitive (using `sensitiveOutputFields`) and prevents revealing them, even for users with reveal access.
 - **Error metadata**: n8n redacts error messages, preserving only the error type and HTTP status code (for API errors) to aid in troubleshooting.
 
 In the redacted execution:
@@ -111,7 +111,7 @@ To reveal data:
 The execution data becomes visible for that execution in the current session.
 
 /// note | Executions using dynamic credentials
-n8n denies reveal requests for executions that used dynamic credentials, regardless of the user's permissions or the redaction policy in effect. This prevents exposing credential material that was resolved at runtime.
+n8n denies reveal requests for executions that used dynamic credentials, regardless of the user's permissions or the redaction policy in effect. This prevents exposing credentials that the execution resolved at runtime.
 ///
 
 ## Audit logging
@@ -142,11 +142,11 @@ By default, instance owners, admins, and project admins have the permissions to 
 Redaction controls the visibility of execution data when users view executions. It's not a backend access control, and some data paths fall outside its scope. Keep these limitations in mind when evaluating redaction for compliance:
 
 - **Code node `console.log` output**: data that a Code node logs with `console.log` isn't redacted. In manual executions, the output appears in the editor's Logs panel. In production executions, the output goes to the server's standard output (stdout) and any logging infrastructure attached to it.
-- **Data flowing between nodes**: redaction doesn't restrict what downstream nodes receive. During an execution, data flows freely between nodes, so any node in the workflow can send execution data to external systems. Redaction controls what users see in the execution viewer, not what the workflow itself does with the data.
+- **Data flowing between nodes**: redaction doesn't restrict what downstream nodes receive. During an execution, data flows between nodes without restriction, so any node in the workflow can send execution data to external systems. Redaction controls what users see in the execution viewer, not what the workflow itself does with the data.
 - **Webhook responses**: the response body that a workflow returns to a caller (for example, through the Respond to Webhook node or a node's respond option) is the raw data, not a redacted version.
 - **Authentication headers in outbound requests**: redaction doesn't alter the requests workflows make to external services, including any authentication headers they contain.
 - **No field-level redaction**: redaction applies to a node's entire data payload. You can't configure redaction for individual fields within the data. The exception is fields that node authors declare as sensitive, which n8n always redacts.
-- **Stored data is unchanged**: redaction doesn't encrypt or modify execution data in the database. n8n applies redaction when the data is read through the API. Anyone with direct database access can read the underlying data.
+- **Stored data stays as it is**: redaction doesn't encrypt or change execution data in the database. n8n applies redaction when serving the data through the API. Anyone with direct database access can read the underlying data.
 - **Enforcement doesn't propagate through source control**: instance-level enforcement is an instance policy and isn't included when you push workflows with [source control](/source-control-environments/index.md). A workflow pushed from an enforced instance to a non-enforced instance isn't redacted on the target instance. This matches the behavior of other instance-level policies, such as two-factor authentication enforcement.
 
 ## Best practices

--- a/docs/workflows/executions/execution-data-redaction.md
+++ b/docs/workflows/executions/execution-data-redaction.md
@@ -9,12 +9,14 @@ contentType: howto
 /// info | Feature availability
 Data redaction is available on Enterprise Self-hosted and Enterprise Cloud plans.
 
-**Available from:** n8n version 2.16.0
+**Available from:** n8n version 2.16.0 (per-workflow redaction), n8n version 2.26.0 (instance-level enforcement)
 ///
 
 Execution data redaction lets you hide the input and output data of workflow executions. This helps protect sensitive information like personal data, authentication tokens, and financial records from users who can view the workflow but don't need to see the underlying data.
 
 When you enable redaction, execution metadata (status, timing, node names) remains visible, but n8n replaces the actual data payload processed by each node with a redacted indicator.
+
+You can configure redaction per workflow, or [enforce it instance-wide](#instance-level-enforcement) so that every workflow redacts execution data.
 
 ## Why use execution data redaction
 
@@ -39,6 +41,10 @@ To configure redaction:
 5. For each setting, choose either **Default - Do not redact** or **Redact**.
 6. Select **Save**.
 
+/// note | Settings locked by instance enforcement
+When [instance-level enforcement](#instance-level-enforcement) is active, the settings covered by the enforced scope are locked to **Redact** and can't be turned off at the workflow level.
+///
+
 ### Redaction settings explained
 
 There are two independent toggles that control redaction:
@@ -48,13 +54,39 @@ There are two independent toggles that control redaction:
 | **Redact production execution data** | Controls whether n8n redacts data from production (non-manually triggered) executions. Production executions include those triggered by webhooks, schedules, or other triggers when the workflow stays active. |
 | **Redact manual execution data** | Controls whether n8n redacts data from manually triggered executions. Manual executions include those you start by selecting **Execute Workflow** in the editor. |
 
-## What redacted data looks like
+## Instance-level enforcement
 
-When n8n redacts an execution:
+Instance owners and admins can enforce redaction for all workflows on the instance instead of relying on each workflow's individual settings. Enforcement sets a minimum redaction policy (a "floor") that applies everywhere.
 
-- n8n replaces all input and output data for each node with an empty object.
-- n8n removes binary data (files, images).
-- n8n redacts error messages, preserving only the error type and HTTP status code (for API errors) to aid in troubleshooting.
+To enable enforcement, navigate to **Settings** > **Security** and configure the **Data redaction** section. Refer to [Security settings](/security-settings.md#enforce-execution-data-redaction) for the step-by-step instructions.
+
+### Enforcement scope
+
+The enforcement scope controls which executions n8n redacts across the instance:
+
+| Scope | What it enforces |
+| ----- | ---------------- |
+| **Production executions** | n8n redacts data from production executions in every workflow. Manual executions follow each workflow's own settings. This is the recommended setting: it protects live data while keeping manual test runs visible for debugging. |
+| **Manual and production executions** | n8n redacts data from all executions in every workflow. Use this when even test data is sensitive. |
+
+### How enforcement interacts with workflow settings
+
+- **Enforcement applies when execution data is read.** n8n redacts data covered by the enforcement scope whenever anyone views an execution, including executions from workflows that don't have redaction enabled in their own settings.
+- **Workflow settings can't be weaker than the enforced scope.** The workflow settings UI locks the affected redaction toggles, and the [public API](/api/index.md) rejects attempts to create or update a workflow with a redaction policy below the floor. Workflows can still opt into stricter redaction than the floor.
+- **New workflows start at the floor.** When you create a workflow while enforcement is active, its redaction policy defaults to the enforced scope. If you create a workflow through the public API without specifying a redaction policy, n8n sets it to the floor.
+- **Existing workflow settings aren't rewritten.** Enabling enforcement doesn't modify the stored settings of existing workflows. Their execution data is still redacted at the enforced scope, and if you later disable enforcement, each workflow returns to its own settings.
+
+## What gets redacted
+
+When n8n redacts an execution, it redacts:
+
+- **Item JSON data**: n8n replaces all input and output data (`item.json`) for each node with an empty object.
+- **Binary data**: n8n removes binary data (`item.binary`) such as files and images.
+- **Declared sensitive fields**: fields that node authors mark as sensitive (using `sensitiveOutputFields`) are always redacted and can't be revealed, even by users with reveal access.
+- **Error metadata**: n8n redacts error messages, preserving only the error type and HTTP status code (for API errors) to aid in troubleshooting.
+
+In the redacted execution:
+
 - The execution viewer displays a **"Data redacted"** indicator with a shredder icon instead of the usual data tables.
 - Execution metadata remains visible: node names, execution status (success/failure), timing information, and the workflow structure.
 
@@ -78,14 +110,19 @@ To reveal data:
 
 The execution data becomes visible for that execution in the current session.
 
-### Audit logging
+/// note | Executions using dynamic credentials
+n8n denies reveal requests for executions that used dynamic credentials, regardless of the user's permissions or the redaction policy in effect. This prevents exposing credential material that was resolved at runtime.
+///
 
-[Log streaming](/log-streaming.md) tracks all reveal actions. Two audit events are available:
+## Audit logging
+
+[Log streaming](/log-streaming.md) tracks reveal actions and enforcement policy changes. The following audit events are available:
 
 | Event | Description |
 | ----- | ----------- |
 | `n8n.audit.execution.data.revealed` | n8n emits this event when a user reveals redacted execution data. Includes the user, execution ID, workflow ID, timestamp, IP address, and the redaction policy in effect. |
 | `n8n.audit.execution.data.reveal_failure` | n8n emits this event when it denies a reveal attempt (for example, due to insufficient permissions). Includes the same fields plus the rejection reason. |
+| `n8n.audit.redaction-enforcement.updated` | n8n emits this event when a user changes the instance-level enforcement policy. Includes the user and the policy values before and after the change. |
 
 These events integrate with your existing log streaming destinations (syslog, webhooks, Sentry) and support compliance reporting and access auditing.
 
@@ -99,6 +136,18 @@ Execution data redaction introduces the following permission scopes that you can
 | `workflow:disableRedaction` | Allows turning redaction off in workflow settings. Displayed as **Disable data redaction** in the role configuration UI. |
 
 By default, instance owners, admins, and project admins have the permissions to enable or disable redaction and to reveal redacted data. You can create custom roles to give more users, such as workflow builders, one or both scopes independently.
+
+## What redaction doesn't cover
+
+Redaction controls the visibility of execution data when users view executions. It's not a backend access control, and some data paths fall outside its scope. Keep these limitations in mind when evaluating redaction for compliance:
+
+- **Code node `console.log` output**: data that a Code node logs with `console.log` isn't redacted. In manual executions, the output appears in the editor's Logs panel. In production executions, the output goes to the server's standard output (stdout) and any logging infrastructure attached to it.
+- **Data flowing between nodes**: redaction doesn't restrict what downstream nodes receive. During an execution, data flows freely between nodes, so any node in the workflow can send execution data to external systems. Redaction controls what users see in the execution viewer, not what the workflow itself does with the data.
+- **Webhook responses**: the response body that a workflow returns to a caller (for example, through the Respond to Webhook node or a node's respond option) is the raw data, not a redacted version.
+- **Authentication headers in outbound requests**: redaction doesn't alter the requests workflows make to external services, including any authentication headers they contain.
+- **No field-level redaction**: redaction applies to a node's entire data payload. You can't configure redaction for individual fields within the data. The exception is fields that node authors declare as sensitive, which n8n always redacts.
+- **Stored data is unchanged**: redaction doesn't encrypt or modify execution data in the database. n8n applies redaction when the data is read through the API. Anyone with direct database access can read the underlying data.
+- **Enforcement doesn't propagate through source control**: instance-level enforcement is an instance policy and isn't included when you push workflows with [source control](/source-control-environments/index.md). A workflow pushed from an enforced instance to a non-enforced instance isn't redacted on the target instance. This matches the behavior of other instance-level policies, such as two-factor authentication enforcement.
 
 ## Best practices
 
@@ -122,5 +171,4 @@ By default, instance owners, admins, and project admins have the permissions to 
 - n8n applies redaction at the API level and never sends redacted data to the browser.
 - When you [create custom nodes](/integrations/creating-nodes/overview.md), you can declare specific output fields as sensitive (using `sensitiveOutputFields` in the node type definition). n8n always redacts these fields and prevents revealing them, even for users with reveal access.
 - If the redaction service can't resolve a node's type definition (for example, after uninstalling a community node), n8n fully redacts all output data for that node. This fail-closed approach prevents unknown nodes from leaking sensitive fields.
-- Redaction doesn't change how execution data is stored in the database. The underlying data isn't encrypted or stored differently when redaction is enabled. Redaction controls visibility at the API layer.
 - When redaction is enabled, execution data is also automatically redacted from [log streaming](/log-streaming.md) and logging output.

--- a/docs/workflows/settings.md
+++ b/docs/workflows/settings.md
@@ -80,6 +80,8 @@ Controls whether n8n redacts execution data from production (non-manually trigge
 
 Controls whether n8n redacts execution data from manually triggered executions. When set to **Redact**, n8n hides the input and output data of each node and replaces it with a redacted indicator.
 
+If your instance admin [enforces data redaction instance-wide](/workflows/executions/execution-data-redaction.md#instance-level-enforcement), the settings covered by the enforced scope are locked to **Redact** and can't be turned off here.
+
 Refer to [Execution data redaction](/workflows/executions/execution-data-redaction.md) for details on redaction policies, revealing data, and permission requirements.
 
 ### Estimated time saved

--- a/docs/workflows/settings.md
+++ b/docs/workflows/settings.md
@@ -80,7 +80,7 @@ Controls whether n8n redacts execution data from production (non-manually trigge
 
 Controls whether n8n redacts execution data from manually triggered executions. When set to **Redact**, n8n hides the input and output data of each node and replaces it with a redacted indicator.
 
-If your instance admin [enforces data redaction instance-wide](/workflows/executions/execution-data-redaction.md#instance-level-enforcement), the settings covered by the enforced scope are locked to **Redact** and can't be turned off here.
+If your instance admin [enforces data redaction instance-wide](/workflows/executions/execution-data-redaction.md#instance-level-enforcement), n8n locks the settings covered by the enforced scope to **Redact**. You can't turn them off here.
 
 Refer to [Execution data redaction](/workflows/executions/execution-data-redaction.md) for details on redaction policies, revealing data, and permission requirements.
 

--- a/styles/config/vocabularies/default/accept.txt
+++ b/styles/config/vocabularies/default/accept.txt
@@ -232,6 +232,7 @@ Spotify
 spreadsheetId
 Stackby
 Stackshare
+stdout
 Storyblok
 Strapi
 Strava


### PR DESCRIPTION
## Summary

Updates the execution data redaction docs to cover instance-level enforcement and explicitly document what is and isn't redacted.

closes https://linear.app/n8n/issue/ENT-25/update-public-docs-for-redaction-enforcement

## Changes

### `docs/workflows/executions/execution-data-redaction.md`
- Split availability note: per-workflow redaction (2.16.0) vs instance enforcement (2.26.0)
- New **Instance-level enforcement** section: scope options (production recommended), floor semantics (read-time enforcement, API rejects below-floor policies, new workflows seeded to floor, existing settings not rewritten)
- New **What gets redacted** section: `item.json`, `item.binary`, declared sensitive fields, error metadata
- New **What redaction doesn't cover** section: Code node `console.log`, data flow between nodes, webhook responses, outbound auth headers, no field-level redaction, stored data unchanged, source-control non-propagation
- Note: reveal denied for executions using dynamic credentials
- Audit logging promoted to page-level section; added `n8n.audit.redaction-enforcement.updated` event

### `docs/security-settings.md`
- New **Enforce execution data redaction** section with UI steps (matches the **Data redaction** section in **Settings** > **Security**)

### `docs/workflows/settings.md`
- Note that instance enforcement locks the per-workflow redaction settings

## Context

- Linear: ENT-25, IAM-433 (Security settings UI), IAM-622 (audit event), IAM-428 (settings lock)
- All UI labels, policy values, validation behavior, audit event name, and license gating verified against the n8n source.
- Ticket mentions enabling enforcement via public API; the endpoint is internal REST only and isn't in `openapi.yml`, so only the UI path is documented.
- Enforcement is still behind the `N8N_ENV_FEAT_REDACTION_ENFORCEMENT` flag (ENT-30); the flag is intentionally not documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)