### PR TITLE
Add Kafka Trigger message-compression limitation note

### DIFF
--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.kafkatrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.kafkatrigger.md
@@ -17,6 +17,10 @@ You can find authentication information for this node [here](/integrations/built
 To decode messages with an authenticated Confluent Schema Registry (for example, Confluent Cloud), enable **Use Schema Registry** in the node and add a [Schema Registry credential](/integrations/builtin/credentials/schemaregistry.md).
 ///
 
+/// warning | Message compression
+The Kafka Trigger can consume uncompressed messages and messages compressed with **GZIP**. It can't decode messages compressed with **LZ4**, **Snappy**, or **ZSTD** (a common default for Confluent and JVM producers): consuming such a topic fails with an unsupported-compression-format error. To consume the topic, configure the producer to use gzip or no compression.
+///
+
 /// note | Examples and templates
 For usage examples and templates to help you get started, refer to n8n's [Kafka Trigger integrations](https://n8n.io/integrations/kafka-trigger/) page.
 ///


### PR DESCRIPTION
## Summary

Documents that the Kafka Trigger only decodes **GZIP** and uncompressed messages. Topics compressed with **LZ4/Snappy/ZSTD** (a common Confluent/JVM producer default) fail with an unsupported-compression-format error; the note tells users to switch the producer to gzip or no compression.

Pairs with the error-handling change in n8n-io/n8n#32642 (the trigger now surfaces a clear error instead of waiting silently). Full codec support arrives with the upcoming `@confluentinc/kafka-javascript` migration.

Linear: https://linear.app/n8n/issue/ENT-75

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a warning to the Kafka Trigger docs: only GZIP and uncompressed messages are supported; LZ4/Snappy/ZSTD fail with an unsupported-compression-format error. Guides users to switch producers to gzip or no compression (Linear ENT-75).

- **Migration**
  - If your topic uses LZ4/Snappy/ZSTD, switch the producer to gzip or no compression.
  - Wider codec support is planned with the `@confluentinc/kafka-javascript` migration.

<sup>Written for commit f2bfb3ed8fc308598c23aed4ec1f939c7361cf0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

