### PR TITLE
docs: Enhance self-hosting documentation with installation methods an…

### DIFF
--- a/docs/choose-n8n.md
+++ b/docs/choose-n8n.md
@@ -5,10 +5,30 @@ contentType: overview
 
 # Choose your n8n
 
-n8n offers two primary deployment options:
+n8n offers two primary deployment options: **n8n Cloud** (fully-managed) and **Self-hosted** (deploy on your own infrastructure).
 
-- **n8n Cloud**: A fully-managed hosted solution with no installation required
-- **Self-hosted**: Deploy n8n on your own infrastructure using npm, Docker, or server setups
+/// note | Want to try n8n quickly?
+**Start with n8n Cloud** for instant access with no installation required.
+
+[Start free trial](https://n8n.io/cloud/){ .md-button .md-button--primary }
+///
+
+## Decision guide
+
+Use this guide to choose the best option for your needs:
+
+| Your situation | Recommended option | Reason |
+|----------------|-------------------|---------|
+| Want to start quickly | **n8n Cloud** | No installation needed |
+| Don't have technical expertise | **n8n Cloud** | Hosted solution, no setup required |
+| Need production-ready deployment | **Both options work** | Both Cloud and self-hosted support production use |
+| Have customized use cases | **Self-hosted** | Full control over deployment and configuration |
+| Want most features for free | **Self-hosted Community Edition** | Free with almost complete feature set |
+| Need folders and debugging features for free | **Registered Community Edition** | Free registration unlocks these features |
+| Need enterprise features (SSO, environments, projects, etc.) | **Cloud (paid) or Self-hosted Enterprise** | These features require paid plans |
+| Have infrastructure and technical resources | **Self-hosted** | Can manage your own deployment |
+
+For specific feature availability across different plans, see the [pricing page](https://n8n.io/pricing/).
 
 ## Pros and cons comparison
 
@@ -36,7 +56,16 @@ n8n offers two primary deployment options:
 
 **Legend**: ✅ Advantage | ❌ Disadvantage | ⚠️ Mixed/depends on needs
 
-For detailed pricing and plan comparisons, see the [pricing page](https://n8n.io/pricing/).
+For specific feature availability across different plans, see the [pricing page](https://n8n.io/pricing/).
+
+## Getting started
+
+Ready to begin? Choose your deployment option:
+
+- **[Get started with n8n Cloud](https://n8n.io/cloud/)** - Sign up for instant access
+- **[Get started with self-hosted](/hosting/)** - Installation and deployment guides
+
+To register a Community Edition instance for additional features, go to **Settings > Usage and plan** and select **Unlock**.
 
 ## Feature comparison
 
@@ -74,41 +103,3 @@ By registering your Community Edition with your email, you unlock these addition
 Both n8n Cloud (Enterprise plan) and Self-hosted Enterprise editions include all the features listed above that are missing from the Community Edition.
 
 For specific details on which features are available on Cloud Starter, Pro, and Business self-hosted plans, see the [pricing page](https://n8n.io/pricing/).
-
-## Decision guide
-
-| Your situation | Recommended option | Reason |
-|----------------|-------------------|---------|
-| Want to start quickly | **n8n Cloud** | No installation needed |
-| Don't have technical expertise | **n8n Cloud** | Hosted solution, no setup required |
-| Need production-ready deployment | **Both options work** | Both Cloud and self-hosted support production use |
-| Have customized use cases | **Self-hosted** | Recommended for customization |
-| Want most features for free | **Self-hosted Community Edition** | Free with almost complete feature set |
-| Need folders and debugging features for free | **Registered Community Edition** | Free registration unlocks these features |
-| Need enterprise features (SSO, environments, projects, etc.) | **Cloud (paid) or Self-hosted Enterprise** | These features require paid plans |
-| Have infrastructure and technical resources | **Self-hosted** | Can manage your own deployment |
-
-For specific feature availability across different Cloud and self-hosted plans, see the [pricing page](https://n8n.io/pricing/).
-
-## Getting Started
-
-### n8n Cloud
-
-Visit [n8n Cloud](https://n8n.io/cloud/) to sign up for a free trial.
-
-### Self-hosted
-
-Refer to the [hosting documentation](/hosting/index.md) for installation options:
-
-- [npm installation](/hosting/installation/npm.md)
-- [Docker installation](/hosting/installation/docker.md)
-- [Server setup guides](/hosting/installation/server-setups/index.md)
-
-To register a Community Edition instance for additional features, go to **Settings > Usage and plan** and select **Unlock**.
-
-## Additional Resources
-
-- [Pricing details](https://n8n.io/pricing/)
-- [Sustainable Use License](/sustainable-use-license.md)
-- [Community Edition features](/hosting/community-edition-features.md)
-- [Choose your n8n](/choose-n8n.md)

--- a/docs/choose-n8n.md
+++ b/docs/choose-n8n.md
@@ -63,7 +63,7 @@ For specific feature availability across different plans, see the [pricing page]
 Ready to begin? Choose your deployment option:
 
 - **[Get started with n8n Cloud](https://n8n.io/cloud/)** - Sign up for instant access
-- **[Get started with self-hosted](/hosting/)** - Installation and deployment guides
+- **[Get started with self-hosted](/hosting/index.md)** - Installation and deployment guides
 
 To register a Community Edition instance for additional features, go to **Settings > Usage and plan** and select **Unlock**.
 

--- a/docs/hosting/index.md
+++ b/docs/hosting/index.md
@@ -10,48 +10,82 @@ hide:
 
 # Self-hosting n8n
 
-This section provides guidance on setting up self-hosted n8n. All self-hosted installations use the same core product. Without a license key, n8n runs as the free Community edition. Adding a Business or Enterprise license key enables those editions.
+All self-hosted installations use the same core product. Without a license key, n8n runs as the free [Community edition](/hosting/community-edition-features.md). Adding a Business or Enterprise license key enables those editions.
 
-See [Community edition features](/hosting/community-edition-features.md) for a list of available features. 
+## Choose your installation method
 
-<div class="grid-cards-vertical cards" markdown>
+Select the installation method that best fits your technical requirements and infrastructure:
 
-- __Installation and server setups__
+### Quick start options
 
-	Install n8n on any platform using npm or Docker. Or follow our guides to popular hosting platforms.
+- __npm__
 
-	[:octicons-arrow-right-24: Docker installation guide](/hosting/installation/docker.md)
+	**Best for:** Local development, testing, or simple single-server deployments.
+	
+	**Requirements:** Node.js installed on your system.
+	
+	Installs n8n directly using Node Package Manager. Quick to set up but requires managing Node.js versions and dependencies yourself.
 
-- __Configuration__
+	[npm installation guide](/hosting/installation/npm.md)
 
-	Learn how to configure n8n with environment variables.
+- __Docker__
 
-	[:octicons-arrow-right-24: Environment Variables](/hosting/configuration/environment-variables/index.md)
+	**Best for:** Isolated environments, easy updates, and consistent deployments.
+	
+	**Requirements:** Docker installed on your system.
+	
+	Runs n8n in a container with all dependencies included. Simplifies installation and updates.
 
-- __Users and authentication__
+	[Docker installation guide](/hosting/installation/docker.md)
 
-	Choose and set up user authentication for your n8n instance.
+### Cloud platform setups
 
-	[:octicons-arrow-right-24: Authentication](/hosting/configuration/user-management-self-hosted.md)
+Deploy n8n on managed cloud infrastructure for production environments:
 
-- __Scaling__
+- __AWS__
 
-	Manage data, modes, and processes to keep n8n running smoothly at scale.
+	Deploy on Amazon Web Services using EC2, ECS, or other AWS services.
 
-	[:octicons-arrow-right-24: Scaling](/hosting/scaling/queue-mode.md)
+	[AWS setup guide](/hosting/installation/server-setups/aws.md)
 
-- __Securing n8n__
+- __Azure__
 
-	Secure your n8n instance by setting up SSL, SSO, or 2FA or blocking or opting out of some data collection or features.
+	Host n8n on Microsoft Azure with container instances or virtual machines.
 
-	[:octicons-arrow-right-24: Securing n8n guide](/hosting/securing/overview.md)
+	[Azure setup guide](/hosting/installation/server-setups/azure.md)
 
-- __Starter kits__
+- __Google Cloud__
 
-	New to n8n or AI? Try our Self-hosted AI Starter Kit. Curated by n8n, it combines the self-hosted n8n platform with compatible AI products and components to get you started building self-hosted AI workflows.
+	Run n8n on Google Cloud using Cloud Run or Kubernetes Engine.
 
-	[:octicons-arrow-right-24: Starter kits](/hosting/starter-kits/ai-starter-kit.md)
+	[Google Cloud Run](/hosting/installation/server-setups/google-cloud-run.md) | [Kubernetes Engine](/hosting/installation/server-setups/google-kubernetes-engine.md)
 
-</div>
+- __DigitalOcean__
 
---8<-- "_snippets/self-hosting/warning.md"
+	Simple droplet-based hosting ideal for small to medium deployments.
+
+	[DigitalOcean setup guide](/hosting/installation/server-setups/digital-ocean.md)
+
+- __Hetzner__
+
+	Cost-effective European hosting option with excellent performance.
+
+	[Hetzner setup guide](/hosting/installation/server-setups/hetzner.md)
+
+- __Heroku__
+
+	Platform-as-a-service option for quick deployment with minimal configuration.
+
+	[Heroku setup guide](/hosting/installation/server-setups/heroku.md)
+
+- __OpenShift__
+
+	Enterprise Kubernetes platform for containerized applications.
+
+	[OpenShift setup guide](/hosting/installation/server-setups/openshift-crc.md)
+
+- __Docker Compose__
+
+	Multi-container setup ideal for production deployments with databases and additional services.
+
+	[Docker Compose guide](/hosting/installation/server-setups/docker-compose.md)

--- a/docs/hosting/index.md
+++ b/docs/hosting/index.md
@@ -16,8 +16,6 @@ All self-hosted installations use the same core product. Without a license key, 
 
 Select the installation method that best fits your technical requirements and infrastructure:
 
-### Quick start options
-
 - __npm__
 
 	**Best for:** Local development, testing, or simple single-server deployments.
@@ -37,10 +35,6 @@ Select the installation method that best fits your technical requirements and in
 	Runs n8n in a container with all dependencies included. Simplifies installation and updates.
 
 	[Docker installation guide](/hosting/installation/docker.md)
-
-### Cloud platform setups
-
-Deploy n8n on managed cloud infrastructure for production environments:
 
 - __AWS__
 


### PR DESCRIPTION
…d cloud platform setups

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Cloud vs self‑hosted docs and streamlines the self‑hosting landing page with a focused “Choose your installation method” list and corrected links to help users pick and install faster.

- **New Features**
  - Choose your n8n: Added a quick-start Cloud CTA, a clearer decision guide, and a simple Getting started section linking to Cloud and self‑hosted; included guidance on registering Community Edition for extra features and updated pricing links.
  - Self‑hosting index: New “Choose your installation method” with quick starts for npm and Docker (with Best for and Requirements), plus platform setup links for AWS, Azure, Google Cloud Run & GKE, DigitalOcean, Hetzner, Heroku, OpenShift, and Docker Compose.
  - Cleanup and clarity: Clarifies that self‑hosted runs Community Edition by default and how Business/Enterprise unlock via license; removed the old card grid and redundant configuration/auth/scaling/security/starter‑kit sections; fixed and normalized links.

<sup>Written for commit 260f3d403a6750fde7c0e08d701e4ae32fde9caf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

