### PR TITLE
DOC-2052: repoint HTTP Request Tool links to the HTTP Request node

### DIFF
--- a/docs/build/integrate-ai/understand-ai-components/how-tools-work.md
+++ b/docs/build/integrate-ai/understand-ai-components/how-tools-work.md
@@ -31,7 +31,7 @@ n8n provides tool sub-nodes[^1] that you can connect to your [AI agent](#user-co
 
 * [Call n8n Workflow Tool](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolworkflow): use this to load any n8n workflow as a tool.
 * [Custom Code Tool](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolcode): write code that your agent can run.
-* [HTTP Request Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolhttprequest.md): make calls to fetch a website or data from an API.
+* [HTTP Request Tool](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.httprequest): make calls to fetch a website or data from an API.
 
 The next three examples highlight the Call n8n Workflow Tool:
 

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
@@ -60,7 +60,7 @@ This agent supports the following chat models:
 
 * [Call n8n Workflow](../../sub-nodes/n8n-nodes-langchain.toolworkflow.md)
 * [Code](../../sub-nodes/n8n-nodes-langchain.toolcode.md)
-* [HTTP Request](../../../../../../integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolhttprequest.md)
+* [HTTP Request](../../../core-nodes/n8n-nodes-base.httprequest/README.md)
 * [Action Network](../../../app-nodes/n8n-nodes-base.actionnetwork.md)
 * [ActiveCampaign](../../../app-nodes/n8n-nodes-base.activecampaign.md)
 * [Affinity](../../../app-nodes/n8n-nodes-base.affinity.md)

--- a/docs/integrations/builtin/credentials/httprequest.md
+++ b/docs/integrations/builtin/credentials/httprequest.md
@@ -36,7 +36,6 @@ layout:
 You can use these credentials to authenticate the following nodes:
 
 * [HTTP Request](../core-nodes/n8n-nodes-base.httprequest/)
-* [HTTP Request Tool (legacy)](../../../../integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolhttprequest.md)
 
 ## Prerequisites <a href="#prerequisites" id="prerequisites"></a>
 

--- a/docs/release-notes/1.x.md
+++ b/docs/release-notes/1.x.md
@@ -3091,7 +3091,7 @@ This update also includes support for the `$fromAI` function to dynamically gene
 - In the **Tools panel**, select HTTP **Request Tool.**
 - Configure it just like you would a regular **HTTP Request node** — including advanced options
 
-👉 Learn more about configuring the [HTTP Request tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolhttprequest.md).
+👉 Learn more about configuring the [HTTP Request tool](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.httprequest).
 
 
 ### Scoped API keys <a href="#scoped-api-keys" id="scoped-api-keys"></a>
@@ -5344,7 +5344,7 @@ For full release details, refer to [Releases](https://github.com/n8n-io/n8n/rele
 {% hint style="info" %}
 #### New node: HTTP request tool <a href="#new-node-http-request-tool" id="new-node-http-request-tool"></a>
 
-This release adds the HTTP request tool. You can use it with an AI agent as a tool to collect information from a website or API. Refer to the [HTTP request tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolhttprequest.md) for details.
+This release adds the HTTP request tool. You can use it with an AI agent as a tool to collect information from a website or API. Refer to the [HTTP request tool](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.httprequest) for details.
 {% endhint %}
 
 


### PR DESCRIPTION
Linear: DOC-2052

## What

The HTTP Request Tool sub-node (`toolhttprequest`) was a `not_in_nav` hidden page that wasn't carried over in the migration (`#4876`). Per the team-docs thread (Rowena/Kartik), this repoints its 5 remaining inbound links to the main **HTTP Request node** (`integrations/builtin/core-nodes/n8n-nodes-base.httprequest`).

The other 5 migration-dropped pages (crypto, schemaregistry, vectorstoreoracledb, embeddingsoracledb, OEM token-exchange) were restored separately by docs and already resolve.

## Changes (4 files)

- `build/integrate-ai/understand-ai-components/how-tools-work.md` — repoint (cross-space, matches the sibling tool links' `app.gitbook.com/s/<integrations>` form)
- `integrations/.../agent/tools-agent.md` — repoint (same-space relative)
- `release-notes/1.x.md` (×2) — repoint (cross-space); historical wording kept
- `integrations/builtin/credentials/httprequest.md` — **removed** the redundant `HTTP Request Tool (legacy)` bullet, since the HTTP Request node is already listed on the line directly above it (repointing would have duplicated it)

## Note for review
Link text still reads "HTTP Request Tool" on `how-tools-work` while now pointing at the HTTP Request node — kept minimal; happy to adjust wording if Kartik prefers.

## Verify
- `grep -rn "toolhttprequest" docs/` → no matches.
- GitBook preview: the edited links resolve to the HTTP Request node.