### PR TITLE
docs: fix broken internal links from the GitBook migration (DOC-2069)

### DIFF
--- a/docs/administer/use-source-control-and-environments/README.md
+++ b/docs/administer/use-source-control-and-environments/README.md
@@ -26,7 +26,7 @@ In this section:
 	* [Git and n8n](use-git-in-n8n.md): How n8n uses Git. 
 	* [Branch patterns](choose-branching-patterns.md): The possible relationships between n8n instances and Git branches.
 * [Set up source control for environments](set-up-source-control.md): How to connect your n8n instance to Git.
-* [Using](/source-control-environments/using/index.md):
+* Using:
 	* [Push and pull](push-and-pull-changes.md): Send work to Git, and fetch work from Git to your instance.
 	* [Copy work between environments](move-work-between-environments.md): How to copy work between different n8n instances.
 * [Tutorial: Create environments with source control](tutorial-create-environments-with-source-control.md): An end-to-end tutorial, setting up environments using n8n's recommended configurations.

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/common-issues.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/common-issues.md
@@ -74,6 +74,6 @@ To resolve this, click the + Chat Model button at the bottom of your screen when
 
 ## No prompt specified error <a href="#no-prompt-specified-error" id="no-prompt-specified-error"></a>
 
-This error occurs when the agent expects to get the prompt from the previous node automatically. Typically, this happens when you're using the [Chat Trigger Node](../../../core-nodes/n8n-nodes-base.compression/n8n-nodes-base.compression.md).
+This error occurs when the agent expects to get the prompt from the previous node automatically. Typically, this happens when you're using the [Chat Trigger Node](../../../core-nodes/n8n-nodes-langchain.chattrigger/README.md).
 
 To resolve this issue, find the **Prompt** parameter of the AI Agent node and change it from **Connected Chat Trigger Node** to **Define below**. This allows you to manually build your prompt by referencing output data from other nodes or by adding static text.

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
@@ -223,7 +223,7 @@ When enabled, the AI Agent sends data back to the user in real-time as it genera
 {% hint style="info" %}
 **Streaming requirements**
 
-For streaming to work, your workflow must use a trigger that supports streaming responses, such as the [Chat Trigger](../../../core-nodes/n8n-nodes-base.compression/n8n-nodes-base.compression.md) or [Webhook](../../../core-nodes/n8n-nodes-base.webhook/) node with **Response Mode** set to **Streaming**.
+For streaming to work, your workflow must use a trigger that supports streaming responses, such as the [Chat Trigger](../../../core-nodes/n8n-nodes-langchain.chattrigger/README.md) or [Webhook](../../../core-nodes/n8n-nodes-base.webhook/) node with **Response Mode** set to **Streaming**.
 {% endhint %}
 
 ## Templates and examples <a href="#templates-and-examples" id="templates-and-examples"></a>

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.chat.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.chat.md
@@ -127,7 +127,7 @@ Refer to the [Chat Trigger](n8n-nodes-langchain.chattrigger/README.md) node docu
 
 ## Templates and examples <a href="#templates-and-examples" id="templates-and-examples"></a>
 
