### PR TITLE
docs: document async and partial workflow publication states

### DIFF
--- a/docs/build/understand-workflows/save-and-publish-workflows.md
+++ b/docs/build/understand-workflows/save-and-publish-workflows.md
@@ -41,6 +41,8 @@ Publishing makes your workflow live and locks it to a specific version. Producti
 * Schedules will run at the times you've defined
 * Events from connected apps will trigger this workflow
 
+Publishing is asynchronous. When you publish, n8n works out which triggers changed between your last published version and the new one, then applies only those changes in the background. Triggers that haven't changed keep running without interruption. The new version goes live as part of this process. The **Publish** button shows a **Publishing** state until n8n confirms the result, which it does even if you reload the page.
+
 **Initial state** When you open a workflow with no publishable changes, the Publish button is disabled.
 
 ![](../.gitbook/assets/publish-initial.png)
@@ -64,6 +66,12 @@ Publishing makes your workflow live and locks it to a specific version. Producti
 **Published, error** The workflow is published, but there are errors in your recent changes that need to be fixed before you can publish again.
 
 ![](../.gitbook/assets/published-error.png)
+
+**Publishing** After you publish, n8n registers your triggers in the background. The button shows this state until n8n confirms the result.
+
+**Published, partial** n8n published the new version, but at least one trigger failed to activate, for example because a connected app was unavailable. The workflow keeps running the triggers that did activate, and n8n doesn't unpublish it. Hover over the button to see which triggers failed, then publish again to retry them.
+
+**Failed to publish** None of the workflow's triggers activated, so the workflow isn't running. The published version stays set, so you can publish again to retry.
 
 ## How collaboration works <a href="#how-collaboration-works" id="how-collaboration-works"></a>
 


### PR DESCRIPTION
## What

Documents the user-facing behavior of the [Workflow Publication Service](https://linear.app/n8n/project/workflow-publication-service-ad1426810801) on the **Save and publish workflows** page.

Changes to `docs/build/understand-workflows/save-and-publish-workflows.md`:

- **Async publishing paragraph** in "How publishing works": publishing is asynchronous, n8n applies only the trigger changes between versions, unchanged triggers keep running without interruption, and the button resolves once n8n confirms the result (surviving reload).
- **Three new Publish button states**: `Publishing`, `Published, partial` (the workflow stays published with the triggers that activated; no auto-unpublish; re-publish to retry), and `Failed to publish`.

## Why draft / hold merge

This behavior is gated behind the `useWorkflowPublicationService` feature flag, which is still in **gradual rollout** (the flag isn't on by default yet, and CAT-3202 "remove the flag once stable" is still open). The page now reads as if this is the default behavior, so **hold the merge until the flag is on by default.**

## Scope notes

- Publish page only, per scoping discussion.
- No screenshots for the new states (visual differences are minor).
- Possible future follow-ups once the flag is default: queue-mode/multi-main docs and the "cron triggers keep running after import" known-issue note in `use-the-command-line.md`. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents asynchronous publishing and partial publish outcomes on the Save and publish workflows page to align with the Workflow Publication Service. Explains that only changed triggers are applied and adds the new Publish button states.

- **New Features**
  - Added Publish button states: Publishing; Published, partial; Failed to publish.
  - For partial publishes: workflow stays published; hover to see failed triggers; publish again to retry.

- **Migration**
  - Behavior is behind the `useWorkflowPublicationService` feature flag; merge when the flag is on by default.

<sup>Written for commit a9953c86f71287021a4fe93ad53e441013bb241b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

