### PR TITLE
feat(grist): document OAuth2, Trigger node, updates

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.grist.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.grist.md
@@ -30,9 +30,20 @@ Refer to [Grist credentials](../credentials/grist.md) for guidance on setting up
 ## Operations <a href="#operations" id="operations"></a>
 
 * Create rows in a table
+* Create or update rows in a table (upsert)
 * Delete rows from a table
 * Read rows from a table
 * Update rows in a table
+
+## Select the document and table
+
+The **Document** and **Table** parameters are resource locators. Choose **From List** to pick from the documents and tables your account can access, or switch to **By ID** to enter the IDs directly. You can find a document's ID in its URL or in **Document Settings**.
+
+## Map columns
+
+For the **Create**, **Update**, and **Create or Update** operations, the node loads the table's columns so you can map a value to each one. Column types are detected automatically (for example, numbers, toggles, dates, and choices). Formula columns are read-only and can't be set.
+
+For **Create or Update**, choose which column(s) to match on: the node updates the existing row when a match is found, and creates a new row otherwise.
 
 ## Templates and examples <a href="#templates-and-examples" id="templates-and-examples"></a>
 
@@ -47,16 +58,15 @@ To update or delete a particular record, you need the Row ID. There are two ways
 
 Create a new column in your Grist table with the formula `$id`.
 
-**Use the Get All operation**
+**Use the Get Many Rows operation**
 
-The **Get All** operation returns the Row ID of each record along with the fields.
+The **Get Many Rows** operation returns the Row ID of each record along with the fields.
  
 You can get it with the expression `{{$("GristNodeName").item.json.id}}`.
 
 
-## Filter records when using the Get All operation <a href="#filter-records-when-using-the-get-all-operation" id="filter-records-when-using-the-get-all-operation"></a>
+## Filter records when using the Get Many Rows operation
 
 - Select **Add Option** and select **Filter** from the dropdown list.
 - You can add filters for any number of columns. The result will only include records which match all the columns.
 - For each column, you can enter any number of values separated by commas. The result will include records which match any of the values for that column.
-

--- a/docs/integrations/builtin/credentials/grist.md
+++ b/docs/integrations/builtin/credentials/grist.md
@@ -20,6 +20,7 @@ layout:
 You can use these credentials to authenticate the following nodes:
 
 * [Grist](../app-nodes/n8n-nodes-base.grist.md)
+* [Grist Trigger](../trigger-nodes/n8n-nodes-base.gristtrigger.md)
 
 ## Prerequisites <a href="#prerequisites" id="prerequisites"></a>
 
