### PR TITLE
docs: Fix stale S3 license-expiry hint in external storage

### DIFF
--- a/docs/deploy/host-n8n/configure-n8n/scaling/use-external-storage.md
+++ b/docs/deploy/host-n8n/configure-n8n/scaling/use-external-storage.md
@@ -35,7 +35,7 @@ n8n supports [AWS S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welc
 {% hint style="info" %}
 **Enterprise-tier feature**
 
-You will need an [Enterprise license key](../manage-your-license.md) for external storage. If your license key expires and you remain on S3 mode, the instance will be able to read from, but not write to, the S3 bucket.
+You will need an [Enterprise license key](../manage-your-license.md) for external storage. n8n won't start in `s3` binary data mode without a valid license: set `N8N_DEFAULT_BINARY_DATA_MODE` to another mode or upgrade your license.
 {% endhint %}
 
 ### Setup <a href="#setup" id="setup"></a>


### PR DESCRIPTION
## What

Fixes the stale S3 "Enterprise-tier feature" hint on the [Use external storage](https://docs.n8n.io/deploy/host-n8n/configure-n8n/scaling/use-external-storage) page.

**Before:**
> If your license key expires and you remain on S3 mode, the instance will be able to read from, but not write to, the S3 bucket.

**After:**
> n8n won't start in `s3` binary data mode without a valid license: set `N8N_DEFAULT_BINARY_DATA_MODE` to another mode or upgrade your license.

## Why

The described read-only degradation is no longer accurate. In `base-command.ts`, the S3 binary-data write-mode block now calls `process.exit(1)` on startup when the `feat:binaryDataS3` license is missing — it refuses to start rather than running read-only. This matches the Azure behavior documented in #4880; this PR aligns the S3 wording with it.

Verified against n8n-io/n8n#32837 (Azure binary-data parity, merged).

Ref: DOC-2064