### PR TITLE
docs: Document generic Microsoft credential option for Excel and OneDrive nodes

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftexcel.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftexcel.md
@@ -14,8 +14,8 @@ On this page, you'll find a list of operations the Microsoft Excel node supports
 /// note | Credentials
 This node supports two authentication options:
 
-- **Excel OAuth2**: the Microsoft Excel-specific OAuth2 credential (default).
-- **Microsoft OAuth2 (Graph)**: a generic Microsoft Graph credential that you can reuse across other Microsoft nodes. When you select this option, make sure the credential is granted the scopes this node needs (for example, `Files.ReadWrite`, or `Files.ReadWrite.All` if that's the permission your administrator has consented).
+- **Microsoft Excel OAuth2 API**: the Microsoft Excel-specific OAuth2 credential (default).
+- **Microsoft OAuth2 API**: a generic Microsoft Graph credential that you can reuse across other Microsoft nodes. When you select this option, make sure the credential is granted the scopes this node needs (for example, `Files.ReadWrite`, or `Files.ReadWrite.All` if that's the permission your administrator has consented).
 
 Refer to [Microsoft credentials](/integrations/builtin/credentials/microsoft.md) for guidance on setting up authentication.
 ///

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftexcel.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftexcel.md
@@ -17,8 +17,6 @@ This node supports two authentication options:
 - **Excel OAuth2**: the Microsoft Excel-specific OAuth2 credential (default).
 - **Microsoft OAuth2 (Graph)**: a generic Microsoft Graph credential that you can reuse across other Microsoft nodes. When you select this option, make sure the credential is granted the scopes this node needs (for example, `Files.ReadWrite`, or `Files.ReadWrite.All` if that's the permission your administrator has consented).
 
-Existing workflows are unaffected: the node defaults to **Excel OAuth2**.
-
 Refer to [Microsoft credentials](/integrations/builtin/credentials/microsoft.md) for guidance on setting up authentication.
 ///
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftexcel.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftexcel.md
@@ -12,6 +12,13 @@ Use the Microsoft Excel node to automate work in Microsoft Excel, and integrate 
 On this page, you'll find a list of operations the Microsoft Excel node supports and links to more resources.
 
 /// note | Credentials
+This node supports two authentication options:
+
+- **Excel OAuth2**: the Microsoft Excel-specific OAuth2 credential (default).
+- **Microsoft OAuth2 (Graph)**: a generic Microsoft Graph credential that you can reuse across other Microsoft nodes. When you select this option, make sure the credential is granted the scopes this node needs (for example, `Files.ReadWrite`, or `Files.ReadWrite.All` if that's the permission your administrator has consented).
+
+Existing workflows are unaffected: the node defaults to **Excel OAuth2**.
+
 Refer to [Microsoft credentials](/integrations/builtin/credentials/microsoft.md) for guidance on setting up authentication.
 ///
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftonedrive.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftonedrive.md
@@ -12,6 +12,13 @@ Use the Microsoft OneDrive node to automate work in Microsoft OneDrive, and inte
 On this page, you'll find a list of operations the Microsoft OneDrive node supports and links to more resources.
 
 /// note | Credentials
+This node supports two authentication options:
+
+- **OneDrive OAuth2**: the Microsoft OneDrive-specific OAuth2 credential (default).
+- **Microsoft OAuth2 (Graph)**: a generic Microsoft Graph credential that you can reuse across other Microsoft nodes. When you select this option, make sure the credential is granted the scopes this node needs (for example, `Files.ReadWrite.All`).
+
+Existing workflows are unaffected: the node defaults to **OneDrive OAuth2**.
+
 Refer to [Microsoft credentials](/integrations/builtin/credentials/microsoft.md) for guidance on setting up authentication.
 ///
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftonedrive.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftonedrive.md
@@ -17,8 +17,6 @@ This node supports two authentication options:
 - **OneDrive OAuth2**: the Microsoft OneDrive-specific OAuth2 credential (default).
 - **Microsoft OAuth2 (Graph)**: a generic Microsoft Graph credential that you can reuse across other Microsoft nodes. When you select this option, make sure the credential is granted the scopes this node needs (for example, `Files.ReadWrite.All`).
 
-Existing workflows are unaffected: the node defaults to **OneDrive OAuth2**.
-
 Refer to [Microsoft credentials](/integrations/builtin/credentials/microsoft.md) for guidance on setting up authentication.
 ///
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftonedrive.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftonedrive.md
@@ -14,8 +14,8 @@ On this page, you'll find a list of operations the Microsoft OneDrive node suppo
 /// note | Credentials
 This node supports two authentication options:
 
-- **OneDrive OAuth2**: the Microsoft OneDrive-specific OAuth2 credential (default).
-- **Microsoft OAuth2 (Graph)**: a generic Microsoft Graph credential that you can reuse across other Microsoft nodes. When you select this option, make sure the credential is granted the scopes this node needs (for example, `Files.ReadWrite.All`).
+- **Microsoft Drive OAuth2 API**: the Microsoft OneDrive-specific OAuth2 credential (default).
+- **Microsoft OAuth2 API**: a generic Microsoft Graph credential that you can reuse across other Microsoft nodes. When you select this option, make sure the credential is granted the scopes this node needs (for example, `Files.ReadWrite.All`).
 
 Refer to [Microsoft credentials](/integrations/builtin/credentials/microsoft.md) for guidance on setting up authentication.
 ///

--- a/docs/integrations/builtin/credentials/microsoft.md
+++ b/docs/integrations/builtin/credentials/microsoft.md
@@ -20,7 +20,7 @@ You can use these credentials to authenticate the following nodes:
 - [Microsoft To Do](/integrations/builtin/app-nodes/n8n-nodes-base.microsofttodo.md)
 
 /// note | Choosing a credential type
-Some nodes (such as Microsoft Excel and Microsoft OneDrive) provide an **Authentication** dropdown that lets you choose between the node-specific credential (for example, **Excel OAuth2**) and this generic **Microsoft OAuth2 (Graph)** credential. The generic credential can be reused across multiple Microsoft nodes; when you use it, make sure it's granted the scopes each node needs. Nodes that don't show this dropdown use their node-specific credential.
+Some nodes (such as Microsoft Excel and Microsoft OneDrive) let you choose between the node-specific credential (for example, **Microsoft Excel OAuth2 API**) and this generic **Microsoft OAuth2 API** credential. The generic credential can be reused across multiple Microsoft nodes; when you use it, make sure it's granted the scopes each node needs. Nodes that don't show this dropdown use their node-specific credential.
 ///
 
 ## Prerequisites

--- a/docs/integrations/builtin/credentials/microsoft.md
+++ b/docs/integrations/builtin/credentials/microsoft.md
@@ -19,6 +19,10 @@ You can use these credentials to authenticate the following nodes:
 - [Microsoft Teams Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftteamstrigger.md)
 - [Microsoft To Do](/integrations/builtin/app-nodes/n8n-nodes-base.microsofttodo.md)
 
+/// note | Choosing a credential type
+Some nodes (such as Microsoft Excel and Microsoft OneDrive) provide an **Authentication** dropdown that lets you choose between the node-specific credential (for example, **Excel OAuth2**) and this generic **Microsoft OAuth2 (Graph)** credential. The generic credential can be reused across multiple Microsoft nodes; when you use it, make sure it's granted the scopes each node needs. Nodes that don't show this dropdown use their node-specific credential.
+///
+
 ## Prerequisites
 
 - Create a [Microsoft Azure](https://azure.microsoft.com/) account.


### PR DESCRIPTION
## Summary

The Microsoft Excel and Microsoft OneDrive nodes expose an **Authentication** dropdown that lets users choose between the node-specific OAuth2 credential and the generic **Microsoft OAuth2 (Graph)** credential. This documents that choice:

- **Excel** and **OneDrive** node pages: explain the two authentication options, note the default (so existing workflows are unaffected), and mention the scopes the generic credential needs.
- **Microsoft credentials** page: add a note explaining that some nodes provide the Authentication selector and that the generic credential is reusable across Microsoft nodes.

## Related

- Code PR: n8n-io/n8n#32434 (Excel)
- https://linear.app/n8n/issue/ENT-56

🤖 PR Summary generated by AI