### PR TITLE
docs(changelog): add n8n 2.29 MCP server updates entry

### DIFF
--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -28,6 +28,23 @@ Learn more in the [documentation](<https://docs.n8n.io/administer/observe-and-lo
 **Availability:** Pro and above.
 {% endhint %}
 
+### n8n 2.29 — MCP server updates
+
+**Released:** 2026-06-30
+
+We've shipped a number of updates to the n8n MCP server over the past few weeks. Here's a roundup, with the version each change landed in.
+
+* **Build with custom and community nodes.** You can now use your installed custom and community nodes in the workflows you build, not just the built-in ones (v2.29).
+* **Read and change workflow settings.** Workflow settings are now editable through the MCP server, so you can connect an error workflow, set the timezone, or adjust execution options (v2.29).
+* **View and restore workflow history.** You can now browse a workflow's version history and restore an earlier version (v2.29).
+* **More reliable credential assignment.** Fixed a bug where the server could assign a credential that wasn't valid for a node (v2.28).
+* **Look up real field values.** Dynamic fields like Slack channels or Google Sheets tabs now resolve to live values, so nodes are configured with valid selections instead of placeholder IDs (v2.27).
+* **Work with tags.** Tags are now supported, so you can filter a workflow search by tag and apply tags when creating or updating workflows (v2.27).
+* **Faster, targeted edits.** Workflow updates now change only the nodes that need to change instead of rewriting the whole thing (v2.22).
+* **List and choose credentials.** You can now list the credentials on your instance and pick the right one when several could apply, for example among five Gmail credentials (v2.21).
+
+Learn more in the [n8n MCP server documentation](https://docs.n8n.io/connect/connect-to-n8n-mcp-server).
+
 ### n8n 2.28 — Organize large workflows with Canvas Groups
 
 **Released:** 2026-06-29


### PR DESCRIPTION
**Draft for preview.** Adds a roundup changelog entry for the **n8n MCP server** (the workflow-building server), as its own 2.29 entry alongside the existing Insights 2.29 entry.

### What's in the entry
Eight updates shipped across v2.21–v2.29, each tagged with the version it landed in:
- Build with custom and community nodes (v2.29)
- Read and change workflow settings (v2.29)
- View and restore workflow history (v2.29)
- More reliable credential assignment (v2.28)
- Look up real field values / `explore_node_resources` (v2.27)
- Work with tags (v2.27)
- Faster, targeted workflow edits (v2.22)
- List and choose credentials (v2.21)

### Notes for review
- Version tags verified against the release tags (first release containing each change).
- Not beta and no availability hint (available to everyone).
- Follows the changelog house style: benefit-first voice, GitBook-flavored markdown, em dash only in the version heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 2.29 changelog entry for the n8n MCP server, rounding up eight updates shipped across v2.21–v2.29 with version tags for each change. Highlights include custom/community nodes, editable workflow settings, history restore, more reliable credential assignment, dynamic field lookups, tag support, targeted edits, credential listing, and a link to the MCP server docs.

<sup>Written for commit f25349e9a2d5c76472bf1fd224e1e3c75a7abb9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

