### PR TITLE
fix(changelog): correct packages entry to n8n 2.27 (2026-06-16)

### DIFF
--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -8,9 +8,9 @@ For complete, version-by-version detail on every release, see the [Releases page
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/iFLUKG9zJaouigaM7IOo/" %}
 
-### n8n 2.24 — Move workflows between instances as packages
+### n8n 2.27 — Move workflows between instances as packages
 
-**Released:** 2026-07-03
+**Released:** 2026-06-16
 
 You can now bundle workflows into a portable `.n8np` package and move them between n8n instances through the Public API or a matching set of CLI commands that wrap the same endpoints. Copying workflow JSON by hand always worked for one-off moves. Packages make it repeatable and automatable, carrying a set of workflows along with their credential stubs and a `manifest.json` describing their dependencies in a single file.
 


### PR DESCRIPTION
## What

Corrects the **n8n packages** changelog entry (added in #4968) from **2.24 / 2026-07-03** to **2.27 / 2026-06-16** — the release where the feature actually shipped.

## Why

The original coordinates were internally inconsistent: the 2.29 entry released 2026-06-30, so a "2.24" entry cannot be dated 2026-07-03 (after it). Checking the n8n repo, the packages **workflow** export/import capability the entry describes — portable `.n8np` format, Public API **and CLI**, conflict policies, credential stubs — all landed together in **n8n 2.27.0 (2026-06-16)**.

Verified by commit containment against release tags (not just merge dates):

| PR | Capability | First release containing it |
|----|-----------|------------------------------|
| [#31798](https://github.com/n8n-io/n8n/pull/31798) | `workflowConflictPolicy` (conflict policies) | `n8n@2.27.0` |
| [#32228](https://github.com/n8n-io/n8n/pull/32228) | `credentialBindings` (credential stubs) | `n8n@2.27.0` |
| [#32111](https://github.com/n8n-io/n8n/pull/32111) | CLI export/import commands | `n8n@2.27.0` |

The `.0` release date for `n8n@2.27.0` is 2026-06-16. (Later project/folder export work is 2.30 / July and isn't what this entry covers.)

## Change

- Heading: `### n8n 2.24 —` → `### n8n 2.27 —`
- `**Released:** 2026-07-03` → `**Released:** 2026-06-16`

Ordering stays newest-first (2.27 above 2.22). No copy changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
