### PR TITLE
docs: update GitBook include link in changelog

### DIFF
--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -6,7 +6,7 @@ Every n8n release moves the platform forward. The changelog is where we call out
 For complete, version-by-version detail on every release, see the [Releases page](https://github.com/n8n-io/n8n/releases) on GitHub. This changelog covers stable n8n 2.x releases onward; release notes for [1.x](release-notes-1.x.md) and [0.x](release-notes-0.x.md) remain archived.
 {% endhint %}
 
-{% include "https://app.gitbook.com/s/Pv5qtwcPHKJKdJPRJTs2/~/reusable/rUuvvFUxRYV3Lyc96WOk/" %}
+{% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/iFLUKG9zJaouigaM7IOo/" %}
 
 ### n8n 2.22 — Connect to MCP servers with less setup
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Point the changelog to the new GitBook reusable include so it shows the correct current stable and beta versions. Addresses Linear DOC-2075.

<sup>Written for commit bd29f6a610f65be8c6f15247dfe8fafd233e296f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