-[Browse Chat node documentation integration templates](https://n8n.io/integrations/chat) or [search all templates](https://n8n.io/workflows/)
+[Browse n8n integration templates](https://n8n.io/integrations/) or [search all templates](https://n8n.io/workflows/)
 
 ## Common issues <a href="#common-issues" id="common-issues"></a>
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.chat.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.chat.md
@@ -18,12 +18,12 @@ layout:
 
 # Chat node <a href="#chat-node" id="chat-node"></a>
 
-Use the Chat node with the [Chat Trigger](n8n-nodes-base.compression/n8n-nodes-base.compression.md) node to send messages into the chat and optionally wait for responses from users. This enables human-in-the-loop (HITL) use cases in chat workflows, allowing you to have multiple chat interactions within a single execution. The Chat node also works as a tool for AI Agents.
+Use the Chat node with the [Chat Trigger](n8n-nodes-langchain.chattrigger/README.md) node to send messages into the chat and optionally wait for responses from users. This enables human-in-the-loop (HITL) use cases in chat workflows, allowing you to have multiple chat interactions within a single execution. The Chat node also works as a tool for AI Agents.
 
 {% hint style="info" %}
 **Chat Trigger node**
 
-The Chat node requires a [Chat Trigger](n8n-nodes-base.compression/n8n-nodes-base.compression.md) node to be present in the workflow, with the [Response Mode](n8n-nodes-base.compression/n8n-nodes-base.compression.md#response-mode) set to 'Using Response Nodes'.
+The Chat node requires a [Chat Trigger](n8n-nodes-langchain.chattrigger/README.md) node to be present in the workflow, with the [Response Mode](n8n-nodes-langchain.chattrigger/README.md#response-mode) set to 'Using Response Nodes'.
 {% endhint %}
 
 {% hint style="warning" %}
@@ -123,7 +123,7 @@ The Approval response type also offers the following option:
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/mjXhKRIw98UJ5hk9LWBl/" %}
 
-Refer to the [Chat Trigger](n8n-nodes-base.compression/n8n-nodes-base.compression.md) node documentation for information about setting up the chat interface.
+Refer to the [Chat Trigger](n8n-nodes-langchain.chattrigger/README.md) node documentation for information about setting up the chat interface.
 
 ## Templates and examples <a href="#templates-and-examples" id="templates-and-examples"></a>
 
@@ -136,4 +136,4 @@ Refer to the [Chat Trigger](n8n-nodes-base.compression/n8n-nodes-base.compressio
 - The Chat node doesn't work when used in a subworkflow. This includes usage in a subworkflow that's being used as a tool for an AI Agent.
 - Make sure the Chat Trigger node's Response Mode is set to "Using Response Nodes" for the Chat node to function properly.
 
-For common questions or issues with the Chat Trigger node, refer to [Common Chat Trigger Node Issues](n8n-nodes-base.compression/common-issues.md).
+For common questions or issues with the Chat Trigger node, refer to [Common Chat Trigger Node Issues](n8n-nodes-langchain.chattrigger/common-issues.md).

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/common-issues.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/common-issues.md
@@ -22,7 +22,7 @@ layout:
 
 # Chat Trigger node common issues <a href="#chat-trigger-node-common-issues" id="chat-trigger-node-common-issues"></a>
 
-Here are some common errors and issues with the [Chat Trigger node](n8n-nodes-base.compression.md) and steps to resolve or troubleshoot them.
+Here are some common errors and issues with the [Chat Trigger node](README.md) and steps to resolve or troubleshoot them.
 
 ## Pass data from a website to an embedded Chat Trigger node <a href="#pass-data-from-a-website-to-an-embedded-chat-trigger-node" id="pass-data-from-a-website-to-an-embedded-chat-trigger-node"></a>
 
@@ -45,7 +45,7 @@ The `metadata` field can contain arbitrary data that will appear in the Chat Tri
 
 When you configure a Chat Trigger node, you might experience problems fetching previous messages if you aren't careful about how you configure session loading. This often manifests as a `workflow could not be started!` error.
 
-In Chat Triggers, the **Load Previous Session** option retrieves previous chat messages for a session using the `sessionID`. When you set the **Load Previous Session** option to **From memory**, it's almost always best to [connect the same memory node](n8n-nodes-base.compression.md#load-previous-session) to both the Chat Trigger and the Agent in your workflow:
+In Chat Triggers, the **Load Previous Session** option retrieves previous chat messages for a session using the `sessionID`. When you set the **Load Previous Session** option to **From memory**, it's almost always best to [connect the same memory node](README.md#load-previous-session) to both the Chat Trigger and the Agent in your workflow:
 
 1. In your **Chat Trigger** node, set the **Load Previous Session** option to **From Memory**. This is only visible if you've made the chat publicly available.
 2. Attach a **Simple Memory** node to the **Memory** connector.

--- a/docs/integrations/builtin/credentials/microsoftagent365.md
+++ b/docs/integrations/builtin/credentials/microsoftagent365.md
@@ -20,7 +20,7 @@ layout:
 
 You can use these credentials to authenticate the following nodes:
 
-- [Microsoft Agent 365 Trigger](../cluster-nodes/root-nodes/root-nodes.md)
+- [Microsoft Agent 365 Trigger](../cluster-nodes/root-nodes/n8n-nodes-langchain.microsoftagent365trigger.md)
 
 {% hint style="warning" %}
 **Early preview**

--- a/docs/integrations/builtin/credentials/oracledb.md
+++ b/docs/integrations/builtin/credentials/oracledb.md
@@ -35,10 +35,10 @@ layout:
 
 You can use these credentials to authenticate the following nodes:
 
-* [OracleDB](../app-nodes/app-nodes.md)
+* [OracleDB](../app-nodes/n8n-nodes-base.oracledb.md)
 * [Agent](../cluster-nodes/root-nodes/n8n-nodes-langchain.agent/)
-* [Oracle Database Vector Store](../../../../integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreoracledb.md)
-* [Embeddings Oracle Database](../../../../integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsoracledb.md)
+* [Oracle Database Vector Store](../cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreoracledb.md)
+* [Embeddings Oracle Database](../cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsoracledb.md)
 
 {% hint style="info" %}
 These nodes do not support SSH tunnels. They require Oracle Database **19c or later**. For advanced Oracle Database features like Transparent Application Continuity (TAC) and Sharding, they also require Oracle Client Libraries **19c or later**.


### PR DESCRIPTION
Closes DOC-2069. Follow-up to DOC-2068.

## Context
A repo-wide sweep for relative `.md` links whose target file does not exist found 13 broken internal links, all fallout from the GitBook migration (a bad find/replace, relocated paths, and a stale MkDocs-era absolute link). On docs.n8n.io these fall back to a GitHub source URL that 404s. None of the affected pages are `generated: true`.

## Fixes (link text was correct; only the target path was wrong)

**"Chat Trigger" links wrongly pointing at the Compression node** (find/replace corruption):
- `core-nodes/n8n-nodes-langchain.chat.md` (×5 links) -> Chat Trigger node page + `#response-mode`, and Common Issues page
- `cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md`, `.../common-issues.md` -> Chat Trigger node page
- `core-nodes/n8n-nodes-langchain.chattrigger/common-issues.md` (×2) -> its own `README.md` + `#load-previous-session`

**Wrong target / relative depth:**
- `credentials/microsoftagent365.md` -> `n8n-nodes-langchain.microsoftagent365trigger.md`
- `credentials/oracledb.md` -> fixed OracleDB app-node link; removed extra `../` on the vector-store and embeddings links (they climbed above `docs/`)

**Stale MkDocs-era absolute link:**
- `administer/use-source-control-and-environments/README.md` -> `Using` was a grouping label pointing at `/source-control-environments/using/index.md` (no such page; nav is flat). Unlinked it, kept its sub-bullets.

## Verification
- Internal-link sweep now reports **0 broken** (excluding the intentional example links in `docs/contribute/style-guide-for-n8n-docs.md`).
- Spot-check on the GitBook PR preview: each fixed link stays on-site (no `↗` / GitHub 404).

## Related
- DOC-2068 (API reference link)
- DOC-2070 (CI check to catch this class going forward)