### PR TITLE
DOC-2044: fix migration-broken internal links (Phase 1, mechanical)

### DIFF
--- a/docs/build/understand-workflows/README.md
+++ b/docs/build/understand-workflows/README.md
@@ -21,6 +21,6 @@ A workflow[^1] is a collection of nodes connected together to automate a process
 * Debug using the [Executions](understand-executions/README.md) list.
 * [Share](../manage-workflows/share-with-others.md) workflows between users.
 
-If it's your first time building a workflow, you may want to use the [quickstart guides](/try-it-out/index.md) to quickly try out n8n features.
+If it's your first time building a workflow, you may want to use the [quickstart guides](https://app.gitbook.com/s/CxSeOtVxqqhfxMSac0AV/build-your-first-workflow) to quickly try out n8n features.
 
 [^1]: An n8n workflow is a collection of nodes that automate a process. Workflows begin execution when a trigger condition occurs and execute sequentially to achieve complex tasks.

--- a/docs/build/understand-workflows/create-and-run-workflows.md
+++ b/docs/build/understand-workflows/create-and-run-workflows.md
@@ -41,7 +41,7 @@ Or:
 2. If you're doing this from the **Overview** page, you'll create the workflow inside your personal space. If you're doing this from inside a project, you'll create the workflow inside that specific project.
 3. Get started by adding a trigger node: select **Add first step...**
 
-If it's your first time building a workflow, you may want to use the [quickstart guides](../../../try-it-out/index.md) to quickly try out n8n features.
+If it's your first time building a workflow, you may want to use the [quickstart guides](https://app.gitbook.com/s/CxSeOtVxqqhfxMSac0AV/build-your-first-workflow) to quickly try out n8n features.
 
 ## Run workflows manually <a href="#run-workflows-manually" id="run-workflows-manually"></a>
 

--- a/docs/deploy/host-n8n/configure-n8n/scaling/fix-memory-issues.md
+++ b/docs/deploy/host-n8n/configure-n8n/scaling/fix-memory-issues.md
@@ -16,7 +16,7 @@ n8n doesn't restrict the amount of data each node can fetch and process. While t
 {% hint style="info" %}
 **Only for self-hosted n8n**
 
-This page describes memory-related errors when [self-hosting n8n](../../README.md). Visit [Cloud data management](../../../use-n8n-cloud/configure-cloud/manage-your-data.md) to learn about memory limits for [n8n Cloud](/manage-cloud/overview.md).
+This page describes memory-related errors when [self-hosting n8n](../../README.md). Visit [Cloud data management](../../../use-n8n-cloud/configure-cloud/manage-your-data.md) to learn about memory limits for [n8n Cloud](../../../use-n8n-cloud/README.md).
 {% endhint %}
 
 ## Identifying out of memory situations <a href="#identifying-out-of-memory-situations" id="identifying-out-of-memory-situations"></a>

--- a/docs/deploy/host-n8n/install-options/install-with-npm.md
+++ b/docs/deploy/host-n8n/install-options/install-with-npm.md
@@ -59,7 +59,7 @@ n8n start
 
 ### Next steps <a href="#next-steps" id="next-steps"></a>
 
