### PR TITLE
fix(docs): update link to privacy data collection details in control …

### DIFF
--- a/docs/deploy/host-n8n/configure-n8n/security/control-telemetry.md
+++ b/docs/deploy/host-n8n/configure-n8n/security/control-telemetry.md
@@ -32,7 +32,7 @@ n8n collects some anonymous data from self-hosted n8n installations. Use the ins
 
 ## Collected data <a href="#collected-data" id="collected-data"></a>
 
-Refer to [Privacy | Data collection in self-hosted n8n](https://app.gitbook.com/s/ukPPOMQ6NId4gpAIkPXa/#data-collection-in-self-hosted-n8n) for details on the data n8n collects.
+Refer to [Privacy | Data collection in self-hosted n8n](../../../../privacy-and-security/privacy.md#data-collection-in-self-hosted-n8n) for details on the data n8n collects.
 
 ## How collection works <a href="#how-collection-works" id="how-collection-works"></a>
 


### PR DESCRIPTION
…telemetry guide

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the "Collected data" link in the Control telemetry doc to point to the internal privacy page instead of the outdated GitBook URL, ensuring readers reach the correct data collection details.

<sup>Written for commit 733496bcd05a72e22c2e10190ae10cabc63848e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

