### PR TITLE
docs: clarify which triggers and runs don't count towards execution quotas

### DIFF
--- a/docs/workflows/executions/index.md
+++ b/docs/workflows/executions/index.md
@@ -16,7 +16,7 @@ There are two execution modes:
 
 ## How executions count towards quotas:
 
-[Paid plans](https://n8n.io/pricing/), whether cloud or self-hosted, have an execution limit quota. Only production executions count towards this quota. These are executions started automatically by triggers, schedules, or polling. Manual executions, sub-workflows, and error workflows aren't counted. This distinction applies regardless of the instance environment, such as development or production.
+[Paid plans](https://n8n.io/pricing/), whether cloud or self-hosted, have an execution limit quota. Only production executions count towards this quota. These are executions started automatically by triggers, schedules, or polling. This distinction applies regardless of the instance environment, such as development or production.
 
 ### Execution count by trigger type
 

--- a/docs/workflows/executions/index.md
+++ b/docs/workflows/executions/index.md
@@ -26,6 +26,16 @@ The way executions are counted depends on the type of trigger node used:
 * **Polling nodes (like Google Drive Trigger):** Count one execution only when new data is found. Polls that return no results don't count as an execution.
 * **Webhook Trigger nodes:** Count one execution for every inbound request that activates the trigger. This includes requests with an empty body (such as `{}`). Malformed requests that fail before the workflow starts don't count as an execution.
 
+### Triggers and runs that don't count
+
+The following don't count towards your execution quota:
+
+* **Manual executions:** Running a workflow from the editor while building or testing.
+* **Sub-workflow executions:** When a workflow calls another workflow with the Execute Sub-workflow node, only the parent (top-level) execution counts.
+* **Error workflow executions:** Runs of a workflow set as an [error workflow](/flow-logic/error-handling.md).
+* **Polls that return no data:** A polling trigger only counts when it finds new data.
+* **Malformed or rejected requests:** Webhook requests that fail before the workflow starts.
+
 ## Execution lists
 
 n8n provides two execution lists:

--- a/docs/workflows/executions/manual-partial-and-production-executions.md
+++ b/docs/workflows/executions/manual-partial-and-production-executions.md
@@ -48,7 +48,7 @@ To work around this, consider using the [limit node](/integrations/builtin/core-
 
 ## Production executions
 
-Production executions occur when a triggering event or schedule automatically runs a workflow.
+Production executions occur when a triggering event or schedule automatically runs a workflow. On [paid plans](https://n8n.io/pricing/), production executions count towards your execution quota. For details on what does and doesn't count, refer to [How executions count towards quotas](/workflows/executions/index.md#how-executions-count-towards-quotas).
 
 To configure production executions, you must attach a [trigger node](/glossary.md#trigger-node-n8n) (any trigger other than the [manual trigger](/integrations/builtin/core-nodes/n8n-nodes-base.manualworkflowtrigger.md) works) and switch workflow's toggle to **Active**. Once published, the workflow automatically executes whenever the trigger condition occurs.
 


### PR DESCRIPTION
## Summary

Makes it explicit which triggers and runs **don't** count towards execution quotas (manual, sub-workflows, error workflows, empty polls, malformed/rejected requests), and cross-links the production-executions explanation to the quota-counting section.

### Changes
- `workflows/executions/index.md`: adds a **Triggers and runs that don't count** subsection after _Execution count by trigger type_.
- `workflows/executions/manual-partial-and-production-executions.md`: notes that production executions count towards the quota and links to _How executions count towards quotas_.

Closes https://linear.app/n8n/issue/LIGO-750

🤖 Generated with [Claude Code](https://claude.com/claude-code)