### PR TITLE
DOC-2057: fix broken internal links in reusable-content includes

### DIFF
--- a/docs/reusable-content/.gitbook/includes/integrations/builtin/cluster-nodes/langchain-overview-link.md
+++ b/docs/reusable-content/.gitbook/includes/integrations/builtin/cluster-nodes/langchain-overview-link.md
@@ -1,4 +1,4 @@
 ---
 title: langchain-overview-link
 ---
-View n8n's [Advanced AI](/advanced-ai/index.md) documentation.
+View n8n's [Advanced AI](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/integrate-ai) documentation.

--- a/docs/reusable-content/.gitbook/includes/self-hosting/installation/server-setups-next-steps.md
+++ b/docs/reusable-content/.gitbook/includes/self-hosting/installation/server-setups-next-steps.md
@@ -2,4 +2,4 @@
 title: server-setups-next-steps
 ---
 * Learn more about [configuring](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/basic-configuration/use-environment-variables) and [scaling](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/scaling) n8n.
-* Or explore using n8n: try the [Quickstarts](/try-it-out/index.md).
+* Or explore using n8n: try the [Quickstarts](https://app.gitbook.com/s/CxSeOtVxqqhfxMSac0AV/build-your-first-workflow).


### PR DESCRIPTION
Linear: DOC-2057

## What
Two `{% include %}` snippet files still pointed at old IA paths dropped in the migration (#4876). Includes are embedded across multiple spaces, so relative `.md` can't resolve from them — they need the space-independent `app.gitbook.com/s/<spaceId>/` cross-space form (matching the other links already in these includes). Final follow-up to the broken-internal-links work (Phases 1–3).

## Changes (2 files)
- `reusable-content/.gitbook/includes/integrations/builtin/cluster-nodes/langchain-overview-link.md` — `/advanced-ai/index.md` → integrate-ai
- `reusable-content/.gitbook/includes/self-hosting/installation/server-setups-next-steps.md` — `/try-it-out/index.md` → build-your-first-workflow

## Verify
- `grep -rn "try-it-out/index.md\|advanced-ai/index.md" docs/reusable-content/` → no matches.
- Pages embedding these includes resolve the links in the GitBook preview.

Remaining `<video-id>` placeholder tracked separately in DOC-2058.