### PR TITLE
docs: fix broken Endpoint reference / API reference links on n8n API pages (DOC-2068)

### DIFF
--- a/docs/connect/SUMMARY.md
+++ b/docs/connect/SUMMARY.md
@@ -5,6 +5,7 @@
   * [Authentication](n8n-api/authentication.md)
   * [Pagination](n8n-api/pagination.md)
   * [Use an API playground](n8n-api/use-an-api-playground.md)
+  * [Endpoint reference](n8n-api/api-reference.md)
   * ```yaml
     props:
       models: true

--- a/docs/connect/n8n-api/README.md
+++ b/docs/connect/n8n-api/README.md
@@ -32,7 +32,7 @@ Using n8n's public API[^1], you can programmatically perform many of the same ta
 * How to [authenticate](authentication.md)
 * [Paginating](pagination.md) results
 * Using the [built-in API playground](use-an-api-playground.md) (self-hosted n8n only)
-* [Endpoint reference](api-reference.md)
+* The [endpoint reference](api-reference.md)
 
 n8n provides an [n8n API node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.n8n) to access the API in your workflows.
 

--- a/docs/connect/n8n-api/api-reference.md
+++ b/docs/connect/n8n-api/api-reference.md
@@ -1,0 +1,39 @@
+---
+description: Endpoint reference for n8n's public REST API, generated from the OpenAPI specification.
+contentType: reference
+nodeTitle: Endpoint reference
+originalFilePath: api/api-reference.md
+originalUrl: 'https://docs.n8n.io/api/api-reference'
+url: 'https://docs.n8n.io/connect/n8n-api/api-reference'
+layout:
+  description:
+    visible: false
+---
+
+# Endpoint reference
+
+This section is the complete endpoint reference for n8n's public REST API, generated from the OpenAPI specification. Use it to explore every available operation and view the parameters, request bodies, and response schemas.
+
+{% hint style="info" %}
+**Feature availability**
+
+The n8n API isn't available during the free trial. Please upgrade to access this feature.
+{% endhint %}
+
+## Before you start
+
+* **Authenticate**: every request needs an API key. Refer to [Authentication](authentication.md).
+* **Set your base URL**:
+    * n8n Cloud: `https://<your-instance>.app.n8n.cloud/api/v1`
+    * Self-hosted: `https://<your-domain>/api/v1`
+* **Paginate** large result sets. Refer to [Pagination](pagination.md).
+
+## Browse the endpoints
+
+The endpoints are grouped by resource in the left sidebar under **n8n API**: Workflow, Execution, Credential, User, Audit, Tags, Source Control, Variables, Data Table, Projects, and more. Each page documents that resource's operations and schemas.
+
+{% hint style="info" %}
+**Try the API safely**
+
+To experiment with live calls, use the [built-in API playground](use-an-api-playground.md) (self-hosted n8n only), or point requests at a test workflow or test instance.
+{% endhint %}

--- a/docs/connect/n8n-api/use-an-api-playground.md
+++ b/docs/connect/n8n-api/use-an-api-playground.md
@@ -16,7 +16,7 @@ This documentation site provides a playground to test out calls. Self-hosted use
 
 ## Documentation playground <a href="#documentation-playground" id="documentation-playground"></a>
 
-You can test API calls from this site's [API reference](api-reference.md). You need to set your server's base URL and instance name, and add an API key.
+You can test API calls from this site's [endpoint reference](api-reference.md). You need to set your server's base URL and instance name, and add an API key.
 
 n8n uses [Scalar's](https://github.com/scalar/scalar) open source API platform to power this functionality.
 


### PR DESCRIPTION
Closes DOC-2068.

## Problem
The **Endpoint reference** link on the [n8n API overview](https://docs.n8n.io/connect/n8n-api) and the **API reference** link on [Use an API playground](https://docs.n8n.io/connect/n8n-api/use-an-api-playground) are broken. Both point at `api-reference.md`, which does not exist in the space, so GitBook falls them back to the raw GitHub source URL and they 404. Reported in #mission-docs.

## Root cause
The GitBook migration (#4876) replaced the old Scalar-based `api-reference.md` page with the native `builtin:openapi` block (the per-tag endpoint pages, which render fine), but deleted the landing page while leaving the two links pointing at it. Broken since the migration — not caused by a recent PR.

## Provenance check (n8n-docs-next)
Confirmed against the pre-migration page on the `iain/prerelease` branch of `n8n-docs-next` (`gitbook/connect/n8n-api/api-reference.md`). That version is the **old Scalar/MkDocs embed** (`template: api.html` + `@scalar/api-reference` script loading `/api/v1/openapi.yml`, which #4876 also deleted), so it is **not** restored verbatim — that would reintroduce a broken embed and duplicate the native OpenAPI pages. It was used only to confirm the original slug (`/connect/n8n-api/api-reference`) and metadata (`originalFilePath`/`originalUrl`), which are carried into the new page.

## Fix
- Add a thin, GitBook-native `docs/connect/n8n-api/api-reference.md` landing page (intro + auth/base-URL pointers + link into the auto-generated endpoint pages).
- Add `* [Endpoint reference](n8n-api/api-reference.md)` to `docs/connect/SUMMARY.md`, immediately before the `builtin:openapi` block.
- No change to the two links — they resolve once the target exists.

## Verify on the preview
- On both pages, the link stays on-site (the external `↗` arrow disappears; no more GitHub 404).
- The new landing page renders above the OpenAPI endpoint pages in the sidebar.

## Follow-up (separate ticket)
CI missed this because lychee excludes `docs.n8n.io` and sets a URL base, so internal/relative links are never checked. Worth adding an internal-link lychee pass.