-Try out n8n using the [Quickstarts](/try-it-out/index.md).
+Try out n8n using the [Quickstarts](https://app.gitbook.com/s/CxSeOtVxqqhfxMSac0AV/build-your-first-workflow).
 
 ## Updating <a href="#updating" id="updating"></a>
 

--- a/docs/get-started/build-your-first-workflow.md
+++ b/docs/get-started/build-your-first-workflow.md
@@ -39,7 +39,7 @@ This guide will show you how to construct a workflow[^1] in n8n, explaining key 
 
 !["Screenshot of the completed workflow"](.gitbook/assets/tutorial-first.png)
 
-This quickstart uses [n8n Cloud](../../manage-cloud/overview.md), which is recommended for new users. A free trial is available - if you haven't already done so, [sign up](https://app.n8n.cloud/register) for an account now.
+This quickstart uses [n8n Cloud](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/use-n8n-cloud), which is recommended for new users. A free trial is available - if you haven't already done so, [sign up](https://app.n8n.cloud/register) for an account now.
 
 ## Step one: Create a new workflow <a href="#step-one-create-a-new-workflow" id="step-one-create-a-new-workflow"></a>
 
@@ -181,7 +181,7 @@ There are plenty of things you could add to this (perhaps add some more credenti
 
 ## Next steps <a href="#next-steps" id="next-steps"></a>
 
-* Interested in what you could do with AI? Find out [how to build an AI chat agent with n8n](../../advanced-ai/intro-tutorial.md).
+* Interested in what you could do with AI? Find out [how to build an AI chat agent with n8n](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/integrate-ai).
 * Take [courses at n8n Academy](https://learn.n8n.io).
 * Explore more examples in [workflow templates](https://n8n.io/workflows/).
 

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorechroma.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorechroma.md
@@ -134,7 +134,7 @@ This Operation Mode includes one **Node option**, the Metadata Filter
 
 Refer to [LangChain's Chroma documentation](https://js.langchain.com/oss/javascript/integrations/vectorstores/chroma) for more information about the service.
 
-View n8n's [Advanced AI](../../../../../advanced-ai/index.md) documentation.
+View n8n's [Advanced AI](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/integrate-ai) documentation.
 
 [^1]: A vector store, or vector database, stores mathematical representations of information. Use with embeddings and retrievers to create a database that your AI can access when answering questions.
 [^2]: AI chains allow you to interact with large language models (LLMs) and other resources in sequences of calls to components. AI chains in n8n don't use persistent memory, so you can't use them to reference previous context (use AI agents for this).

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.aitransform.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.aitransform.md
@@ -37,7 +37,7 @@ Use the AI Transform node to generate code snippets based on your prompt. The AI
 {% hint style="info" %}
 **Feature availability**
 
-Available only on [Cloud plans](../../../../manage-cloud/overview.md).
+Available only on [Cloud plans](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/use-n8n-cloud).
 {% endhint %}
 
 ## Node parameters <a href="#node-parameters" id="node-parameters"></a>

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.code/common-issues.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.code/common-issues.md
@@ -125,7 +125,7 @@ This error occurs if you try to use `require` in the Code node and n8n can't fin
 {% hint style="warning" %}
 **Only for self-hosted**
 
-n8n doesn't support importing modules in the [Cloud](../../../../../manage-cloud/overview.md) version.
+n8n doesn't support importing modules in the [Cloud](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/use-n8n-cloud) version.
 {% endhint %}
 
 If you're [self-hosting](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n) n8n, follow these steps:

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.extractfromfile.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.extractfromfile.md
@@ -87,6 +87,6 @@ This parameter is only available for these operations:
 
 [Browse Extract From File integration templates](https://n8n.io/integrations/extract-from-file) or [search all templates](https://n8n.io/workflows/)
 
-[HTTP Request Node]: /integrations/builtin/core-nodes/n8n-nodes-base.httprequest/index.md
-[Webhook Node]: /integrations/builtin/core-nodes/n8n-nodes-base.webhook/index.md
+[HTTP Request Node]: /integrations/builtin/core-nodes/n8n-nodes-base.httprequest/README.md
+[Webhook Node]: /integrations/builtin/core-nodes/n8n-nodes-base.webhook/README.md
 [base64]: https://datatracker.ietf.org/doc/html/rfc4648#section-4

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/common-issues.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.scheduletrigger/common-issues.md
@@ -54,7 +54,7 @@ If the Schedule Trigger node runs at the wrong time, it may mean that you need t
 
 ### Adjust the timezone globally <a href="#adjust-the-timezone-globally" id="adjust-the-timezone-globally"></a>
 
-If you're using [n8n Cloud](../../../../../manage-cloud/overview.md), follow the instructions on the [set the Cloud instance timezone](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/use-n8n-cloud/configure-cloud/set-your-timezone) page to ensure that n8n executes in sync with your local time.
+If you're using [n8n Cloud](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/use-n8n-cloud), follow the instructions on the [set the Cloud instance timezone](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/use-n8n-cloud/configure-cloud/set-your-timezone) page to ensure that n8n executes in sync with your local time.
 
 If you're [self hosting](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n), set your global timezone using the [`GENERIC_TIMEZONE` environment variable](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/basic-configuration/use-environment-variables/timezone-and-localization).
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.splitinbatches.md
@@ -67,7 +67,7 @@ When enabled, you can adjust the reset conditions by switching the parameter rep
 
 This workflow allows you to read an RSS feed from two different sources using the Loop Over Items node. You need the Loop Over Items node in the workflow as the RSS Feed Read node only processes the first item it receives. You can also find the [workflow](https://n8n.io/workflows/687-read-rss-feed-from-two-different-sources/) on n8n.io.
 
-The example walks through building the workflow, but assumes you are already familiar with n8n. To build your first workflow, including learning how to add nodes to a workflow, refer to [Try it out](/try-it-out/index.md).
+The example walks through building the workflow, but assumes you are already familiar with n8n. To build your first workflow, including learning how to add nodes to a workflow, refer to [Try it out](https://app.gitbook.com/s/CxSeOtVxqqhfxMSac0AV/build-your-first-workflow).
 
 The final workflow looks like this:
 

--- a/docs/integrations/builtin/credentials/chroma.md
+++ b/docs/integrations/builtin/credentials/chroma.md
@@ -33,7 +33,7 @@ Create and run a [Chroma](https://www.trychroma.com/home) instance. Refer to the
 
 Refer to [Chroma's documentation](https://docs.trychroma.com/docs/overview/getting-started) for more information about the service. Also refer to [Chroma Cloud](https://docs.trychroma.com/cloud/getting-started) for using cloud instance.
 
-View n8n's [Advanced AI](/advanced-ai/index.md) documentation.
+View n8n's [Advanced AI](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/integrate-ai) documentation.
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/mjXhKRIw98UJ5hk9LWBl/" %}
 

--- a/docs/integrations/builtin/node-types.md
+++ b/docs/integrations/builtin/node-types.md
@@ -31,7 +31,7 @@ Nodes in n8n can then request that credential information. As another layer of s
 
 To make sure that the data is secure, it gets saved to the database encrypted. n8n uses a random personal encryption key, which it automatically generates on the first run of n8n and then saved under `~/.n8n/config`.
 
-To learn more about creating, managing, and sharing credentials, refer to [Manage credentials](/credentials/index.md).
+To learn more about creating, managing, and sharing credentials, refer to [Manage credentials](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/understand-workflows/create-and-edit-credentials).
 
 ## Community nodes <a href="#community-nodes" id="community-nodes"></a>
 

--- a/docs/release-notes/1.x.md
+++ b/docs/release-notes/1.x.md
@@ -4951,7 +4951,7 @@ We now also prevent npm downloading community packages from a compromised npm re
 {% hint style="info" %}
 #### New node: AI Transform <a href="#new-node-ai-transform" id="new-node-ai-transform"></a>
 
-This release adds the [AI Transform node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.aitransform). Use the AI Transform node to generate code snippets based on your prompt. The AI is context-aware, understanding the workflow’s nodes and their data types. The node is only available on [Cloud plans](/manage-cloud/overview.md).
+This release adds the [AI Transform node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.aitransform). Use the AI Transform node to generate code snippets based on your prompt. The AI is context-aware, understanding the workflow’s nodes and their data types. The node is only available on [Cloud plans](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/use-n8n-cloud).
 {% endhint %}
 
 
@@ -6554,7 +6554,7 @@ This release contains new features, node enhancements, and bug fixes.
 {% hint style="info" %}
 #### LangChain general availability <a href="#langchain-general-availability" id="langchain-general-availability"></a>
 
-This release adds LangChain support to the main n8n version. Refer to [LangChain](/advanced-ai/langchain/overview.md) for more information on how to build AI tools in n8n, the new nodes n8n has introduced, and related learning resources.
+This release adds LangChain support to the main n8n version. Refer to [LangChain](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/integrate-ai) for more information on how to build AI tools in n8n, the new nodes n8n has introduced, and related learning resources.
 {% endhint %}
 
 
@@ -6926,8 +6926,8 @@ With n8n's LangChain nodes you can build AI-powered functionality within your wo
 
 Read more:
 
-* This is a beta release, and not yet available in the main product. Follow the instructions in [Access LangChain in n8n](/advanced-ai/langchain/overview.md) to try it out. Self-hosted and Cloud options are available.
-* Learn how LangChain concepts map to n8n nodes in [LangChain concepts in n8n](/advanced-ai/langchain/langchain-n8n.md).
+* This is a beta release, and not yet available in the main product. Follow the instructions in [Access LangChain in n8n](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/integrate-ai) to try it out. Self-hosted and Cloud options are available.
+* Learn how LangChain concepts map to n8n nodes in [LangChain concepts in n8n](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/integrate-ai).
 * Browse n8n's new [Cluster nodes](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/cluster-nodes). This is a new set of node types that allows for multiple nodes to work together to configure each other.
 
 ## n8n@1.9.0 <a href="#n8n190" id="n8n190"></a>


### PR DESCRIPTION
Linear: DOC-2044

## What

Repoints **19 broken internal links** left over from the GitBook migration — the unambiguous "section moved" and "index→README" rows from the refreshed broken-links analysis. No prose changes; link targets only (19 insertions / 19 deletions across 14 files).

### Cross-space links (16) — old IA path → `app.gitbook.com/s/<spaceId>/` page-reference form
- `/try-it-out/...` → `build-your-first-workflow` (get-started)
- `manage-cloud/overview.md` → `use-n8n-cloud` (deploy)
- `advanced-ai/index`, `advanced-ai/langchain/*`, `advanced-ai/intro-tutorial` → `integrate-ai` (build)
- `/credentials/index.md` → `understand-workflows/create-and-edit-credentials` (build)

Files: build/understand-workflows/{README,create-and-run-workflows}, deploy/host-n8n/install-options/install-with-npm, get-started/build-your-first-workflow (×2), integrations/builtin/{node-types, core-nodes/n8n-nodes-base.aitransform, core-nodes/n8n-nodes-base.splitinbatches, core-nodes/n8n-nodes-base.code/common-issues, core-nodes/n8n-nodes-base.scheduletrigger/common-issues, cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorechroma, credentials/chroma}, release-notes/1.x (×4).

### Same-space links (3)
- `fix-memory-issues.md`: `/manage-cloud/overview.md` → `../../../use-n8n-cloud/README.md`
- `n8n-nodes-base.extractfromfile.md`: two reference links `…/index.md` → `…/README.md` (httprequest, webhook)

The `app.gitbook.com/s/<spaceId>/` form is GitBook's cross-space page reference (resolves to docs.n8n.io on publish, auto-updates if a page moves) — matches the convention already used in these files.

## Out of scope (tracked separately)
- 17 missing-page links (remove-vs-recreate decision)
- 7 asset links (PDFs, workflow JSONs)
- 1 unfilled `<video-id>` placeholder
- source-control "Using" link (target needs verification)
- **Newly found, not yet ticketed:** 2 same-type broken links in reusable-content includes — `self-hosting/installation/server-setups-next-steps.md` (`/try-it-out/index.md`) and `integrations/builtin/cluster-nodes/langchain-overview-link.md` (`/advanced-ai/index.md`)

## How to verify
- Old targets no longer appear in the edited files (`grep` clean except migration `originalFilePath` frontmatter, which is intentionally preserved).
- Each new target's published equivalent resolves on docs.n8n.io (build-your-first-workflow, use-n8n-cloud, integrate-ai, understand-workflows/create-and-edit-credentials).
- Check the GitBook preview build for broken-link markers on the edited pages.