### PR TITLE
docs: relabel AI Assistant env-var page to Ask n8n AI in Deploy nav

### DIFF
--- a/docs/deploy/SUMMARY.md
+++ b/docs/deploy/SUMMARY.md
@@ -29,7 +29,7 @@
   * [Configure n8n](host-n8n/configure-n8n/README.md)
     * [Basic configuration](host-n8n/configure-n8n/basic-configuration.md)
       * [Use environment variables](host-n8n/configure-n8n/basic-configuration/use-environment-variables/README.md)
-        * [AI Assistant](host-n8n/configure-n8n/basic-configuration/use-environment-variables/ai-assistant.md)
+        * [Ask n8n AI](host-n8n/configure-n8n/basic-configuration/use-environment-variables/ai-assistant.md)
         * [Binary data](host-n8n/configure-n8n/basic-configuration/use-environment-variables/binary-data.md)
         * [Credentials](host-n8n/configure-n8n/basic-configuration/use-environment-variables/credentials.md)
         * [Database](host-n8n/configure-n8n/basic-configuration/use-environment-variables/database.md)

--- a/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/ai-assistant.md
+++ b/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/ai-assistant.md
@@ -1,13 +1,13 @@
 ---
-title: AI Assistant environment variables
-description: Environment variables to configure AI Assistant.
+title: Ask n8n AI environment variables
+description: Environment variables to configure Ask n8n AI.
 contentType: reference
 tags:
   - environment variables
 hide:
   - toc
   - tags
-nodeTitle: AI Assistant
+nodeTitle: Ask n8n AI
 originalFilePath: hosting/configuration/environment-variables/ai-assistant.md
 originalUrl: 'https://docs.n8n.io/hosting/configuration/environment-variables/ai-assistant'
 url: >-
@@ -17,8 +17,8 @@ layout:
     visible: false
 ---
 
-# AI Assistant environment variables <a href="#ai-assistant-environment-variables" id="ai-assistant-environment-variables"></a>
+# Ask n8n AI environment variables <a href="#ai-assistant-environment-variables" id="ai-assistant-environment-variables"></a>
 
 | Variable | Type  | Default  | Description |
 | :------- | :---- | :------- | :---------- |
-| `N8N_AI_ASSISTANT_BASE_URL` | String | (empty) | Base URL of the AI assistant service, specified as `https://ai-assistant.n8n.io `. Required if you self-host n8n and want to enable the AI Assistant. |
+| `N8N_AI_ASSISTANT_BASE_URL` | String | (empty) | Base URL of the AI assistant service, specified as `https://ai-assistant.n8n.io `. Required if you self-host n8n and want to enable Ask n8n AI. |


### PR DESCRIPTION
## What

Relabels the environment-variable reference page in **Deploy** from **AI Assistant** to **Ask n8n AI**.

This page documents the legacy help assistant (`N8N_AI_ASSISTANT_BASE_URL`). The old label collided with the new **AI Assistant (Preview)** feature, so this frees up "AI Assistant" and matches the build-section page already named [Ask n8n AI](https://docs.n8n.io/build/ways-of-building-workflows/use-the-ai-assistant).

## Changes

- `docs/deploy/SUMMARY.md` — sidebar nav label `AI Assistant` → `Ask n8n AI`
- `docs/deploy/.../use-environment-variables/ai-assistant.md` — `title`, `description`, `nodeTitle`, H1, and body prose relabeled

## Not changed (no breakage)

- Env var name `N8N_AI_ASSISTANT_BASE_URL`
- Page slug (`ai-assistant`) — no redirect needed
- Anchor id `#ai-assistant-environment-variables` — existing deep links keep working

Ref: DOC-2079