### PR TITLE
docs: Remove link to github file after copying that content to docs

### DIFF
--- a/docs/connect/n8n-cli.md
+++ b/docs/connect/n8n-cli.md
@@ -194,4 +194,4 @@ n8n-cli package import --file=export.n8np --conflict-policy=fail
 n8n-cli package import --file=export.n8np --project=<project-id> --workflow-id-policy=source --conflict-policy=skip
 ```
 
-See [n8n packages](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/n8n-packages) for what a package contains and how n8n resolves conflicts on import, and the [`package import` command reference](https://github.com/n8n-io/n8n/blob/master/packages/%40n8n/cli/docs/commands/package.md#package-import) for the available arguments.
+See [n8n packages](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/n8n-packages) for a detailed overview of the available flags and what makes up a package.


### PR DESCRIPTION
Removes the link to a github markdown file from https://docs.n8n.io/connect/n8n-cli#export-and-import-packages

The link to github is no longer needed since the content was copied to our docs in https://github.com/n8n-io/n8n-docs/pull/4953/commits/0c5c87896920047d8225c4ed0e7199e98ff78367

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the GitHub command reference link from `docs/connect/n8n-cli.md` and now link to our “n8n packages” page that covers flags and package contents. This consolidates import/export docs on the new site per LIGO-770.

<sup>Written for commit 60cda0512b12dba62ae7b5f133e1376a1908b75f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

