### PR TITLE
fix: remove duplicate GA4 loader to stop page_view double-count

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,9 +51,12 @@ theme:
     # https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=navigation+tabs#anchor-tracking
     - navigation.tracking
 extra:
-  analytics:
-    provider: google
-    property: G-0SC4FF2FH9
+  # GA4 (G-0SC4FF2FH9) is loaded via GTM-K86VCV3 (see _overrides/main.html), which
+  # is the canonical tag manager across all n8n properties. Material's native
+  # `analytics` integration is intentionally NOT configured here: enabling it loads
+  # gtag.js a second time and fires its own `config`, which double-counts page_view
+  # on the consent-acceptance pageview (the duplicate-instance dedup misses the
+  # consent-grant re-fire). Keep GTM as the single GA4 loader.
   # https://squidfunk.github.io/mkdocs-material/reference/#setting-the-page-status
   status:
     beta: This feature is in beta


### PR DESCRIPTION
## Problem

`docs.n8n.io` loads the GA4 Google tag (`G-0SC4FF2FH9`) via **two** independent mechanisms:

1. **MkDocs Material native analytics** — the `extra.analytics` block in `mkdocs.yml`, which injects `gtag/js?id=G-0SC4FF2FH9` and fires its own `gtag("config", …)`.
2. **GTM-K86VCV3** — injected in `_overrides/main.html`; contains the "GA4 - Config + Pageview - G-0SC4FF2FH9" Google tag firing on Initialization.

The GA4 Google tag has *"Ignore duplicate instances of on-page configuration"* enabled, which correctly dedupes the two simultaneous configs on a normal page load. **But** Material's loader is consent-unaware and re-fires on the consent-grant transition: when a visitor accepts the cookie banner, a second `page_view` lands a few seconds later and escapes the dedup.

### Verified empirically (headless Chromium network capture)

| Scenario | `page_view` to `tid=G-0SC4FF2FH9` |
|---|---|
| Load, no banner interaction | **1** ✓ (3/3) |
| Load → Accept → stay on page | **2** ✗ (6/6) |
| Already-consented visitor, next page | **1** ✓ (2/2) |
| Control: n8n.io (single GTM loader) → Accept | **1** ✓ (3/3) |

The two surviving beacons on docs carry **different `gtm=` fingerprints**, confirming two distinct config sources rather than one re-send. The single-loader control (n8n.io) never doubles. Impact is bounded to the consent-acceptance pageview (not a blanket 2×), but it is a real, reproducible inflation of docs `page_view` counts.

## Fix

Remove Material's native `analytics` config from `mkdocs.yml`, leaving **GTM as the single canonical GA4 loader** — consistent with every other n8n property. GTM-K86VCV3 already carries the GA4 config tag plus 7 GA4 event tags for docs (link clicks, file downloads, outbound, `selfhost_signal`, Chat-With-Docs), so no pageview or event coverage is lost from GTM.

## ⚠️ Follow-up (not in this PR)

Material's native integration was also the **only** source of two GA4 events that GTM does not currently replicate:

- `search` — documentation search terms (~3,008/wk)
- `feedback` — "Was this page helpful?" votes (~197/wk)

These will stop reaching GA4 once this merges. If the docs/marketing team wants to keep them, they should be re-added as **GA4 event tags in GTM-K86VCV3** (the container already has the pattern). Flagging so this is a conscious decision, not a silent loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)