### PR TITLE
Change GitHub token to use secrets

### DIFF
--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: dessant/support-requests@47d5ea12f6c9e4a081637de9626b7319b415a3bf
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }} en
           support-label: 'issue:support'
           issue-comment: >
             :wave: @{issue-author}. Sorry you are having a problem!


### PR DESCRIPTION
Updated GitHub token usage in support workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the support workflow to use `secrets.GITHUB_TOKEN` instead of `github.token`. This standardizes token usage and follows GitHub Actions security best practices.

<sup>Written for commit 3d4d881af3d33ee9bbb6055db9ae9a4f7c1a3907. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

