### PR TITLE
docs: clarify Code node limitations for DateTime methods and variables

### DIFF
--- a/docs/build/code-in-n8n/use-built-in-shortcuts.md
+++ b/docs/build/code-in-n8n/use-built-in-shortcuts.md
@@ -17,7 +17,7 @@ n8n provides built-in methods and variables for working with data and accessing 
 {% hint style="warning" %}
 **Availability in the expressions editor and the Code node**
 
-Not every method and variable in this reference works in the [Code node](code-node.md). The Code node runs plain JavaScript against native Luxon, not n8n's expression engine, so any entry marked **Source: Custom n8n functionality** on a reference page (for example, [`DateTime.format()`](/build/work-with-data/transform-data/expression-reference/datetime.md#datetimeformat)) is an n8n-only extension that may not exist, or may behave differently, in the Code node.
+Not every method and variable in this reference works in the [Code node](cookbook/code-node/README.md). The Code node runs plain JavaScript against native Luxon, not n8n's expression engine, so any entry marked **Source: Custom n8n functionality** on a reference page (for example, [`DateTime.format()`](../work-with-data/transform-data/expression-reference/datetime.md#datetimeformat)) is an n8n-only extension that may not exist, or may behave differently, in the Code node.
 
 If code in the Code node throws `... is not a function`, or silently produces the wrong result:
 

--- a/docs/build/code-in-n8n/use-built-in-shortcuts.md
+++ b/docs/build/code-in-n8n/use-built-in-shortcuts.md
@@ -14,14 +14,19 @@ layout:
 
 n8n provides built-in methods and variables for working with data and accessing n8n data. This section provides a reference of available methods and variables for use in expressions[^1], with a short description. 
 
-{% hint style="info" %}
+{% hint style="warning" %}
 **Availability in the expressions editor and the Code node**
 
-Some methods and variables aren't available in the Code node. These aren't in the documentation.
+Not every method and variable in this reference works in the [Code node](code-node.md). The Code node runs plain JavaScript against native Luxon, not n8n's expression engine, so any entry marked **Source: Custom n8n functionality** on a reference page (for example, [`DateTime.format()`](/build/work-with-data/transform-data/expression-reference/datetime.md#datetimeformat)) is an n8n-only extension that may not exist, or may behave differently, in the Code node.
 
