### PR TITLE
ci(vale): ignore GitBook {% ... %} liquid tags (DOC-2084)

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -6,4 +6,4 @@ BasedOnStyles = from-write-good, n8n-styles, from-microsoft, Vale
 Vale.Terms = NO
 from-alex.Profanity = NO
 from-microsoft.Quotes = NO
-TokenIgnores = (\-\-8\<\-\- \".*\"), (-only), (\*\*.*\*\*), (\*\*Release date:\*\*.*), (\[\[\%.*\%\]\]), (\[\[.*\]\]), (Rocket\.Chat), (\(https.*\)),
+TokenIgnores = (\-\-8\<\-\- \".*\"), (-only), (\*\*.*\*\*), (\*\*Release date:\*\*.*), (\[\[\%.*\%\]\]), (\[\[.*\]\]), (Rocket\.Chat), (\(https.*\)), (\{%[^%]*%\}),


### PR DESCRIPTION
## What

Makes Vale ignore GitBook `{% ... %}` liquid tags. Resolves DOC-2084.

Vale was flagging liquid closing tags — `endhint`, `endstep`, `endtabs`, `endtab`, `endcontent`, `endcolumn`, `endcode`, `endfile`, `endembed` — as `Vale.Spelling` **errors**, because the `{% ... %}` tag wasn't ignored and Vale read the concatenated tag name as a misspelled word. Vale runs on the whole `docs/` tree, so this turned the `vale` check **red on essentially every docs PR** (`endhint` alone appears ~1377 times). It was first reported on the n8n Packages PR (#4953).

## Change

One line — add `(\{%[^%]*%\})` to the `TokenIgnores` list in `.vale.ini`, so Vale skips the contents of liquid tags.

## Verification

- Sample files (`administer/README.md`, `connect/n8n-cli.md`, `build/manage-workflows/n8n-packages.md`, `build/README.md`): **many `Vale.Spelling` errors → 0**, with no `end*` liquid-tag errors remaining.
- **No regression**: the rule only ignores text *inside* `{% %}`. A real prose typo outside a block is still caught (verified: `sentance` → still flagged, `endhint` inside `{% endhint %}` → ignored).
