### PR TITLE
docs: document $evaluateExpression not working in Code node under secure-mode task runners

### DIFF
--- a/docs/2-0-breaking-changes.md
+++ b/docs/2-0-breaking-changes.md
@@ -79,6 +79,18 @@ n8n will enable [task runners](/hosting/configuration/task-runners.md) by defaul
 
 **Migration path:** Before upgrading to v2.0, set N8N_RUNNERS_ENABLED=true to test this behavior. Make sure your infrastructure meets the requirements for running task runners. For additional security, consider using [external mode](/hosting/configuration/task-runners.md#external-mode).
 
+### `$evaluateExpression` no longer works in the Code node
+
+Because Code node executions now run on task runners in secure mode by default, the `$evaluateExpression()` convenience method no longer works inside the Code node. Secure mode disables evaluating strings as code, which is the mechanism expressions rely on, so `$evaluateExpression()` calls in a Code node return `null` or error. Expressions in regular node fields, such as the Edit Fields (Set) node, aren't affected.
+
+**Migration path:** Move the expression evaluation out of the Code node, in order of preference:
+
+- Write the logic directly in JavaScript instead of calling `$evaluateExpression()`.
+- Evaluate the expression in an Edit Fields (Set) node before the Code node, then read the result from the incoming item.
+- If you have no other option, set `N8N_RUNNERS_INSECURE_MODE=true` to re-enable the disabled JavaScript features. This turns off the task runner's security measures and is discouraged for production use.
+
+`$evaluateExpression()` in the Code node may be removed entirely in a future version, so treat `N8N_RUNNERS_INSECURE_MODE=true` as a temporary workaround rather than a permanent solution.
+
 ### Remove task runner from `n8nio/n8n` docker image
 
 Starting with v2.0, the main `n8nio/n8n` Docker image will no longer include the task runner for external mode. You must use the separate `n8nio/runners` Docker image to run task runners in external mode.


### PR DESCRIPTION
## Summary

Documents that `$evaluateExpression()` no longer works inside the **Code node** in n8n v2.

Since v2.0, Code node executions run on task runners in **secure mode by default**, which disables evaluating strings as code — the mechanism expressions rely on. So `$evaluateExpression()` calls inside a Code node return `null` or error. This has been the case for the entire v2 lifetime. Expressions in regular node fields (e.g. Edit Fields (Set)) are unaffected.

This adds a subsection under **Security → "Enable task runners by default"** in the v2.0 breaking changes page (the spot the release notes link to for migration guidance), covering:

- **Why** it happens (secure-mode task runners disable dynamic code evaluation).
- **Migration paths**, in order of preference: write JS directly → evaluate in an Edit Fields (Set) node before the Code node → `N8N_RUNNERS_INSECURE_MODE=true` as a last resort (discouraged for production).
- A note that the method **may be removed entirely in a future version**, so insecure mode shouldn't be treated as a permanent solution.

## Related

- GitHub issue: https://github.com/n8n-io/n8n/issues/24307
- Linear: https://linear.app/n8n/issue/CAT-3208
- Context: the convenience-methods docs were inadvertently removed in #4077; this restores the relevant guidance in the breaking-changes page.

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document that `$evaluateExpression()` no longer works in the Code node in v2 because task runners run in secure mode by default. Adds migration steps; expressions in regular node fields still work. Linear CAT-3208.

- **Migration**
  - Write the logic directly in JavaScript instead of calling `$evaluateExpression()`.
  - Evaluate the expression in an Edit Fields (Set) node before the Code node, then read the result.
  - If you have no other option, set `N8N_RUNNERS_INSECURE_MODE=true` temporarily; not for production, and `$evaluateExpression()` in the Code node may be removed in a future release.

<sup>Written for commit b991617d90ca054bab422d1c6f44036373950c2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

