### PR TITLE
fix(vale): omit endtab from spellcheck

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -6,4 +6,4 @@ BasedOnStyles = from-write-good, n8n-styles, from-microsoft, Vale
 Vale.Terms = NO
 from-alex.Profanity = NO
 from-microsoft.Quotes = NO
-TokenIgnores = (\-\-8\<\-\- \".*\"), (-only), (\*\*.*\*\*), (\*\*Release date:\*\*.*), (\[\[\%.*\%\]\]), (\[\[.*\]\]), (Rocket\.Chat), (\(https.*\)),
+TokenIgnores = (\-\-8\<\-\- \".*\"), (-only), (\*\*.*\*\*), (\*\*Release date:\*\*.*), (\[\[\%.*\%\]\]), (\[\[.*\]\]), (Rocket\.Chat), (\(https.*\)), (\{%.*?%\}),


### PR DESCRIPTION
## Summary

Stops Vale from flagging `endtab` (and other Jinja macro keywords) as spelling errors.

Vale's `Vale.Spelling` rule was raising errors like:

```
[Vale.Spelling] Did you really mean 'endtab'?
```

on any changed line containing a `{% endtab %}` tab macro — e.g. `docs/integrations/builtin/credentials/slack.md:284`. These macros are valid template syntax used across ~19 docs files, not prose.

## Change

Added `(\{%.*?%\})` to `TokenIgnores` in [.vale.ini](.vale.ini), so Vale skips the contents of `{% ... %}` Jinja macro tags when spell-checking.

- The non-greedy `.*?` matches each tag individually, so multiple tags on one line are handled correctly.
- Covers `tab`, `tabs`, `endtab`, `endtabs`, and any future macro keyword in one rule — rather than whitelisting each word in `accept.txt`, which would also allow those words as valid prose anywhere.
