### PR TITLE
docs: Document generic Microsoft credential option for Outlook nodes

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftoutlook.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftoutlook.md
@@ -12,6 +12,11 @@ Use the Microsoft Outlook node to automate work in Microsoft Outlook, and integr
 On this page, you'll find a list of operations the Microsoft Outlook node supports and links to more resources.
 
 /// note | Credentials
+This node supports two authentication options:
+
+- **Microsoft Outlook OAuth2 API**: the Microsoft Outlook-specific OAuth2 credential (default).
+- **Microsoft OAuth2 API**: a generic Microsoft Graph credential that you can reuse across other Microsoft nodes. When you select this option, make sure the credential is granted the scopes this node needs (for example, `Mail.ReadWrite`, `Mail.Send`, `Calendars.ReadWrite`, and `Contacts.ReadWrite`).
+
 Refer to [Microsoft credentials](/integrations/builtin/credentials/microsoft.md) for guidance on setting up authentication.
 ///
 

--- a/docs/integrations/builtin/credentials/microsoft.md
+++ b/docs/integrations/builtin/credentials/microsoft.md
@@ -14,6 +14,7 @@ You can use these credentials to authenticate the following nodes:
 - [Microsoft Graph Security](/integrations/builtin/app-nodes/n8n-nodes-base.microsoftgraphsecurity.md)
 - [Microsoft OneDrive](/integrations/builtin/app-nodes/n8n-nodes-base.microsoftonedrive.md)
 - [Microsoft Outlook](/integrations/builtin/app-nodes/n8n-nodes-base.microsoftoutlook.md)
+- [Microsoft Outlook Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftoutlooktrigger.md)
 - [Microsoft SharePoint](/integrations/builtin/app-nodes/n8n-nodes-base.microsoftsharepoint.md)
 - [Microsoft Teams](/integrations/builtin/app-nodes/n8n-nodes-base.microsoftteams.md)
 - [Microsoft Teams Trigger](/integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftteamstrigger.md)

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftoutlooktrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.microsoftoutlooktrigger.md
@@ -12,6 +12,11 @@ Use the Microsoft Outlook Trigger node to respond to events in [Microsoft Outloo
 On this page, you'll find a list of events the Microsoft Outlook Trigger node can respond to, and links to more resources.
 
 ///  note  | Credentials
+This node supports two authentication options:
+
+- **Microsoft Outlook OAuth2 API**: the Microsoft Outlook-specific OAuth2 credential (default).
+- **Microsoft OAuth2 API**: a generic Microsoft Graph credential that you can reuse across other Microsoft nodes. When you select this option, make sure the credential is granted the scopes this node needs (for example, `Mail.ReadWrite`).
+
 You can find authentication information for this node [here](/integrations/builtin/credentials/microsoft.md).
 ///
 


### PR DESCRIPTION
## Summary

The Microsoft Outlook and Microsoft Outlook Trigger nodes now let users choose between the node-specific OAuth2 credential and the generic **Microsoft OAuth2 (Graph)** credential. This documents that choice, mirroring the Excel/OneDrive docs in n8n-io/n8n-docs#4827:

- **Microsoft Outlook** and **Microsoft Outlook Trigger** node pages: explain the two authentication options, note the default (so existing workflows are unaffected), and mention the scopes the generic credential needs.
- **Microsoft credentials** page: add the Microsoft Outlook Trigger to the supported-nodes list.

The generic "Choosing a credential type" note on the credentials page is owned by #4827 (Excel/OneDrive) and is intentionally not duplicated here.

## Related

- Code PR: n8n-io/n8n#32531 (Outlook)
- Sibling docs PR: n8n-io/n8n-docs#4827 (Excel/OneDrive)
- https://linear.app/n8n/issue/ENT-57

🤖 PR Summary generated by AI