### PR TITLE
docs: document Schema Registry credentials for Kafka (ENT-11)

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.kafka.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.kafka.md
@@ -25,7 +25,7 @@ To encode messages with an authenticated Confluent Schema Registry (for example,
 
 - Send message
 
-## Templates and examples
+### Templates and examples
 
 <!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->
 [[ templatesWidget(page.title, 'kafka') ]]

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.kafka.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.kafka.md
@@ -25,7 +25,7 @@ To encode messages with an authenticated Confluent Schema Registry (for example,
 
 - Send message
 
-### Templates and examples
+## Templates and examples
 
 <!-- see https://www.notion.so/n8n/Pull-in-templates-for-the-integrations-pages-37c716837b804d30a33b47475f6e3780 -->
 [[ templatesWidget(page.title, 'kafka') ]]

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.kafka.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.kafka.md
@@ -15,6 +15,10 @@ On this page, you'll find a list of operations the Kafka node supports and links
 Refer to [Kafka credentials](/integrations/builtin/credentials/kafka.md) for guidance on setting up authentication. 
 ///
 
+/// note | Schema Registry
+To encode messages with an authenticated Confluent Schema Registry (for example, Confluent Cloud), enable **Use Schema Registry** in the node and add a [Schema Registry credential](/integrations/builtin/credentials/schemaregistry.md).
+///
+
 --8<-- "_snippets/integrations/builtin/app-nodes/ai-tools.md"
 
 ## Operations

--- a/docs/integrations/builtin/credentials/kafka.md
+++ b/docs/integrations/builtin/credentials/kafka.md
@@ -12,6 +12,10 @@ You can use these credentials to authenticate the following nodes:
 - [Kafka](/integrations/builtin/app-nodes/n8n-nodes-base.kafka.md)
 - [Kafka Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.kafkatrigger.md)
 
+/// note | Schema Registry
+These credentials authenticate the Kafka brokers. To connect to an authenticated Confluent Schema Registry for Avro encoding and decoding, use the separate [Schema Registry credentials](/integrations/builtin/credentials/schemaregistry.md).
+///
+
 ## Supported authentication methods
 
 - Client ID

--- a/docs/integrations/builtin/credentials/schemaregistry.md
+++ b/docs/integrations/builtin/credentials/schemaregistry.md
@@ -12,12 +12,12 @@ You can use these credentials to authenticate the following nodes when you enabl
 - [Kafka](/integrations/builtin/app-nodes/n8n-nodes-base.kafka.md)
 - [Kafka Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.kafkatrigger.md)
 
-The Kafka node and Kafka Trigger use a Schema Registry to encode and decode Avro messages. This credential is separate from your [Kafka credentials](/integrations/builtin/credentials/kafka.md): the registry usually has its own endpoint and authentication, distinct from the Kafka brokers.
+The Kafka node and Kafka Trigger use a Schema Registry to encode and decode Avro messages. This credential is separate from your [Kafka credentials](/integrations/builtin/credentials/kafka.md): the registry has its own endpoint and authentication, distinct from the Kafka brokers.
 
 ## Supported authentication methods
 
 - None
-- Basic Auth (username and password) — for example, a Confluent Cloud Schema Registry API key and secret
+- Basic Auth (username and password), such as a Confluent Cloud Schema Registry API key and secret
 
 ## Related resources
 

--- a/docs/integrations/builtin/credentials/schemaregistry.md
+++ b/docs/integrations/builtin/credentials/schemaregistry.md
@@ -1,0 +1,38 @@
+---
+title: Schema Registry credentials
+description: Documentation for Schema Registry credentials. Use these credentials to authenticate Schema Registry in n8n, a workflow automation platform.
+contentType: [integration, reference]
+priority: medium
+---
+
+# Schema Registry credentials
+
+You can use these credentials to authenticate the following nodes when you enable **Use Schema Registry**:
+
+- [Kafka](/integrations/builtin/app-nodes/n8n-nodes-base.kafka.md)
+- [Kafka Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.kafkatrigger.md)
+
+The Kafka node and Kafka Trigger use a Schema Registry to encode and decode Avro messages. This credential is separate from your [Kafka credentials](/integrations/builtin/credentials/kafka.md): the registry usually has its own endpoint and authentication, distinct from the Kafka brokers.
+
+## Supported authentication methods
+
+- None
+- Basic Auth (username and password) — for example, a Confluent Cloud Schema Registry API key and secret
+
+## Related resources
+
+Refer to the [Confluent Schema Registry documentation](https://docs.confluent.io/platform/current/schema-registry/index.html) for more information about using the service.
+
+## Setting up the credential
+
+To configure this credential, you'll need the URL of your Schema Registry and, if it requires authentication, the details to access it.
+
+1. In the **URL** field, enter the base URL of your Schema Registry, for example `https://psrc-xxxxx.region.aws.confluent.cloud`.
+2. Select the **Authentication** method:
+    - **None**: use this for a Schema Registry that doesn't require authentication.
+    - **Basic Auth**: use this for a Schema Registry that requires HTTP Basic Auth, such as Confluent Cloud. Then add:
+        1. The **Username**. For Confluent Cloud, this is the Schema Registry API key.
+        2. The **Password**. For Confluent Cloud, this is the Schema Registry API secret.
+3. Select **Save**. n8n tests the credential by calling the registry's `/subjects` endpoint.
+
+To use the credential, open your Kafka or Kafka Trigger node, enable **Use Schema Registry**, and select this credential.

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.kafkatrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.kafkatrigger.md
@@ -13,6 +13,10 @@ priority: medium
 You can find authentication information for this node [here](/integrations/builtin/credentials/kafka.md).
 ///
 
+/// note | Schema Registry
+To decode messages with an authenticated Confluent Schema Registry (for example, Confluent Cloud), enable **Use Schema Registry** in the node and add a [Schema Registry credential](/integrations/builtin/credentials/schemaregistry.md).
+///
+
 /// note | Examples and templates
 For usage examples and templates to help you get started, refer to n8n's [Kafka Trigger integrations](https://n8n.io/integrations/kafka-trigger/) page.
 ///

--- a/nav.yml
+++ b/nav.yml
@@ -1088,6 +1088,7 @@ nav:
         - integrations/builtin/credentials/s3.md
         - integrations/builtin/credentials/salesforce.md
         - integrations/builtin/credentials/salesmate.md
+        - integrations/builtin/credentials/schemaregistry.md
         - integrations/builtin/credentials/searxng.md
         - integrations/builtin/credentials/seatable.md
         - integrations/builtin/credentials/securityscorecard.md

--- a/styles/config/vocabularies/default/accept.txt
+++ b/styles/config/vocabularies/default/accept.txt
@@ -17,6 +17,7 @@ Authentik
 [Aa]uto-fixing
 Automizy
 [Aa]utorenew
+Avro
 Axios
 Backblaze
 [Bb]ackend


### PR DESCRIPTION
## Summary

Documents the new **Schema Registry** credential added for the Kafka node and Kafka Trigger in ENT-11 (code PR n8n-io/n8n#32026).

- **New page** `credentials/schemaregistry.md` — the credential's `documentationUrl: 'schemaregistry'` had no page, so the credential-modal docs link 404'd. This adds it: URL + `None`/`Basic Auth` setup, Confluent Cloud example, and the `/subjects` credential test.
- Registers the page in `nav.yml` (alphabetical).
- Cross-links it from the Kafka credentials, Kafka node, and Kafka Trigger pages via note callouts (enable **Use Schema Registry** and select the credential).

## Related

- Code PR: n8n-io/n8n#32026
- Linear: https://linear.app/n8n/issue/ENT-11

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs for the new Schema Registry credential used by the Kafka node and Kafka Trigger, enabling authenticated Confluent Schema Registry setups (ENT-11). Fixes the credential modal 404 and addresses Vale findings (adds “Avro” to accepted terms).

- **New Features**
  - Added `docs/integrations/builtin/credentials/schemaregistry.md` with setup (URL, None/Basic Auth), Confluent Cloud example, and `/subjects` test.
  - Linked from the Kafka node, Kafka Trigger, and Kafka credentials pages via note callouts.
  - Registered the page in `nav.yml`.

<sup>Written for commit 4c623664590822822a4950546d0de1c275a3731e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

