### PR TITLE
docs: clean up formatting and improve clarity in testing instructions

### DIFF
--- a/docs/reusable-content/.gitbook/includes/integrations/creating-nodes/testing.md
+++ b/docs/reusable-content/.gitbook/includes/integrations/creating-nodes/testing.md
@@ -13,30 +13,54 @@ You can test your node as you build it by running it in a local n8n instance.
   npm run build
   npm link
   ```
-3. Install the node into your local n8n instance:<br>
-  ```shell
-  # In the nodes directory within your n8n installation
-  # node-package-name is the name from the package.json
-  npm link <node-package-name>
-  ```
+3. Install the node into your local n8n instance:
+	```shell
+	# In the nodes directory within your n8n installation
+	# node-package-name is the name from the package.json
+	npm link <node-package-name>
+	```
 
-    <div data-gb-custom-block data-tag="hint" data-style="info" class="hint hint-info"><p><strong>Check your directory</strong></p><p>Make sure you run <code>npm link &lt;node-name&gt;</code> in the nodes directory within your n8n installation. This can be:</p><ul><li><code>~/.n8n/custom/</code></li><li><code>~/.n8n/&lt;your-custom-name&gt;</code>: if your n8n installation set a different name using <code>N8N_CUSTOM_EXTENSIONS</code>.</li></ul></div>
+	{% hint style="info" %}
+	**Check your directory**
+
+	Make sure you run `npm link <node-name>` in the nodes directory within your n8n installation.
+
+	The default location depends on your operating system:
+	- For Windows: `C:\Users\<username>\.n8n\custom`
+	- For Linux: `/home/<username>/.n8n/custom`
+	- For MacOS: `/Users/<username>/.n8n/custom`
+
+	If your n8n installation set a different name using `N8N_CUSTOM_EXTENSIONS`, use that custom directory instead.
+
+	Note: The `.n8n` folder is a hidden folder so it may not appear in your file browser.
+	{% endhint %}
 
 4. Start n8n:
   ```
   n8n start
   ```
-5. Open n8n in your browser. You should see your nodes when you search for them in the nodes panel.<br>
+5. Open n8n in your browser. You should see your nodes when you search for them in the nodes panel.
 
-    <div data-gb-custom-block data-tag="hint" data-style="info" class="hint hint-info"><p><strong>Node names</strong></p><p>Make sure you search using the node name, not the package name. For example, if your npm package name is <code>n8n-nodes-weather-nodes</code>, and the package contains nodes named <code>rain</code>, <code>sun</code>, <code>snow</code>, you should search for <code>rain</code>, not <code>weather-nodes</code>.</p></div>
+	{% hint style="info" %}
+	**Node names**
+
+	Make sure you search using the node name, not the package name. For example, if your npm package name is `n8n-nodes-weather-nodes`, and the package contains nodes named `rain`, `sun`, `snow`, you should search for `rain`, not `weather-nodes`.
+	{% endhint %}
 
 ### Troubleshooting <a href="#troubleshooting" id="troubleshooting"></a>
 
-If there's no `custom` directory in `~/.n8n` local installation, you have to create `custom` directory manually and run `npm init`:
+If there's no `custom` directory in your `.n8n` local installation, you have to create the `custom` directory manually and run `npm init`.
+
+The `.n8n` directory location depends on your operating system:
+- For Windows: `C:\Users\<username>\.n8n\custom`
+- For Linux: `/home/<username>/.n8n/custom`
+- For MacOS: `/Users/<username>/.n8n/custom`
+
+Note: The `.n8n` folder is a hidden folder so it may not appear in your file browser.
 
 ```shell
-# In ~/.n8n directory run <a href="#in-n8n-directory-run" id="in-n8n-directory-run"></a>
-mkdir custom 
-cd custom 
+# Navigate to your .n8n directory and run:
+mkdir custom
+cd custom
 npm init
 ```


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up the “Testing custom nodes” docs to make setup clearer and more consistent. Adds OS-specific default paths and clarifies where to run `npm link` and how to find nodes in the UI.

- **Refactors**
  - Replaced HTML callouts with GitBook hint blocks.
  - Clarified install steps: run `npm link <node-package-name>` in the n8n nodes directory; added OS-specific default locations, `N8N_CUSTOM_EXTENSIONS` guidance, and a note about the hidden `.n8n` folder.
  - Added guidance to search by node name (not the package name).
  - Simplified troubleshooting with exact shell commands to create `custom` and run `npm init`.

<sup>Written for commit 39c36baebe63fa211cd55607affeb2d2806d5fe0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