@@ -28,18 +29,47 @@ Create a [Grist](https://getgrist.com/) account.
 ## Supported authentication methods <a href="#supported-authentication-methods" id="supported-authentication-methods"></a>
 
 - API key
+- OAuth2 (PKCE)
 
 ## Related resources <a href="#related-resources" id="related-resources"></a>
 
 Refer to [Grist's API documentation](https://support.getgrist.com/api/) for more information about the service.
 
+## Grist URL
+
+Both authentication methods use a single **Grist URL** field that points n8n at your Grist server:
+
+- The default, `https://api.getgrist.com`, works for any account on hosted Grist (getgrist.com).
+- To restrict the connection to a single team, use `https://YOUR_TEAM.getgrist.com`.
+- For a self-managed instance, use its URL, without `/api` and without a trailing slash (for example `https://grist.example.com`).
+
 ## Using API key <a href="#using-api-key" id="using-api-key"></a>
 
 To configure this credential, you'll need:
 
-- An **API Key**: Refer to the [Grist API authentication documentation](https://support.getgrist.com/rest-api/#authentication) for instructions on creating an API key.
-- To select your Grist **Plan Type**. Options include:
-    - Free
-    - Paid: If selected, provide your Grist **Custom Subdomain**. This is the portion that comes before `.getgrist.com`. For example, if our full Grist domain was `n8n.getgrist.com`, we'd enter `n8n` here.
-    - Self-Hosted: If selected, provide your Grist **Self-Hosted URL**. This should be the full URL.
+- A **Grist URL** (see [Grist URL](#grist-url) above).
+- An **API Key**: in Grist, open the account menu (top right), then go to **Account settings** > **Developer** to create or copy your API key. Refer to the [Grist API authentication documentation](https://support.getgrist.com/rest-api/#authentication) for more information.
 
+## Using OAuth2
+
+OAuth2 lets n8n connect to Grist without storing a long-lived API key. Grist uses the PKCE authorization flow.
+
+To configure this credential, you'll need:
+
+- A **Grist URL** (see [Grist URL](#grist-url) above).
+- A **Client ID** and **Client Secret** from a Grist OAuth app.
+
+To create the OAuth app in Grist:
+
+1. In Grist, open the account menu (top right), then go to **Account settings** > **Developer** > **OAuth apps** and register a new app.
+2. Set the redirect URL to your n8n OAuth callback: `https://<n8n-host>/rest/oauth2-credential/callback`. n8n shows the exact **OAuth Redirect URL** to use on the credential screen.
+3. Copy the generated **Client ID** and **Client Secret** into the n8n credential.
+4. Select **Connect my account** and complete the Grist consent screen.
+
+The credential requests the following scopes: `offline_access`, `doc:read`, `doc:write`, and `doc:webhooks`. The `doc:webhooks` scope is required for the [Grist Trigger](../trigger-nodes/n8n-nodes-base.gristtrigger.md) node.
+
+{% hint style="info" %}
+**Self-managed Grist**
+
+OAuth2 requires a Grist instance with OAuth Apps enabled. Use your instance URL in the **Grist URL** field.
+{% endhint %}

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.gristtrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.gristtrigger.md
@@ -6,6 +6,9 @@ description: >-
 contentType:
   - integration
   - reference
+layout:
+  description:
+    visible: false
 ---
 
 # Grist Trigger node

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.gristtrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.gristtrigger.md
@@ -1,0 +1,77 @@
+---
+title: Grist Trigger node documentation
+description: >-
+  Learn how to use the Grist Trigger node in n8n. Follow technical documentation
+  to integrate Grist Trigger node into your workflows.
+contentType:
+  - integration
+  - reference
+---
+
+# Grist Trigger node
+
+[Grist](https://getgrist.com/) is a modern relational spreadsheet that combines the flexibility of a spreadsheet with the robustness of a database.
+
+The Grist Trigger node starts a workflow when records are added to or updated in a Grist table. It registers a [Grist webhook](https://support.getgrist.com/webhooks/) on the document, so the workflow runs as soon as Grist reports the change.
+
+On this page, you'll find a list of events the Grist Trigger node can respond to and links to more resources.
+
+{% hint style="info" %}
+**Credentials**
+
+You can find authentication information for this node [here](../credentials/grist.md).
+{% endhint %}
+
+## Events
+
+* **Record Created**: a new record is added to the table.
+* **Record Updated**: an existing record in the table changes.
+
+## Related resources
+
+n8n provides an app node for Grist. You can find the node docs [here](../app-nodes/n8n-nodes-base.grist.md).
+
+Refer to [Grist's webhook documentation](https://support.getgrist.com/webhooks/) for details about how Grist delivers events.
+
+## Node parameters
+
+Use these parameters to configure your node.
+
+### Document
+
+The Grist document to watch. Choose **From List** to pick a document your account can access, or switch to **By ID** to enter the document ID directly. You can find the ID in the document's URL or in **Document Settings**.
+
+### Table
+
+The table within the document to watch. Choose **From List** to pick a table from the selected document, or switch to **By ID** to enter the table ID directly.
+
+### Trigger On
+
+The record events that start the workflow. Select one or both of **Record Created** and **Record Updated**.
+
+## Node options
+
+### Ready Column Name or ID
+
+A boolean (toggle) column that marks a record as ready. When set, the workflow only triggers once a record becomes ready (the column becomes true). This lets you fill in a record over several steps and trigger only when it's complete. Choose a column from the list, or specify a column ID using an [expression](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/work-with-data/expressions-versus-data-nodes).
+
+## Output
+
+Grist delivers changed records as a JSON array, and the node emits one workflow item per record. Each item contains the record's `id` plus a field for every column in the table.
+
+{% hint style="info" %}
+**Cell value encoding**
+
+Complex Grist column types are delivered in Grist's encoded form. For example, lists and choice lists arrive as `["L", ...]`, dates and datetimes as `["d", timestamp]` / `["D", timestamp, timezone]`, and references as `["R", tableId, rowId]`. Decode these downstream if you need the raw values.
+{% endhint %}
+
+{% hint style="info" %}
+**Batching**
+
+Grist batches deliveries, sending up to 100 records per webhook call. A change affecting more records arrives across several executions.
+{% endhint %}
+
+## Requirements
+
+- The account behind the credential must own the document you want to watch.
+- On self-managed Grist, the n8n host must be listed in the `ALLOWED_WEBHOOK_DOMAINS` environment variable, otherwise Grist refuses to register the webhook.


### PR DESCRIPTION
Some updates to documentation for Grist.

- Add the Grist Trigger node page (events, parameters, ready column, output encoding, batching, requirements).
- Document OAuth2 (PKCE) auth and the unified Grist URL field on the credential page; update supported authentication methods.
- Document the v2 column mapper, the Create or Update (upsert) operation, and the Document/Table resource locators on the node page; rename "Get All" to "Get Many Rows".

Companion docs for https://github.com/n8n-io/n8n/pull/34798 and https://github.com/n8n-io/n8n/pull/34190

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs for the Grist Trigger node and OAuth2 (PKCE) authentication, plus updates to the Grist node docs. Clarifies resource selection and column mapping, documents the unified `Grist URL`, and renames "Get All" to "Get Many Rows".

- **New Features**
  - Grist Trigger node: documents create/update events, optional Ready column, output encoding, batching, and requirements.
  - Credentials: adds OAuth2 (PKCE) with a unified `Grist URL`; setup steps, requested scopes, and a note that self-managed instances must have OAuth Apps enabled.
  - Grist node: documents v2 column mapper and Create or Update (upsert), and adds Document/Table resource locators; updates examples to "Get Many Rows".

<sup>Written for commit 3e72548007049a1cbe615ee3d6aba21869b6ee50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