-All data transformation functions are only available in the expressions editor.
+If code in the Code node throws `... is not a function`, or silently produces the wrong result:
+
+* Check whether the method's reference entry is tagged **Custom n8n functionality**.
+* Look for a native Luxon or JavaScript equivalent. For example, use [`toFormat()`](https://moment.github.io/luxon/api-docs/index.html#datetimetoformat) instead of the n8n-only `DateTime.format()`.
+* Watch for methods that exist in both places but with different signatures, such as `DateTime.plus()`/`minus()`: n8n's expression version accepts `(amount, unit)`, while native Luxon's version only accepts a single Duration-like object (`{ days: 7 }`). Using the expression-style signature in the Code node won't error, but won't produce the expected result either.
+
+All data transformation functions (the top-level helper functions listed in this section, such as `$if()` or `$jmespath()`) are only available in the expressions editor, not the Code node.
 {% endhint %}
-
 
 The [Cookbook](README.md) contains examples for some common tasks, including some [Code node only](cookbook/code-node/README.md) functions.
 

--- a/docs/build/work-with-data/transform-data/expression-reference/datetime.md
+++ b/docs/build/work-with-data/transform-data/expression-reference/datetime.md
@@ -188,6 +188,21 @@ layout:
   dt.format("HH 'hours and' mm 'minutes'") //=> '18 hours and 49 minutes'
   ```
 
+{% hint style="warning" %}
+**Not available in the Code node**
+
+`format()` is a custom n8n extension added to Luxon `DateTime` objects in the expressions editor. It doesn't exist in the [Code node](/build/code-in-n8n/code-node.md), because Code node scripts run against plain, unmodified Luxon. Calling it there throws `... .format is not a function`.
+
+Use Luxon's native [`toFormat()`](https://moment.github.io/luxon/api-docs/index.html#datetimetoformat) instead:
+
+```javascript
+// In the Code node
+DateTime.now().toFormat('dd/LL/yyyy'); //=> '30/04/2024'
+```
+
+This applies to any method on this page marked **Source: Custom n8n functionality**: it's available in expressions (e.g. the Set node) but may not be available in the Code node. See [Built-in methods and variables](/build/code-in-n8n/use-built-in-shortcuts.md#availability-in-the-expressions-editor-and-the-code-node) for more on this distinction.
+{% endhint %}
+
 ## _`DateTime`_.**`hasSame()`** <a href="#datetimehassame" id="datetimehassame"></a>
 
 **Description:** Returns <code>true</code> if the two DateTimes are the same, down to the unit specified. Time zones are ignored (only local times are compared), so use <code>toUTC()</code> first if needed.
@@ -331,6 +346,10 @@ layout:
   dt.minus(4, 'years') //=> 2020-04-30T18:49
   ```
 
+{% hint style="info" %}
+**Code node:** Luxon's native `DateTime.prototype.minus()` also exists in the Code node, but only accepts a single [Duration-like object](https://moment.github.io/luxon/api-docs/index.html#datetimeminus) (e.g. `dt.minus({ days: 7 })`), not this page's n8n-only `(n, unit)` shorthand. Passing `dt.minus(7, 'days')` in the Code node will not raise an error but will not subtract 7 days either — double-check the result if you use this signature there.
+{% endhint %}
+
 ## _`DateTime`_.**`minute`** <a href="#datetimeminute" id="datetimeminute"></a>
 
 **Description:** The minute of the hour (0-59)
@@ -435,6 +454,10 @@ layout:
   // dt = "2024-03-30T18:49".toDateTime()
   dt.plus(4, 'years') //=> 2028-04-30T18:49
   ```
+
+{% hint style="info" %}
+**Code node:** Luxon's native `DateTime.prototype.plus()` also exists in the Code node, but only accepts a single [Duration-like object](https://moment.github.io/luxon/api-docs/index.html#datetimeplus) (e.g., `dt.plus({ days: 7 })`), not this page's n8n-only `(n, unit)` shorthand. Passing `dt.plus(7, 'days')` in the Code node will not raise an error but will not add 7 days either. Double-check the result if you use this signature there.
+{% endhint %}
 
 ## _`DateTime`_.**`quarter`** <a href="#datetimequarter" id="datetimequarter"></a>
 
@@ -870,4 +893,3 @@ layout:
   ```javascript
   $now.zone //=> {"zoneName": "Europe/Berlin", "valid": true}
   ```
-

--- a/docs/build/work-with-data/transform-data/expression-reference/datetime.md
+++ b/docs/build/work-with-data/transform-data/expression-reference/datetime.md
@@ -191,7 +191,7 @@ layout:
 {% hint style="warning" %}
 **Not available in the Code node**
 
-`format()` is a custom n8n extension added to Luxon `DateTime` objects in the expressions editor. It doesn't exist in the [Code node](/build/code-in-n8n/code-node.md), because Code node scripts run against plain, unmodified Luxon. Calling it there throws `... .format is not a function`.
+`format()` is a custom n8n extension added to Luxon `DateTime` objects in the expressions editor. It doesn't exist in the Code node, because Code node scripts run against plain, unmodified Luxon. Calling it there throws `... .format is not a function`.
 
 Use Luxon's native [`toFormat()`](https://moment.github.io/luxon/api-docs/index.html#datetimetoformat) instead:
 
@@ -200,7 +200,7 @@ Use Luxon's native [`toFormat()`](https://moment.github.io/luxon/api-docs/index.
 DateTime.now().toFormat('dd/LL/yyyy'); //=> '30/04/2024'
 ```
 
-This applies to any method on this page marked **Source: Custom n8n functionality**: it's available in expressions (e.g. the Set node) but may not be available in the Code node. See [Built-in methods and variables](/build/code-in-n8n/use-built-in-shortcuts.md#availability-in-the-expressions-editor-and-the-code-node) for more on this distinction.
+This applies to any method on this page marked **Source: Custom n8n functionality**: it's available in expressions (e.g. the Set node) but may not be available in the Code node. See [Built-in methods and variables](../../../code-in-n8n/use-built-in-shortcuts.md) for more on this distinction.
 {% endhint %}
 
 ## _`DateTime`_.**`hasSame()`** <a href="#datetimehassame" id="datetimehassame"></a>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies that some `DateTime` methods and variables are expression-only and not available in the Code node, addressing DOC-2015. 

Adds warnings and examples in built-in shortcuts and the `DateTime` reference, recommends Luxon `toFormat()` in Code instead of `DateTime.format()`, explains `plus()`/`minus()` signature differences (may not error but give wrong results), calls out that top‑level helpers like `$if()`/`$jmespath()` are expressions‑only, and updates links to the Code node cookbook and Luxon API.

<sup>Written for commit 6dc975ff7c4673da36ae2cb16ffa232c88f2cc4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/4994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

