### PR TITLE
docs: add "Qwen" to Vale accepted-words vocabulary

### DIFF
--- a/styles/config/vocabularies/default/accept.txt
+++ b/styles/config/vocabularies/default/accept.txt
@@ -214,6 +214,7 @@ Qdrant
 QRadar
 Qualys
 [Qq]uickstarts
+Qwen
 Realtime
 Rekognition
 requester


### PR DESCRIPTION
## Summary
- Add `Qwen` to the default Vale accepted-words vocabulary (`styles/config/vocabularies/default/accept.txt`).

## Background
The Alibaba Cloud -> Qwen Cloud rename (#4905, core [n8n#32632](https://github.com/n8n-io/n8n/pull/32632)) introduces the proper noun "Qwen". Vale's `Vale.Spelling` rule doesn't recognize it and fails CI with `Did you really mean 'Qwen'?` on every occurrence (SUMMARY.md and the three node/credential pages).

Only `Qwen` needs adding — "Cloud", "Chat", and "Model" are already valid words, and qwencloud.com URLs are ignored by Vale's `TokenIgnores`.

## Notes
- This unblocks the Vale check on #4905. Merge this first (or alongside) so #4905 goes green on re-run.

Closes DOC-2043