### PR TITLE
docs: Add security warning to LangChain Code node page

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.code.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.code.md
@@ -11,6 +11,10 @@ Use the LangChain Code node to import LangChain. This means if there is function
 
 On this page, you'll find the node parameters, guidance on configuring the node, and links to more resources.
 
+/// warning | Deprecated due to security issues
+This node has critical security issues and isn't safe to use. It's deprecated and hidden from the nodes panel. Avoid using it in your workflows.
+///
+
 /// note | Not available on Cloud
 This node is only available on self-hosted n8n.
 ///


### PR DESCRIPTION
## Summary

- Adds a security warning admonition to the LangChain Code node documentation page, noting it has critical security issues, is deprecated, and is hidden from the nodes panel.
- Wording stays generic per the discussion on [NODE-4502](https://linear.app/n8n/issue/NODE-4502/arbitrary-file-read-via-langchain-code-node).

Resolves [DOC-2005](https://linear.app/n8n/issue/DOC-2005/docs-for-arbitrary-file-read-via-langchain-code-node).