### PR TITLE
docs: document Stripe Trigger webhook signature verification (DOC-2020)

### DIFF
--- a/docs/integrations/builtin/credentials/stripe.md
+++ b/docs/integrations/builtin/credentials/stripe.md
@@ -27,7 +27,7 @@ You can use these credentials to authenticate the following nodes:
 
 - Secret key
 
-You'll also need a Stripe **Signature Secret** or endpoint secret, which is a unique key for each webhook endpoint used to verify incoming requests, ensuring they truly came from Stripe.
+n8n strongly recommends also setting a **Signature Secret** (sometimes called an endpoint secret), a unique key for each webhook endpoint. This allows the [Stripe Trigger](../trigger-nodes/n8n-nodes-base.stripetrigger.md) node to verify that incoming requests genuinely come from Stripe. For setup steps, refer to [Verify incoming requests](#verify-incoming-requests).
 
 ## Related resources <a href="#related-resources" id="related-resources"></a>
 
@@ -56,6 +56,20 @@ To use a Secret key in test mode, you must copy the existing one:
 3. Copy the key and enter it in your n8n credential as the **Secret Key**.
 
 Refer to Stripe's [Create a secret API key](https://docs.stripe.com/keys#create-api-secret-key) for more information.
+
+## Verify incoming requests <a href="#verify-incoming-requests" id="verify-incoming-requests"></a>
+
+From n8n version 2.25.7 and 2.26.2, the [Stripe Trigger](../trigger-nodes/n8n-nodes-base.stripetrigger.md) node can verify that incoming webhook requests genuinely come from Stripe. n8n strongly recommends setting a **Signature Secret** so others can't send forged events to your workflow, even if they know your webhook URL.
+
+n8n creates and manages the Stripe webhook endpoint for you when you activate a workflow, so you set the **Signature Secret** after the endpoint exists:
+
+1. Build your workflow with the **Stripe Trigger** node and activate it. n8n creates a webhook endpoint in your Stripe account.
+2. In the Stripe Dashboard, go to **Workbench** > **Webhooks**. In older dashboards, go to **Developers** > **Webhooks**.
+3. Select the endpoint n8n created. You can identify it by the description `Created by n8n for workflow ID: <workflow-id>` and by the webhook URL, which matches your n8n production webhook URL.
+4. Under **Signing secret**, select **Click to reveal** and copy the value. It starts with `whsec_`.
+5. In n8n, open your Stripe credential, paste the value into the **Signature Secret** field, and save.
+
+Stripe generates a unique signing secret for each endpoint, and a separate one for test mode and live mode. Copy the secret from the endpoint that matches the credential you're using. Refer to Stripe's [Webhooks documentation](https://docs.stripe.com/webhooks) for more information.
 
 ## Test mode and live mode <a href="#test-mode-and-live-mode" id="test-mode-and-live-mode"></a>
 

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.stripetrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.stripetrigger.md
@@ -28,6 +28,12 @@ layout:
 You can find authentication information for this node [here](../credentials/stripe.md).
 {% endhint %}
 
+## Webhook authentication <a href="#webhook-authentication" id="webhook-authentication"></a>
+
+From n8n version 2.25.7 and 2.26.2, the Stripe Trigger node can verify that incoming requests genuinely come from Stripe. When you set a **Signature Secret** on your [Stripe credential](../credentials/stripe.md), the node checks the `Stripe-Signature` header on each request and rejects any request that's unsigned, forged, or more than five minutes old with a `401 Unauthorized` response. n8n doesn't run your workflow for rejected requests.
+
+Without a **Signature Secret**, the node doesn't verify incoming requests, so anyone who knows your webhook URL could send forged events. n8n strongly recommends setting one. For setup steps, refer to [Verify incoming requests](../credentials/stripe.md#verify-incoming-requests).
+
 {% hint style="info" %}
 **Examples and templates**
 


### PR DESCRIPTION
## What

Documents the webhook signature verification added to the **Stripe Trigger** node.

- **Trigger page** ([n8n-nodes-base.stripetrigger.md](https://github.com/n8n-io/n8n-docs/blob/DOC-2020/stripe-trigger-webhook-validation/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.stripetrigger.md)) — new **Webhook authentication** section: the node verifies the `Stripe-Signature` header and returns `401` for unsigned, forged, or stale (>5 min) requests when a Signature Secret is set.
- **Credential page** ([stripe.md](https://github.com/n8n-io/n8n-docs/blob/DOC-2020/stripe-trigger-webhook-validation/docs/integrations/builtin/credentials/stripe.md)) — new **Verify incoming requests** section with steps to obtain the per-endpoint signing secret from the Stripe dashboard, plus reframing the existing Signature Secret mention as strongly recommended.

## Why

Security advisory `GHSA-jvc7-762p-3743` / `CVE-2026-54308` ("Missing Token Validation on Microsoft Agent 365 Trigger and Stripe Nodes") covers the Stripe Trigger as well as Microsoft Agent 365. The fix (n8n#22764) is **released and public in n8n 2.25.7 and 2.26.2**, but verification is **opt-in** — without a Signature Secret the node still accepts forged requests, so the setup steps matter.

This is the Stripe counterpart to #4749 (Microsoft Agent 365, DOC-1968).

## Notes

- Verified node behavior against the source (`StripeTrigger.node.ts`, `StripeTriggerHelpers.ts`): HMAC-SHA256 over `timestamp.rawBody`, 5-minute tolerance, timing-safe compare; secret read from the credential's `signatureSecret` field. n8n auto-creates and manages the Stripe webhook endpoint, so the secret must be copied from that endpoint after activation — reflected in the steps.
- Structure mirrors the Slack Trigger convention.
- Local `mkdocs build` passes; both pages render and the cross-links resolve.

Linear: DOC-2020
