### PR TITLE
docs: backfill changelog entries (2.14–2.30)

### DIFF
--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -20,12 +20,6 @@ Until now, Microsoft automations were tied to a person's OAuth session: when tha
 
 _OneDrive and Outlook support released in 2.29 (2026-06-30)._
 
-### GitHub App authentication
-
-_Released in 2.29 (2026-06-30)._
-
-[GitHub nodes](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) can now authenticate as a GitHub App instead of a personal access token. Authentication is JWT-based with standardized private-key handling, so your GitHub automations belong to the organization rather than to whoever created the token, with fine-grained permissions and no PAT to rotate when people move on.
-
 ### mTLS authentication for Kafka
 
 The [Kafka credential](https://docs.n8n.io/integrations/builtin/credentials/kafka) now supports mutual TLS: provide a CA certificate, client certificate, and private key (PEM) to connect to brokers that require client-certificate authentication. mTLS applies to the Kafka node, the Kafka Trigger, and the credential test, and n8n validates that certificate and key match before you save.
@@ -70,6 +64,14 @@ We've shipped a number of updates to the n8n MCP server over the past few weeks.
 * **List and choose credentials.** You can now list the credentials on your instance and pick the right one when several could apply, for example among five Gmail credentials (v2.21).
 
 Learn more in the [n8n MCP server documentation](https://docs.n8n.io/connect/connect-to-n8n-mcp-server).
+
+---
+
+## `n8n 2.29` GitHub App authentication
+
+**Released:** 2026-06-30
+
+[GitHub nodes](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) can now authenticate as a GitHub App instead of a personal access token. Authentication is JWT-based with standardized private-key handling, so your GitHub automations belong to the organization rather than to whoever created the token, with fine-grained permissions and no PAT to rotate when people move on.
 
 ---
 

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -14,9 +14,9 @@ For complete, version-by-version detail on every release, see the [Releases page
 
 **Released:** 2026-07-07
 
-You can now authenticate Microsoft nodes with a [Microsoft Entra Service Principal](https://docs.n8n.io/integrations/builtin/credentials/microsoftentraserviceprincipal), so workflows run as an application instead of a signed-in user. OneDrive and Outlook gained the option in 2.29; Excel 365, Microsoft Teams, and Microsoft To Do follow in 2.30 — all sharing a single app-only credential.
+You can now authenticate Microsoft nodes with a [Microsoft Entra Service Principal](https://docs.n8n.io/integrations/builtin/credentials/microsoftentraserviceprincipal), so workflows run as an application instead of a signed-in user. OneDrive and Outlook gained the option in 2.29; Excel 365, Microsoft Teams, and Microsoft To Do follow in 2.30, all sharing a single app-only credential.
 
-Until now, Microsoft automations were tied to a person's OAuth session: when that person left the company or their token expired, the workflow broke. With app-only authentication, the workflow authenticates non-interactively with tenant-level permissions and targets the user, mailbox, drive, or site you specify — read a shared mailbox, process files in any user's drive, or post to Teams channels with nobody logged in. OAuth2 remains the default everywhere, so existing workflows are untouched, and operations that only make sense for a signed-in user are disabled per node with a clear error.
+Until now, Microsoft automations were tied to a person's OAuth session: when that person left the company or their token expired, the workflow broke. With app-only authentication, the workflow authenticates non-interactively with tenant-level permissions and targets the user, mailbox, drive, or site you specify: read a shared mailbox, process files in any user's drive, or post to Teams channels with nobody logged in. OAuth2 remains the default everywhere, so existing workflows are untouched, and operations that only make sense for a signed-in user are disabled per node with a clear error.
 
 _OneDrive and Outlook support released in 2.29 (2026-06-30)._
 
@@ -24,7 +24,7 @@ _OneDrive and Outlook support released in 2.29 (2026-06-30)._
 
 _Released in 2.29 (2026-06-30)._
 
-[GitHub nodes](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) can now authenticate as a GitHub App instead of a personal access token. Authentication is JWT-based with standardized private-key handling, so your GitHub automations belong to the organization rather than to whoever created the token — with fine-grained permissions and no PAT to rotate when people move on.
+[GitHub nodes](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) can now authenticate as a GitHub App instead of a personal access token. Authentication is JWT-based with standardized private-key handling, so your GitHub automations belong to the organization rather than to whoever created the token, with fine-grained permissions and no PAT to rotate when people move on.
 
 ### mTLS authentication for Kafka
 
@@ -89,11 +89,11 @@ Learn more in the [Canvas Groups documentation](https://docs.n8n.io/build/unders
 
 ### GitHub node: manage the full pull request lifecycle
 
-The [GitHub node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) now has a dedicated Pull Request resource. Create pull requests (including drafts and cross-fork PRs), update, close, and reopen them, read and add comments, fetch diffs and patches, and merge with merge, squash, or rebase — native operations that replace the custom HTTP Request setups these tasks used to need. Errors are surfaced exactly as GitHub returns them, so failures are easy to diagnose.
+The [GitHub node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) now has a dedicated Pull Request resource. Create pull requests (including drafts and cross-fork PRs), update, close, and reopen them, read and add comments, fetch diffs and patches, and merge with merge, squash, or rebase. These native operations replace the custom HTTP Request setups that such tasks used to need. Errors are surfaced exactly as GitHub returns them, so failures are easy to diagnose.
 
 ### Webhook node: Only Run If
 
-The [Webhook node](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook) gains an expression-based **Only run if** option that rejects requests that don't match a condition before an execution starts. Filter out health checks, retries, or irrelevant events at the door instead of starting a run that immediately exits — fewer no-op executions, less noise in your execution list, and saved execution quota.
+The [Webhook node](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook) gains an expression-based **Only run if** option that rejects requests that don't match a condition before an execution starts. Filter out health checks, retries, or irrelevant events at the door instead of starting a run that immediately exits: fewer no-op executions, less noise in your execution list, and saved execution quota.
 
 ---
 
@@ -119,11 +119,11 @@ Learn more in the [n8n Packages documentation](https://docs.n8n.io/build/manage-
 
 **Released:** 2026-06-02
 
-Your AI agents can now search the web out of the box. Enable web search from the agent's Advanced panel: where the model provider offers a native search tool, the agent uses it directly, and for providers without one, n8n falls back to Brave Search or a self-hosted SearXNG instance. Until now, giving an agent live web access meant wiring up a community node or an external API by hand; now it's built in, so agents can ground their answers in current information — prices, docs, news — without extra setup.
+Your AI agents can now search the web out of the box. Enable web search from the agent's Advanced panel: where the model provider offers a native search tool, the agent uses it directly, and for providers without one, n8n falls back to Brave Search or a self-hosted SearXNG instance. Until now, giving an agent live web access meant wiring up a community node or an external API by hand; now it's built in, so agents can ground their answers in current information like prices, docs, and news, without extra setup.
 
 ### Form Trigger: restrict forms to logged-in users
 
-The [Form Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger) (v2.6) adds an **n8n User Auth** option that gates a form to authenticated users of your instance. Visitors who aren't signed in are redirected to the n8n login, and the trigger outputs the authenticated user's ID, email, and name alongside the submission (with an opt-out). It works with all n8n auth modes and across multi-page forms — ideal for internal request forms where you need to know reliably who submitted.
+The [Form Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger) (v2.6) adds an **n8n User Auth** option that gates a form to authenticated users of your instance. Visitors who aren't signed in are redirected to the n8n login, and the trigger outputs the authenticated user's ID, email, and name alongside the submission (with an opt-out). It works with all n8n auth modes and across multi-page forms, which makes it ideal for internal request forms where you need to know reliably who submitted.
 
 ### Custom OAuth scopes for Microsoft credentials
 
@@ -135,7 +135,7 @@ The OneDrive, Outlook, and SharePoint OAuth2 credentials now include a **Custom 
 
 **Released:** 2026-05-27
 
-The [Odoo node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.odoo) has been rebuilt as v2, while existing v1 workflows keep working unchanged. The new version supports API-key authentication for Odoo 19+, searchable resource locators so you pick records from a list instead of pasting IDs, and dynamic field mapping on create and update that shows the actual fields of your Odoo instance — with read-only and computed fields hidden so you can't write to what can't be written. Contact, Opportunity, Activity, and Custom resources round out the coverage, and the node selects the right API transport for your Odoo version automatically.
+The [Odoo node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.odoo) has been rebuilt as v2, while existing v1 workflows keep working unchanged. The new version supports API-key authentication for Odoo 19+, searchable resource locators so you pick records from a list instead of pasting IDs, and dynamic field mapping on create and update that shows the actual fields of your Odoo instance, with read-only and computed fields hidden so you can't write to what can't be written. Contact, Opportunity, Activity, and Custom resources round out the coverage, and the node selects the right API transport for your Odoo version automatically.
 
 ### Oracle Database as a vector store
 
@@ -143,7 +143,7 @@ New [Oracle DB Vector Store](https://docs.n8n.io/integrations/builtin/cluster-no
 
 ### Complete results from multi-run sub-workflows
 
-When a sub-workflow's last node runs more than once, the [Execute Workflow Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger) (v1.2) now returns the items from every run, concatenated per output branch — previously you only got the final run. Older trigger versions keep their existing behavior and gain an **Items to return** option to opt in.
+When a sub-workflow's last node runs more than once, the [Execute Workflow Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger) (v1.2) now returns the items from every run, concatenated per output branch. Previously you only got the final run. Older trigger versions keep their existing behavior and gain an **Items to return** option to opt in.
 
 ---
 
@@ -180,13 +180,13 @@ Learn more in the [documentation](<https://docs.n8n.io/deploy/host-n8n/keep-n8n-
 
 Fourteen trigger nodes now verify the signatures of incoming webhooks, so forged or tampered requests are rejected with a 401 before they ever start an execution: Acuity Scheduling, Asana, Cal.com, Calendly, Customer.io, Figma, Formstack, GitLab, MailerLite, Mautic, Onfleet, Taiga, Trello, and Twilio.
 
-Verification uses each service's own signing mechanism — typically an HMAC signature header — with constant-time comparison and, where the service supports it, replay protection. Signing secrets are generated and registered automatically when n8n creates the webhook and stored with the workflow. Existing webhooks without a stored secret keep working, so nothing breaks on upgrade; new webhooks simply come out more secure by default.
+Verification uses each service's own signing mechanism, typically an HMAC signature header, with constant-time comparison and, where the service supports it, replay protection. Signing secrets are generated and registered automatically when n8n creates the webhook and stored with the workflow. Existing webhooks without a stored secret keep working, so nothing breaks on upgrade; new webhooks simply come out more secure by default.
 
 This is part of a broader hardening pass across releases: Netlify verification shipped in 2.20, and AWS SNS, Box, and Microsoft Teams followed in 2.22.
 
 ### Jira: OAuth2 authentication
 
-The [Jira node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.jira) and [Jira Trigger](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.jiratrigger) add a **Cloud (OAuth2)** authentication option using Atlassian's OAuth 2.0 authorization code flow (3LO). Connect through auth.atlassian.com with your Atlassian cloud ID resolved and cached automatically — no more creating and rotating API tokens by hand for Jira Cloud.
+The [Jira node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.jira) and [Jira Trigger](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.jiratrigger) add a **Cloud (OAuth2)** authentication option using Atlassian's OAuth 2.0 authorization code flow (3LO). Connect through auth.atlassian.com with your Atlassian cloud ID resolved and cached automatically. No more creating and rotating API tokens by hand for Jira Cloud.
 
 ---
 
@@ -272,7 +272,7 @@ A [MiniMax chat-model sub-node](https://docs.n8n.io/integrations/builtin/cluster
 
 _Released in 2.26 (2026-06-09)._
 
-The NVIDIA Nemotron Embeddings node generates embeddings from NeMo Retriever models via build.nvidia.com or a self-hosted NIM, reusing the existing NVIDIA credential. The node automatically sets the right input type per call — "passage" when indexing, "query" when searching — preventing the silent retrieval-quality degradation that mismatched input types cause.
+The NVIDIA Nemotron Embeddings node generates embeddings from NeMo Retriever models via build.nvidia.com or a self-hosted NIM, reusing the existing NVIDIA credential. The node automatically sets the right input type per call ("passage" when indexing, "query" when searching), preventing the silent retrieval-quality degradation that mismatched input types cause.
 
 ---
 
@@ -336,7 +336,7 @@ This is the foundational T1 feature. It was extended across later releases: node
 
 **Released:** 2026-03-24
 
-n8n now connects natively to Databricks. The new node runs SQL with asynchronous polling and chunked results (each row arrives as its own item), manages Unity Catalog objects — catalogs, schemas, tables, volumes, and functions — calls Model Serving endpoints with automatic input detection and validation, interacts with Genie AI, handles file operations up to 5 GiB, and manages Vector Search indexes. Lakehouse data can flow through the same workflows as the rest of your stack, without custom HTTP wiring. Learn more in the [Databricks node documentation](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.databricks).
+n8n now connects natively to Databricks. The new node runs SQL with asynchronous polling and chunked results (each row arrives as its own item), manages Unity Catalog objects (catalogs, schemas, tables, volumes, and functions), calls Model Serving endpoints with automatic input detection and validation, interacts with Genie AI, handles file operations up to 5 GiB, and manages Vector Search indexes. Lakehouse data can flow through the same workflows as the rest of your stack, without custom HTTP wiring. Learn more in the [Databricks node documentation](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.databricks).
 
 ### Perplexity node v2
 
@@ -344,7 +344,7 @@ The [Perplexity node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nod
 
 ### See what depends on what
 
-Workflow, credential, and data table cards — and the data table detail view — now show dependency information, so you can check what relies on a resource before you delete or change it.
+Workflow, credential, and data table cards, as well as the data table detail view, now show dependency information, so you can check what relies on a resource before you delete or change it.
 
 ---
 

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -26,28 +26,6 @@ The [Kafka credential](https://docs.n8n.io/integrations/builtin/credentials/kafk
 
 ---
 
-## `n8n 2.29` Insights alerts you when date ranges exceed available data
-
-**Released:** 2026-06-30
-
-When you select a date range in the Insights dashboard, you can now see at a glance whether your data retention policy covers that period. Instead of staring at an empty chart and wondering whether something is broken, an alert banner tells you exactly what is happening with your data coverage.
-
-Three states guide you as you work with custom date ranges:
-
-* **No data in range:** The entire selected period falls outside your retention window, so no executions are available to display.
-* **Partial data:** Some executions exist within the range. The alert specifies the earliest available date so you know where your data begins.
-* **Complete data:** All executions in the selected range are present. No alert appears.
-
-To use this, open the Insights dashboard, choose a date range with the date range picker, and check the alert banner at the top of the dashboard. If you see a partial or no-data alert, adjust your range to align with the dates your retention policy covers. Note that the alerts reflect your current retention configuration and do not extend how long execution data is stored.
-
-Learn more in the [documentation](<https://docs.n8n.io/administer/observe-and-log/track-usage-with-insights#disable-or-configure-insights-metrics-collection>).
-
-{% hint style="info" %}
-**Availability:** Pro and above.
-{% endhint %}
-
----
-
 ## `n8n 2.29` MCP server updates
 
 **Released:** 2026-06-30
@@ -65,13 +43,27 @@ We've shipped a number of updates to the n8n MCP server over the past few weeks.
 
 Learn more in the [n8n MCP server documentation](https://docs.n8n.io/connect/connect-to-n8n-mcp-server).
 
----
-
-## `n8n 2.29` GitHub App authentication
-
-**Released:** 2026-06-30
+### GitHub App authentication
 
 [GitHub nodes](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) can now authenticate as a GitHub App instead of a personal access token. Authentication is JWT-based with standardized private-key handling, so your GitHub automations belong to the organization rather than to whoever created the token, with fine-grained permissions and no PAT to rotate when people move on.
+
+### Insights alerts you when date ranges exceed available data
+
+When you select a date range in the Insights dashboard, you can now see at a glance whether your data retention policy covers that period. Instead of staring at an empty chart and wondering whether something is broken, an alert banner tells you exactly what is happening with your data coverage.
+
+Three states guide you as you work with custom date ranges:
+
+* **No data in range:** The entire selected period falls outside your retention window, so no executions are available to display.
+* **Partial data:** Some executions exist within the range. The alert specifies the earliest available date so you know where your data begins.
+* **Complete data:** All executions in the selected range are present. No alert appears.
+
+To use this, open the Insights dashboard, choose a date range with the date range picker, and check the alert banner at the top of the dashboard. If you see a partial or no-data alert, adjust your range to align with the dates your retention policy covers. Note that the alerts reflect your current retention configuration and do not extend how long execution data is stored.
+
+Learn more in the [documentation](<https://docs.n8n.io/administer/observe-and-log/track-usage-with-insights#disable-or-configure-insights-metrics-collection>).
+
+{% hint style="info" %}
+**Availability:** Pro and above.
+{% endhint %}
 
 ---
 

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -10,6 +10,28 @@ For complete, version-by-version detail on every release, see the [Releases page
 
 ---
 
+## `n8n 2.30` App-only authentication for Microsoft nodes
+
+**Released:** 2026-07-07
+
+You can now authenticate Microsoft nodes with a Microsoft Entra Service Principal, so workflows run as an application instead of a signed-in user. OneDrive and Outlook gained the option in 2.29; Excel 365, Microsoft Teams, and Microsoft To Do follow in 2.30 — all sharing a single app-only credential.
+
+Until now, Microsoft automations were tied to a person's OAuth session: when that person left the company or their token expired, the workflow broke. With app-only authentication, the workflow authenticates non-interactively with tenant-level permissions and targets the user, mailbox, drive, or site you specify — read a shared mailbox, process files in any user's drive, or post to Teams channels with nobody logged in. OAuth2 remains the default everywhere, so existing workflows are untouched, and operations that only make sense for a signed-in user are disabled per node with a clear error.
+
+_OneDrive and Outlook support released in 2.29 (2026-06-30)._
+
+### GitHub App authentication
+
+_Released in 2.29 (2026-06-30)._
+
+GitHub nodes can now authenticate as a GitHub App instead of a personal access token. Authentication is JWT-based with standardized private-key handling, so your GitHub automations belong to the organization rather than to whoever created the token — with fine-grained permissions and no PAT to rotate when people move on.
+
+### mTLS authentication for Kafka
+
+The Kafka credential now supports mutual TLS: provide a CA certificate, client certificate, and private key (PEM) to connect to brokers that require client-certificate authentication. mTLS applies to the Kafka node, the Kafka Trigger, and the credential test, and n8n validates that certificate and key match before you save.
+
+---
+
 ## `n8n 2.29` Insights alerts you when date ranges exceed available data
 
 **Released:** 2026-06-30
@@ -65,6 +87,14 @@ A Canvas Group is saved with the workflow, so anyone who opens it sees the same 
 
 Learn more in the [Canvas Groups documentation](https://docs.n8n.io/build/understand-workflows/workflow-components/canvas-groups).
 
+### GitHub node: manage the full pull request lifecycle
+
+The GitHub node now has a dedicated Pull Request resource. Create pull requests (including drafts and cross-fork PRs), update, close, and reopen them, read and add comments, fetch diffs and patches, and merge with merge, squash, or rebase — native operations that replace the custom HTTP Request setups these tasks used to need. Errors are surfaced exactly as GitHub returns them, so failures are easy to diagnose.
+
+### Webhook node: Only Run If
+
+The Webhook node gains an expression-based **Only run if** option that rejects requests that don't match a condition before an execution starts. Filter out health checks, retries, or irrelevant events at the door instead of starting a run that immediately exits — fewer no-op executions, less noise in your execution list, and saved execution quota.
+
 ---
 
 ## `n8n 2.27` Move workflows between instances as packages
@@ -82,6 +112,38 @@ This feature is in **beta**. The package format and APIs are still under develop
 {% endhint %}
 
 Learn more in the [n8n Packages documentation](https://docs.n8n.io/build/manage-workflows/n8n-packages).
+
+---
+
+## `n8n 2.25` Web search for AI agents
+
+**Released:** 2026-06-02
+
+Your AI agents can now search the web out of the box. Enable web search from the agent's Advanced panel: where the model provider offers a native search tool, the agent uses it directly, and for providers without one, n8n falls back to Brave Search or a self-hosted SearXNG instance. Until now, giving an agent live web access meant wiring up a community node or an external API by hand; now it's built in, so agents can ground their answers in current information — prices, docs, news — without extra setup.
+
+### Form Trigger: restrict forms to logged-in users
+
+The Form Trigger (v2.6) adds an **n8n User Auth** option that gates a form to authenticated users of your instance. Visitors who aren't signed in are redirected to the n8n login, and the trigger outputs the authenticated user's ID, email, and name alongside the submission (with an opt-out). It works with all n8n auth modes and across multi-page forms — ideal for internal request forms where you need to know reliably who submitted.
+
+### Custom OAuth scopes for Microsoft credentials
+
+The OneDrive, Outlook, and SharePoint OAuth2 credentials now include a **Custom Scopes** toggle. Defaults stay unchanged, but you can grant additional Microsoft Graph permissions or trim scopes down to what your tenant allows, instead of being limited to n8n's default consent set.
+
+---
+
+## `n8n 2.23` Rebuilt Odoo node and Oracle vector search
+
+**Released:** 2026-05-27
+
+The Odoo node has been rebuilt as v2, while existing v1 workflows keep working unchanged. The new version supports API-key authentication for Odoo 19+, searchable resource locators so you pick records from a list instead of pasting IDs, and dynamic field mapping on create and update that shows the actual fields of your Odoo instance — with read-only and computed fields hidden so you can't write to what can't be written. Contact, Opportunity, Activity, and Custom resources round out the coverage, and the node selects the right API transport for your Odoo version automatically.
+
+### Oracle Database as a vector store
+
+New Oracle DB Vector Store and Oracle ONNX Embedding nodes bring retrieval-augmented generation to data that lives in Oracle. Insert, load, and retrieve documents (including retrieve-as-tool for AI agents) with configurable distance strategies and metadata filtering that supports nested AND/OR conditions. Embeddings are generated by an ONNX model loaded in the database itself, so vectors and source data stay in one place. Requires an ONNX model in the database.
+
+### Complete results from multi-run sub-workflows
+
+When a sub-workflow's last node runs more than once, the Execute Workflow Trigger (v1.2) now returns the items from every run, concatenated per output branch — previously you only got the final run. Older trigger versions keep their existing behavior and gain an **Items to return** option to opt in.
 
 ---
 
@@ -109,6 +171,22 @@ Learn more in the [documentation](<https://docs.n8n.io/deploy/host-n8n/keep-n8n-
 **Availability:** Enterprise.
 {% endhint %}
 
+
+---
+
+## `n8n 2.21` Verified webhooks across fourteen trigger nodes
+
+**Released:** 2026-05-12
+
+Fourteen trigger nodes now verify the signatures of incoming webhooks, so forged or tampered requests are rejected with a 401 before they ever start an execution: Acuity Scheduling, Asana, Cal.com, Calendly, Customer.io, Figma, Formstack, GitLab, MailerLite, Mautic, Onfleet, Taiga, Trello, and Twilio.
+
+Verification uses each service's own signing mechanism — typically an HMAC signature header — with constant-time comparison and, where the service supports it, replay protection. Signing secrets are generated and registered automatically when n8n creates the webhook and stored with the workflow. Existing webhooks without a stored secret keep working, so nothing breaks on upgrade; new webhooks simply come out more secure by default.
+
+This is part of a broader hardening pass across releases: Netlify verification shipped in 2.20, and AWS SNS, Box, and Microsoft Teams followed in 2.22.
+
+### Jira: OAuth2 authentication
+
+The Jira node and Jira Trigger add a **Cloud (OAuth2)** authentication option using Atlassian's OAuth 2.0 authorization code flow (3LO). Connect through auth.atlassian.com with your Atlassian cloud ID resolved and cached automatically — no more creating and rotating API tokens by hand for Jira Cloud.
 
 ---
 
@@ -157,6 +235,44 @@ This makes deployment configuration the single source of truth, so you can stand
 {% hint style="info" %}
 **Availability:** Enterprise.
 {% endhint %}
+
+---
+
+## `n8n 2.18` Favorites
+
+**Released:** 2026-04-21
+
+You can now mark projects, folders, workflows, and data tables as favorites for quick access. Instead of searching for the same handful of resources every day, pin them once and they're one click away. The bigger your instance grows — more projects, more teammates, more workflows — the more time this saves.
+
+### Slack Trigger: App Home opens as a dedicated event
+
+The Slack Trigger now offers **app_home_opened** as a dedicated event option. Previously, reacting to App Home opens meant subscribing to Any Event and filtering downstream, which started an execution for every unrelated Slack event. Now workflows subscribe to exactly this event and nothing else runs.
+
+### Linear Trigger: webhook signature verification
+
+Linear credentials gain an optional signing secret. When set, the Linear Trigger verifies each incoming webhook's HMAC-SHA256 signature and validates its timestamp within a 60-second window, rejecting invalid or replayed requests with a 401.
+
+---
+
+## `n8n 2.17` New model providers: Moonshot Kimi and Alibaba Cloud Model Studio
+
+**Released:** 2026-04-13
+
+Two model providers join n8n's AI lineup natively. **Moonshot Kimi** arrives as both a chat-model sub-node for AI Agents (with a dynamic model list, defaulting to kimi-k2.5) and a standalone node with multi-turn chat, tool calling, built-in web search, thinking mode, JSON responses, and image analysis. **Alibaba Cloud Model Studio** brings the Qwen family: chat with web search and agent-tool support, vision-language image analysis, text-to-image, and text- and image-to-video generation with automatic download of results.
+
+More providers followed in later releases:
+
+### MiniMax
+
+_Released in 2.18 (2026-04-21)._
+
+A MiniMax chat-model sub-node (OpenAI-compatible API, default MiniMax-M2.7, with a Hide Thinking option that strips reasoning traces for clean responses) plus a standalone MiniMax node covering chat, image generation, asynchronous video generation, and text-to-speech with voice, emotion, speed, and pitch controls.
+
+### NVIDIA Nemotron embeddings
+
+_Released in 2.26 (2026-06-09)._
+
+The NVIDIA Nemotron Embeddings node generates embeddings from NeMo Retriever models via build.nvidia.com or a self-hosted NIM, reusing the existing NVIDIA credential. The node automatically sets the right input type per call — "passage" when indexing, "query" when searching — preventing the silent retrieval-quality degradation that mismatched input types cause.
 
 ---
 
@@ -213,6 +329,22 @@ This is the foundational T1 feature. It was extended across later releases: node
 {% hint style="info" %}
 **Availability:** Free, Pro, and Enterprise.
 {% endhint %}
+
+---
+
+## `n8n 2.14` Databricks node
+
+**Released:** 2026-03-24
+
+n8n now connects natively to Databricks. The new node runs SQL with asynchronous polling and chunked results (each row arrives as its own item), manages Unity Catalog objects — catalogs, schemas, tables, volumes, and functions — calls Model Serving endpoints with automatic input detection and validation, interacts with Genie AI, handles file operations up to 5 GiB, and manages Vector Search indexes. Lakehouse data can flow through the same workflows as the rest of your stack, without custom HTTP wiring.
+
+### Perplexity node v2
+
+The Perplexity node moves to v2 with full API coverage while keeping v1 workflows compatible: agent responses with third-party models, tools, and JSON-schema structured outputs; raw search with advanced filters; and embeddings, including contextualized embeddings.
+
+### See what depends on what
+
+Workflow, credential, and data table cards — and the data table detail view — now show dependency information, so you can check what relies on a resource before you delete or change it.
 
 ---
 

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -14,9 +14,9 @@ For complete, version-by-version detail on every release, see the [Releases page
 
 **Released:** 2026-07-07
 
-You can now authenticate Microsoft nodes with a [Microsoft Entra Service Principal](https://docs.n8n.io/integrations/builtin/credentials/microsoftentraserviceprincipal), so workflows run as an application instead of a signed-in user. OneDrive and Outlook gained the option in 2.29; Excel 365, Microsoft Teams, and Microsoft To Do follow in 2.30—all sharing a single app-only credential.
+You can now authenticate Microsoft nodes with a [Microsoft Entra Service Principal](https://docs.n8n.io/integrations/builtin/credentials/microsoftentraserviceprincipal), so workflows run as an application instead of a signed-in user. OneDrive and Outlook gained the option in 2.29; Excel 365, Microsoft Teams, and Microsoft To Do follow in 2.30 — all sharing a single app-only credential.
 
-Until now, Microsoft access in n8n was tied to a person's OAuth session: when that person left the company or their token expired, the workflow broke. With app-only authentication, the workflow authenticates non-interactively with tenant-level permissions and targets the user, mailbox, drive, or site you specify—read a shared mailbox, process files in any user's drive, or post to Teams channels with nobody logged in. OAuth2 remains the default everywhere, so existing workflows are untouched, and operations that only make sense for a signed-in user are disabled per node with a clear error.
+Until now, Microsoft automations were tied to a person's OAuth session: when that person left the company or their token expired, the workflow broke. With app-only authentication, the workflow authenticates non-interactively with tenant-level permissions and targets the user, mailbox, drive, or site you specify — read a shared mailbox, process files in any user's drive, or post to Teams channels with nobody logged in. OAuth2 remains the default everywhere, so existing workflows are untouched, and operations that only make sense for a signed-in user are disabled per node with a clear error.
 
 _OneDrive and Outlook support released in 2.29 (2026-06-30)._
 
@@ -24,7 +24,7 @@ _OneDrive and Outlook support released in 2.29 (2026-06-30)._
 
 _Released in 2.29 (2026-06-30)._
 
-[GitHub nodes](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) can now authenticate as a GitHub App instead of a personal access token. Authentication is JWT-based with standardized private-key handling, so your GitHub workflows belong to the organization rather than to whoever created the token—with fine-grained permissions and no PAT to rotate when people move on.
+[GitHub nodes](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) can now authenticate as a GitHub App instead of a personal access token. Authentication is JWT-based with standardized private-key handling, so your GitHub automations belong to the organization rather than to whoever created the token — with fine-grained permissions and no PAT to rotate when people move on.
 
 ### mTLS authentication for Kafka
 
@@ -87,13 +87,13 @@ A Canvas Group is saved with the workflow, so anyone who opens it sees the same 
 
 Learn more in the [Canvas Groups documentation](https://docs.n8n.io/build/understand-workflows/workflow-components/canvas-groups).
 
-### GitHub node: Manage the full pull request lifecycle
+### GitHub node: manage the full pull request lifecycle
 
-The [GitHub node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) now has a dedicated Pull Request resource. Create pull requests (including drafts and cross-fork PRs), update, close, and reopen them, read and add comments, fetch diffs and patches, and merge with `merge`, `squash`, or `rebase`—native operations that replace the custom HTTP Request setups these tasks used to need. Errors are surfaced exactly as GitHub returns them, so failures are easy to diagnose.
+The [GitHub node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) now has a dedicated Pull Request resource. Create pull requests (including drafts and cross-fork PRs), update, close, and reopen them, read and add comments, fetch diffs and patches, and merge with merge, squash, or rebase — native operations that replace the custom HTTP Request setups these tasks used to need. Errors are surfaced exactly as GitHub returns them, so failures are easy to diagnose.
 
 ### Webhook node: Only Run If
 
-The [Webhook node](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook) gains an expression-based **Only run if** option that rejects requests that don't match a condition before an execution starts. Filter out health checks, retries, or irrelevant events at the door instead of starting a run that immediately exits—fewer no-op executions, less noise in your execution list, and saved execution quota.
+The [Webhook node](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook) gains an expression-based **Only run if** option that rejects requests that don't match a condition before an execution starts. Filter out health checks, retries, or irrelevant events at the door instead of starting a run that immediately exits — fewer no-op executions, less noise in your execution list, and saved execution quota.
 
 ---
 
@@ -119,11 +119,11 @@ Learn more in the [n8n Packages documentation](https://docs.n8n.io/build/manage-
 
 **Released:** 2026-06-02
 
-Your AI agents can now search the web out of the box. Enable web search from the agent's Advanced panel: where the model provider offers a native search tool, the agent uses it directly, and for providers without one, n8n falls back to Brave Search or a self-hosted SearXNG instance. Until now, giving an agent live web access meant wiring up a community node or an external API by hand; now it's built in, so agents can ground their answers in current information—prices, docs, news—without extra setup.
+Your AI agents can now search the web out of the box. Enable web search from the agent's Advanced panel: where the model provider offers a native search tool, the agent uses it directly, and for providers without one, n8n falls back to Brave Search or a self-hosted SearXNG instance. Until now, giving an agent live web access meant wiring up a community node or an external API by hand; now it's built in, so agents can ground their answers in current information — prices, docs, news — without extra setup.
 
-### Form Trigger: Restrict forms to logged-in users
+### Form Trigger: restrict forms to logged-in users
 
-The [Form Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger) (v2.6) adds an **n8n User Auth** option that gates a form to authenticated users of your instance. Visitors who aren't signed in are redirected to the n8n login, and the trigger outputs the authenticated user's ID, email, and name alongside the submission (with an opt-out). It works with all n8n auth modes and across multi-page forms—ideal for internal request forms where you need to know reliably who submitted.
+The [Form Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger) (v2.6) adds an **n8n User Auth** option that gates a form to authenticated users of your instance. Visitors who aren't signed in are redirected to the n8n login, and the trigger outputs the authenticated user's ID, email, and name alongside the submission (with an opt-out). It works with all n8n auth modes and across multi-page forms — ideal for internal request forms where you need to know reliably who submitted.
 
 ### Custom OAuth scopes for Microsoft credentials
 
@@ -135,7 +135,7 @@ The OneDrive, Outlook, and SharePoint OAuth2 credentials now include a **Custom 
 
 **Released:** 2026-05-27
 
-The [Odoo node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.odoo) has been rebuilt as v2, while existing v1 workflows keep working unchanged. The new version supports API-key authentication for Odoo 19+, searchable resource locators so you pick records from a list instead of pasting IDs, and dynamic field mapping on create and update that shows the actual fields of your Odoo instance—with read-only and computed fields hidden so you can't write to what can't be written. Contact, Opportunity, Activity, and Custom resources round out the coverage, and the node selects the right API transport for your Odoo version automatically.
+The [Odoo node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.odoo) has been rebuilt as v2, while existing v1 workflows keep working unchanged. The new version supports API-key authentication for Odoo 19+, searchable resource locators so you pick records from a list instead of pasting IDs, and dynamic field mapping on create and update that shows the actual fields of your Odoo instance — with read-only and computed fields hidden so you can't write to what can't be written. Contact, Opportunity, Activity, and Custom resources round out the coverage, and the node selects the right API transport for your Odoo version automatically.
 
 ### Oracle Database as a vector store
 
@@ -143,7 +143,7 @@ New [Oracle DB Vector Store](https://docs.n8n.io/integrations/builtin/cluster-no
 
 ### Complete results from multi-run sub-workflows
 
-When a sub-workflow's last node runs more than once, the [Execute Workflow Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger) (v1.2) now returns the items from every run, concatenated per output branch—previously you only got the final run. Older trigger versions keep their existing behavior and gain an **Items to return** option to opt in.
+When a sub-workflow's last node runs more than once, the [Execute Workflow Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger) (v1.2) now returns the items from every run, concatenated per output branch — previously you only got the final run. Older trigger versions keep their existing behavior and gain an **Items to return** option to opt in.
 
 ---
 
@@ -180,13 +180,13 @@ Learn more in the [documentation](<https://docs.n8n.io/deploy/host-n8n/keep-n8n-
 
 Fourteen trigger nodes now verify the signatures of incoming webhooks, so forged or tampered requests are rejected with a 401 before they ever start an execution: Acuity Scheduling, Asana, Cal.com, Calendly, Customer.io, Figma, Formstack, GitLab, MailerLite, Mautic, Onfleet, Taiga, Trello, and Twilio.
 
-Verification uses each service's own signing mechanism—typically an HMAC signature header—with constant-time comparison and, where the service supports it, replay protection. Signing secrets are generated and registered automatically when n8n creates the webhook and stored with the workflow. Existing webhooks without a stored secret keep working, so nothing breaks on upgrade; new webhooks simply come out more secure by default.
+Verification uses each service's own signing mechanism — typically an HMAC signature header — with constant-time comparison and, where the service supports it, replay protection. Signing secrets are generated and registered automatically when n8n creates the webhook and stored with the workflow. Existing webhooks without a stored secret keep working, so nothing breaks on upgrade; new webhooks simply come out more secure by default.
 
 This is part of a broader hardening pass across releases: Netlify verification shipped in 2.20, and AWS SNS, Box, and Microsoft Teams followed in 2.22.
 
 ### Jira: OAuth2 authentication
 
-The [Jira node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.jira) and [Jira Trigger](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.jiratrigger) add a **Cloud (OAuth2)** authentication option using Atlassian's OAuth 2.0 authorization code flow (3LO). Connect through auth.atlassian.com with your Atlassian cloud ID resolved and cached automatically—no more creating and rotating API tokens by hand for Jira Cloud.
+The [Jira node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.jira) and [Jira Trigger](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.jiratrigger) add a **Cloud (OAuth2)** authentication option using Atlassian's OAuth 2.0 authorization code flow (3LO). Connect through auth.atlassian.com with your Atlassian cloud ID resolved and cached automatically — no more creating and rotating API tokens by hand for Jira Cloud.
 
 ---
 
@@ -248,9 +248,9 @@ You can now mark projects, folders, workflows, and data tables as favorites, so 
 
 The [Slack Trigger](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger) now offers **app_home_opened** as a dedicated event option. Previously, reacting to App Home opens meant subscribing to Any Event and filtering downstream, which started an execution for every unrelated Slack event.
 
-### Linear Trigger: Webhook signature verification
+### Linear Trigger: webhook signature verification
 
-Linear credentials gain an optional signing secret. When set, the [Linear Trigger](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.lineartrigger) verifies the HMAC-SHA256 signature of each incoming webhook and validates its timestamp within a 60-second window, rejecting invalid or replayed requests with a 401.
+Linear credentials gain an optional signing secret. When set, the [Linear Trigger](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.lineartrigger) verifies each incoming webhook's HMAC-SHA256 signature and validates its timestamp within a 60-second window, rejecting invalid or replayed requests with a 401.
 
 ---
 
@@ -272,7 +272,7 @@ A [MiniMax chat-model sub-node](https://docs.n8n.io/integrations/builtin/cluster
 
 _Released in 2.26 (2026-06-09)._
 
-The NVIDIA Nemotron Embeddings node generates embeddings from NeMo Retriever models via build.nvidia.com or a self-hosted NIM, reusing the existing NVIDIA credential. The node automatically sets the right input type per call—"passage" when indexing, "query" when searching—preventing the silent retrieval-quality degradation that mismatched input types cause.
+The NVIDIA Nemotron Embeddings node generates embeddings from NeMo Retriever models via build.nvidia.com or a self-hosted NIM, reusing the existing NVIDIA credential. The node automatically sets the right input type per call — "passage" when indexing, "query" when searching — preventing the silent retrieval-quality degradation that mismatched input types cause.
 
 ---
 
@@ -336,7 +336,7 @@ This is the foundational T1 feature. It was extended across later releases: node
 
 **Released:** 2026-03-24
 
-n8n now connects natively to Databricks. The new node runs SQL with asynchronous polling and chunked results (each row arrives as its own item), manages Unity Catalog objects—catalogs, schemas, tables, volumes, and functions—calls Model Serving endpoints with automatic input detection and validation, interacts with Genie AI, handles file operations up to 5 GiB, and manages Vector Search indexes. Databricks data can flow through the same workflows as the rest of your stack, without custom HTTP wiring. Learn more in the [Databricks node documentation](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.databricks).
+n8n now connects natively to Databricks. The new node runs SQL with asynchronous polling and chunked results (each row arrives as its own item), manages Unity Catalog objects — catalogs, schemas, tables, volumes, and functions — calls Model Serving endpoints with automatic input detection and validation, interacts with Genie AI, handles file operations up to 5 GiB, and manages Vector Search indexes. Lakehouse data can flow through the same workflows as the rest of your stack, without custom HTTP wiring. Learn more in the [Databricks node documentation](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.databricks).
 
 ### Perplexity node v2
 
@@ -344,7 +344,7 @@ The [Perplexity node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nod
 
 ### See what depends on what
 
-Workflow, credential, and data table cards—and the data table detail view—now show dependency information, so you can check what relies on a resource before you delete or change it.
+Workflow, credential, and data table cards — and the data table detail view — now show dependency information, so you can check what relies on a resource before you delete or change it.
 
 ---
 

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -242,11 +242,11 @@ This makes deployment configuration the single source of truth, so you can stand
 
 **Released:** 2026-04-21
 
-You can now mark projects, folders, workflows, and data tables as favorites for quick access. Instead of searching for the same handful of resources every day, pin them once and they're one click away. The bigger your instance grows — more projects, more teammates, more workflows — the more time this saves.
+You can now mark projects, folders, workflows, and data tables as favorites, so the resources you work with every day are one click away instead of a search away.
 
 ### Slack Trigger: App Home opens as a dedicated event
 
-The Slack Trigger now offers **app_home_opened** as a dedicated event option. Previously, reacting to App Home opens meant subscribing to Any Event and filtering downstream, which started an execution for every unrelated Slack event. Now workflows subscribe to exactly this event and nothing else runs.
+The Slack Trigger now offers **app_home_opened** as a dedicated event option. Previously, reacting to App Home opens meant subscribing to Any Event and filtering downstream, which started an execution for every unrelated Slack event.
 
 ### Linear Trigger: webhook signature verification
 

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -14,9 +14,9 @@ For complete, version-by-version detail on every release, see the [Releases page
 
 **Released:** 2026-07-07
 
-You can now authenticate Microsoft nodes with a [Microsoft Entra Service Principal](https://docs.n8n.io/integrations/builtin/credentials/microsoftentraserviceprincipal), so workflows run as an application instead of a signed-in user. OneDrive and Outlook gained the option in 2.29; Excel 365, Microsoft Teams, and Microsoft To Do follow in 2.30 — all sharing a single app-only credential.
+You can now authenticate Microsoft nodes with a [Microsoft Entra Service Principal](https://docs.n8n.io/integrations/builtin/credentials/microsoftentraserviceprincipal), so workflows run as an application instead of a signed-in user. OneDrive and Outlook gained the option in 2.29; Excel 365, Microsoft Teams, and Microsoft To Do follow in 2.30—all sharing a single app-only credential.
 
-Until now, Microsoft automations were tied to a person's OAuth session: when that person left the company or their token expired, the workflow broke. With app-only authentication, the workflow authenticates non-interactively with tenant-level permissions and targets the user, mailbox, drive, or site you specify — read a shared mailbox, process files in any user's drive, or post to Teams channels with nobody logged in. OAuth2 remains the default everywhere, so existing workflows are untouched, and operations that only make sense for a signed-in user are disabled per node with a clear error.
+Until now, Microsoft access in n8n was tied to a person's OAuth session: when that person left the company or their token expired, the workflow broke. With app-only authentication, the workflow authenticates non-interactively with tenant-level permissions and targets the user, mailbox, drive, or site you specify—read a shared mailbox, process files in any user's drive, or post to Teams channels with nobody logged in. OAuth2 remains the default everywhere, so existing workflows are untouched, and operations that only make sense for a signed-in user are disabled per node with a clear error.
 
 _OneDrive and Outlook support released in 2.29 (2026-06-30)._
 
@@ -24,7 +24,7 @@ _OneDrive and Outlook support released in 2.29 (2026-06-30)._
 
 _Released in 2.29 (2026-06-30)._
 
-[GitHub nodes](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) can now authenticate as a GitHub App instead of a personal access token. Authentication is JWT-based with standardized private-key handling, so your GitHub automations belong to the organization rather than to whoever created the token — with fine-grained permissions and no PAT to rotate when people move on.
+[GitHub nodes](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) can now authenticate as a GitHub App instead of a personal access token. Authentication is JWT-based with standardized private-key handling, so your GitHub workflows belong to the organization rather than to whoever created the token—with fine-grained permissions and no PAT to rotate when people move on.
 
 ### mTLS authentication for Kafka
 
@@ -87,13 +87,13 @@ A Canvas Group is saved with the workflow, so anyone who opens it sees the same 
 
 Learn more in the [Canvas Groups documentation](https://docs.n8n.io/build/understand-workflows/workflow-components/canvas-groups).
 
-### GitHub node: manage the full pull request lifecycle
+### GitHub node: Manage the full pull request lifecycle
 
-The [GitHub node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) now has a dedicated Pull Request resource. Create pull requests (including drafts and cross-fork PRs), update, close, and reopen them, read and add comments, fetch diffs and patches, and merge with merge, squash, or rebase — native operations that replace the custom HTTP Request setups these tasks used to need. Errors are surfaced exactly as GitHub returns them, so failures are easy to diagnose.
+The [GitHub node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) now has a dedicated Pull Request resource. Create pull requests (including drafts and cross-fork PRs), update, close, and reopen them, read and add comments, fetch diffs and patches, and merge with `merge`, `squash`, or `rebase`—native operations that replace the custom HTTP Request setups these tasks used to need. Errors are surfaced exactly as GitHub returns them, so failures are easy to diagnose.
 
 ### Webhook node: Only Run If
 
-The [Webhook node](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook) gains an expression-based **Only run if** option that rejects requests that don't match a condition before an execution starts. Filter out health checks, retries, or irrelevant events at the door instead of starting a run that immediately exits — fewer no-op executions, less noise in your execution list, and saved execution quota.
+The [Webhook node](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook) gains an expression-based **Only run if** option that rejects requests that don't match a condition before an execution starts. Filter out health checks, retries, or irrelevant events at the door instead of starting a run that immediately exits—fewer no-op executions, less noise in your execution list, and saved execution quota.
 
 ---
 
@@ -119,11 +119,11 @@ Learn more in the [n8n Packages documentation](https://docs.n8n.io/build/manage-
 
 **Released:** 2026-06-02
 
-Your AI agents can now search the web out of the box. Enable web search from the agent's Advanced panel: where the model provider offers a native search tool, the agent uses it directly, and for providers without one, n8n falls back to Brave Search or a self-hosted SearXNG instance. Until now, giving an agent live web access meant wiring up a community node or an external API by hand; now it's built in, so agents can ground their answers in current information — prices, docs, news — without extra setup.
+Your AI agents can now search the web out of the box. Enable web search from the agent's Advanced panel: where the model provider offers a native search tool, the agent uses it directly, and for providers without one, n8n falls back to Brave Search or a self-hosted SearXNG instance. Until now, giving an agent live web access meant wiring up a community node or an external API by hand; now it's built in, so agents can ground their answers in current information—prices, docs, news—without extra setup.
 
-### Form Trigger: restrict forms to logged-in users
+### Form Trigger: Restrict forms to logged-in users
 
-The [Form Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger) (v2.6) adds an **n8n User Auth** option that gates a form to authenticated users of your instance. Visitors who aren't signed in are redirected to the n8n login, and the trigger outputs the authenticated user's ID, email, and name alongside the submission (with an opt-out). It works with all n8n auth modes and across multi-page forms — ideal for internal request forms where you need to know reliably who submitted.
+The [Form Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger) (v2.6) adds an **n8n User Auth** option that gates a form to authenticated users of your instance. Visitors who aren't signed in are redirected to the n8n login, and the trigger outputs the authenticated user's ID, email, and name alongside the submission (with an opt-out). It works with all n8n auth modes and across multi-page forms—ideal for internal request forms where you need to know reliably who submitted.
 
 ### Custom OAuth scopes for Microsoft credentials
 
@@ -135,7 +135,7 @@ The OneDrive, Outlook, and SharePoint OAuth2 credentials now include a **Custom 
 
 **Released:** 2026-05-27
 
-The [Odoo node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.odoo) has been rebuilt as v2, while existing v1 workflows keep working unchanged. The new version supports API-key authentication for Odoo 19+, searchable resource locators so you pick records from a list instead of pasting IDs, and dynamic field mapping on create and update that shows the actual fields of your Odoo instance — with read-only and computed fields hidden so you can't write to what can't be written. Contact, Opportunity, Activity, and Custom resources round out the coverage, and the node selects the right API transport for your Odoo version automatically.
+The [Odoo node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.odoo) has been rebuilt as v2, while existing v1 workflows keep working unchanged. The new version supports API-key authentication for Odoo 19+, searchable resource locators so you pick records from a list instead of pasting IDs, and dynamic field mapping on create and update that shows the actual fields of your Odoo instance—with read-only and computed fields hidden so you can't write to what can't be written. Contact, Opportunity, Activity, and Custom resources round out the coverage, and the node selects the right API transport for your Odoo version automatically.
 
 ### Oracle Database as a vector store
 
@@ -143,7 +143,7 @@ New [Oracle DB Vector Store](https://docs.n8n.io/integrations/builtin/cluster-no
 
 ### Complete results from multi-run sub-workflows
 
-When a sub-workflow's last node runs more than once, the [Execute Workflow Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger) (v1.2) now returns the items from every run, concatenated per output branch — previously you only got the final run. Older trigger versions keep their existing behavior and gain an **Items to return** option to opt in.
+When a sub-workflow's last node runs more than once, the [Execute Workflow Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger) (v1.2) now returns the items from every run, concatenated per output branch—previously you only got the final run. Older trigger versions keep their existing behavior and gain an **Items to return** option to opt in.
 
 ---
 
@@ -180,13 +180,13 @@ Learn more in the [documentation](<https://docs.n8n.io/deploy/host-n8n/keep-n8n-
 
 Fourteen trigger nodes now verify the signatures of incoming webhooks, so forged or tampered requests are rejected with a 401 before they ever start an execution: Acuity Scheduling, Asana, Cal.com, Calendly, Customer.io, Figma, Formstack, GitLab, MailerLite, Mautic, Onfleet, Taiga, Trello, and Twilio.
 
-Verification uses each service's own signing mechanism — typically an HMAC signature header — with constant-time comparison and, where the service supports it, replay protection. Signing secrets are generated and registered automatically when n8n creates the webhook and stored with the workflow. Existing webhooks without a stored secret keep working, so nothing breaks on upgrade; new webhooks simply come out more secure by default.
+Verification uses each service's own signing mechanism—typically an HMAC signature header—with constant-time comparison and, where the service supports it, replay protection. Signing secrets are generated and registered automatically when n8n creates the webhook and stored with the workflow. Existing webhooks without a stored secret keep working, so nothing breaks on upgrade; new webhooks simply come out more secure by default.
 
 This is part of a broader hardening pass across releases: Netlify verification shipped in 2.20, and AWS SNS, Box, and Microsoft Teams followed in 2.22.
 
 ### Jira: OAuth2 authentication
 
-The [Jira node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.jira) and [Jira Trigger](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.jiratrigger) add a **Cloud (OAuth2)** authentication option using Atlassian's OAuth 2.0 authorization code flow (3LO). Connect through auth.atlassian.com with your Atlassian cloud ID resolved and cached automatically — no more creating and rotating API tokens by hand for Jira Cloud.
+The [Jira node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.jira) and [Jira Trigger](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.jiratrigger) add a **Cloud (OAuth2)** authentication option using Atlassian's OAuth 2.0 authorization code flow (3LO). Connect through auth.atlassian.com with your Atlassian cloud ID resolved and cached automatically—no more creating and rotating API tokens by hand for Jira Cloud.
 
 ---
 
@@ -248,9 +248,9 @@ You can now mark projects, folders, workflows, and data tables as favorites, so 
 
 The [Slack Trigger](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger) now offers **app_home_opened** as a dedicated event option. Previously, reacting to App Home opens meant subscribing to Any Event and filtering downstream, which started an execution for every unrelated Slack event.
 
-### Linear Trigger: webhook signature verification
+### Linear Trigger: Webhook signature verification
 
-Linear credentials gain an optional signing secret. When set, the [Linear Trigger](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.lineartrigger) verifies each incoming webhook's HMAC-SHA256 signature and validates its timestamp within a 60-second window, rejecting invalid or replayed requests with a 401.
+Linear credentials gain an optional signing secret. When set, the [Linear Trigger](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.lineartrigger) verifies the HMAC-SHA256 signature of each incoming webhook and validates its timestamp within a 60-second window, rejecting invalid or replayed requests with a 401.
 
 ---
 
@@ -272,7 +272,7 @@ A [MiniMax chat-model sub-node](https://docs.n8n.io/integrations/builtin/cluster
 
 _Released in 2.26 (2026-06-09)._
 
-The NVIDIA Nemotron Embeddings node generates embeddings from NeMo Retriever models via build.nvidia.com or a self-hosted NIM, reusing the existing NVIDIA credential. The node automatically sets the right input type per call — "passage" when indexing, "query" when searching — preventing the silent retrieval-quality degradation that mismatched input types cause.
+The NVIDIA Nemotron Embeddings node generates embeddings from NeMo Retriever models via build.nvidia.com or a self-hosted NIM, reusing the existing NVIDIA credential. The node automatically sets the right input type per call—"passage" when indexing, "query" when searching—preventing the silent retrieval-quality degradation that mismatched input types cause.
 
 ---
 
@@ -336,7 +336,7 @@ This is the foundational T1 feature. It was extended across later releases: node
 
 **Released:** 2026-03-24
 
-n8n now connects natively to Databricks. The new node runs SQL with asynchronous polling and chunked results (each row arrives as its own item), manages Unity Catalog objects — catalogs, schemas, tables, volumes, and functions — calls Model Serving endpoints with automatic input detection and validation, interacts with Genie AI, handles file operations up to 5 GiB, and manages Vector Search indexes. Lakehouse data can flow through the same workflows as the rest of your stack, without custom HTTP wiring. Learn more in the [Databricks node documentation](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.databricks).
+n8n now connects natively to Databricks. The new node runs SQL with asynchronous polling and chunked results (each row arrives as its own item), manages Unity Catalog objects—catalogs, schemas, tables, volumes, and functions—calls Model Serving endpoints with automatic input detection and validation, interacts with Genie AI, handles file operations up to 5 GiB, and manages Vector Search indexes. Databricks data can flow through the same workflows as the rest of your stack, without custom HTTP wiring. Learn more in the [Databricks node documentation](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.databricks).
 
 ### Perplexity node v2
 
@@ -344,7 +344,7 @@ The [Perplexity node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nod
 
 ### See what depends on what
 
-Workflow, credential, and data table cards — and the data table detail view — now show dependency information, so you can check what relies on a resource before you delete or change it.
+Workflow, credential, and data table cards—and the data table detail view—now show dependency information, so you can check what relies on a resource before you delete or change it.
 
 ---
 

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -14,7 +14,7 @@ For complete, version-by-version detail on every release, see the [Releases page
 
 **Released:** 2026-07-07
 
-You can now authenticate Microsoft nodes with a Microsoft Entra Service Principal, so workflows run as an application instead of a signed-in user. OneDrive and Outlook gained the option in 2.29; Excel 365, Microsoft Teams, and Microsoft To Do follow in 2.30 — all sharing a single app-only credential.
+You can now authenticate Microsoft nodes with a [Microsoft Entra Service Principal](https://docs.n8n.io/integrations/builtin/credentials/microsoftentraserviceprincipal), so workflows run as an application instead of a signed-in user. OneDrive and Outlook gained the option in 2.29; Excel 365, Microsoft Teams, and Microsoft To Do follow in 2.30 — all sharing a single app-only credential.
 
 Until now, Microsoft automations were tied to a person's OAuth session: when that person left the company or their token expired, the workflow broke. With app-only authentication, the workflow authenticates non-interactively with tenant-level permissions and targets the user, mailbox, drive, or site you specify — read a shared mailbox, process files in any user's drive, or post to Teams channels with nobody logged in. OAuth2 remains the default everywhere, so existing workflows are untouched, and operations that only make sense for a signed-in user are disabled per node with a clear error.
 
@@ -24,11 +24,11 @@ _OneDrive and Outlook support released in 2.29 (2026-06-30)._
 
 _Released in 2.29 (2026-06-30)._
 
-GitHub nodes can now authenticate as a GitHub App instead of a personal access token. Authentication is JWT-based with standardized private-key handling, so your GitHub automations belong to the organization rather than to whoever created the token — with fine-grained permissions and no PAT to rotate when people move on.
+[GitHub nodes](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) can now authenticate as a GitHub App instead of a personal access token. Authentication is JWT-based with standardized private-key handling, so your GitHub automations belong to the organization rather than to whoever created the token — with fine-grained permissions and no PAT to rotate when people move on.
 
 ### mTLS authentication for Kafka
 
-The Kafka credential now supports mutual TLS: provide a CA certificate, client certificate, and private key (PEM) to connect to brokers that require client-certificate authentication. mTLS applies to the Kafka node, the Kafka Trigger, and the credential test, and n8n validates that certificate and key match before you save.
+The [Kafka credential](https://docs.n8n.io/integrations/builtin/credentials/kafka) now supports mutual TLS: provide a CA certificate, client certificate, and private key (PEM) to connect to brokers that require client-certificate authentication. mTLS applies to the Kafka node, the Kafka Trigger, and the credential test, and n8n validates that certificate and key match before you save.
 
 ---
 
@@ -89,11 +89,11 @@ Learn more in the [Canvas Groups documentation](https://docs.n8n.io/build/unders
 
 ### GitHub node: manage the full pull request lifecycle
 
-The GitHub node now has a dedicated Pull Request resource. Create pull requests (including drafts and cross-fork PRs), update, close, and reopen them, read and add comments, fetch diffs and patches, and merge with merge, squash, or rebase — native operations that replace the custom HTTP Request setups these tasks used to need. Errors are surfaced exactly as GitHub returns them, so failures are easy to diagnose.
+The [GitHub node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.github) now has a dedicated Pull Request resource. Create pull requests (including drafts and cross-fork PRs), update, close, and reopen them, read and add comments, fetch diffs and patches, and merge with merge, squash, or rebase — native operations that replace the custom HTTP Request setups these tasks used to need. Errors are surfaced exactly as GitHub returns them, so failures are easy to diagnose.
 
 ### Webhook node: Only Run If
 
-The Webhook node gains an expression-based **Only run if** option that rejects requests that don't match a condition before an execution starts. Filter out health checks, retries, or irrelevant events at the door instead of starting a run that immediately exits — fewer no-op executions, less noise in your execution list, and saved execution quota.
+The [Webhook node](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook) gains an expression-based **Only run if** option that rejects requests that don't match a condition before an execution starts. Filter out health checks, retries, or irrelevant events at the door instead of starting a run that immediately exits — fewer no-op executions, less noise in your execution list, and saved execution quota.
 
 ---
 
@@ -123,7 +123,7 @@ Your AI agents can now search the web out of the box. Enable web search from the
 
 ### Form Trigger: restrict forms to logged-in users
 
-The Form Trigger (v2.6) adds an **n8n User Auth** option that gates a form to authenticated users of your instance. Visitors who aren't signed in are redirected to the n8n login, and the trigger outputs the authenticated user's ID, email, and name alongside the submission (with an opt-out). It works with all n8n auth modes and across multi-page forms — ideal for internal request forms where you need to know reliably who submitted.
+The [Form Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger) (v2.6) adds an **n8n User Auth** option that gates a form to authenticated users of your instance. Visitors who aren't signed in are redirected to the n8n login, and the trigger outputs the authenticated user's ID, email, and name alongside the submission (with an opt-out). It works with all n8n auth modes and across multi-page forms — ideal for internal request forms where you need to know reliably who submitted.
 
 ### Custom OAuth scopes for Microsoft credentials
 
@@ -135,15 +135,15 @@ The OneDrive, Outlook, and SharePoint OAuth2 credentials now include a **Custom 
 
 **Released:** 2026-05-27
 
-The Odoo node has been rebuilt as v2, while existing v1 workflows keep working unchanged. The new version supports API-key authentication for Odoo 19+, searchable resource locators so you pick records from a list instead of pasting IDs, and dynamic field mapping on create and update that shows the actual fields of your Odoo instance — with read-only and computed fields hidden so you can't write to what can't be written. Contact, Opportunity, Activity, and Custom resources round out the coverage, and the node selects the right API transport for your Odoo version automatically.
+The [Odoo node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.odoo) has been rebuilt as v2, while existing v1 workflows keep working unchanged. The new version supports API-key authentication for Odoo 19+, searchable resource locators so you pick records from a list instead of pasting IDs, and dynamic field mapping on create and update that shows the actual fields of your Odoo instance — with read-only and computed fields hidden so you can't write to what can't be written. Contact, Opportunity, Activity, and Custom resources round out the coverage, and the node selects the right API transport for your Odoo version automatically.
 
 ### Oracle Database as a vector store
 
-New Oracle DB Vector Store and Oracle ONNX Embedding nodes bring retrieval-augmented generation to data that lives in Oracle. Insert, load, and retrieve documents (including retrieve-as-tool for AI agents) with configurable distance strategies and metadata filtering that supports nested AND/OR conditions. Embeddings are generated by an ONNX model loaded in the database itself, so vectors and source data stay in one place. Requires an ONNX model in the database.
+New [Oracle DB Vector Store](https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreoracledb) and [Oracle ONNX Embedding](https://docs.n8n.io/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsoracledb) nodes bring retrieval-augmented generation to data that lives in Oracle. Insert, load, and retrieve documents (including retrieve-as-tool for AI agents) with configurable distance strategies and metadata filtering that supports nested AND/OR conditions. Embeddings are generated by an ONNX model loaded in the database itself, so vectors and source data stay in one place. Requires an ONNX model in the database.
 
 ### Complete results from multi-run sub-workflows
 
-When a sub-workflow's last node runs more than once, the Execute Workflow Trigger (v1.2) now returns the items from every run, concatenated per output branch — previously you only got the final run. Older trigger versions keep their existing behavior and gain an **Items to return** option to opt in.
+When a sub-workflow's last node runs more than once, the [Execute Workflow Trigger](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger) (v1.2) now returns the items from every run, concatenated per output branch — previously you only got the final run. Older trigger versions keep their existing behavior and gain an **Items to return** option to opt in.
 
 ---
 
@@ -186,7 +186,7 @@ This is part of a broader hardening pass across releases: Netlify verification s
 
 ### Jira: OAuth2 authentication
 
-The Jira node and Jira Trigger add a **Cloud (OAuth2)** authentication option using Atlassian's OAuth 2.0 authorization code flow (3LO). Connect through auth.atlassian.com with your Atlassian cloud ID resolved and cached automatically — no more creating and rotating API tokens by hand for Jira Cloud.
+The [Jira node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.jira) and [Jira Trigger](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.jiratrigger) add a **Cloud (OAuth2)** authentication option using Atlassian's OAuth 2.0 authorization code flow (3LO). Connect through auth.atlassian.com with your Atlassian cloud ID resolved and cached automatically — no more creating and rotating API tokens by hand for Jira Cloud.
 
 ---
 
@@ -246,11 +246,11 @@ You can now mark projects, folders, workflows, and data tables as favorites, so 
 
 ### Slack Trigger: App Home opens as a dedicated event
 
-The Slack Trigger now offers **app_home_opened** as a dedicated event option. Previously, reacting to App Home opens meant subscribing to Any Event and filtering downstream, which started an execution for every unrelated Slack event.
+The [Slack Trigger](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger) now offers **app_home_opened** as a dedicated event option. Previously, reacting to App Home opens meant subscribing to Any Event and filtering downstream, which started an execution for every unrelated Slack event.
 
 ### Linear Trigger: webhook signature verification
 
-Linear credentials gain an optional signing secret. When set, the Linear Trigger verifies each incoming webhook's HMAC-SHA256 signature and validates its timestamp within a 60-second window, rejecting invalid or replayed requests with a 401.
+Linear credentials gain an optional signing secret. When set, the [Linear Trigger](https://docs.n8n.io/integrations/builtin/trigger-nodes/n8n-nodes-base.lineartrigger) verifies each incoming webhook's HMAC-SHA256 signature and validates its timestamp within a 60-second window, rejecting invalid or replayed requests with a 401.
 
 ---
 
@@ -258,7 +258,7 @@ Linear credentials gain an optional signing secret. When set, the Linear Trigger
 
 **Released:** 2026-04-13
 
-Two model providers join n8n's AI lineup natively. **Moonshot Kimi** arrives as both a chat-model sub-node for AI Agents (with a dynamic model list, defaulting to kimi-k2.5) and a standalone node with multi-turn chat, tool calling, built-in web search, thinking mode, JSON responses, and image analysis. **Alibaba Cloud Model Studio** brings the Qwen family: chat with web search and agent-tool support, vision-language image analysis, text-to-image, and text- and image-to-video generation with automatic download of results.
+Two model providers join n8n's AI lineup natively. **Moonshot Kimi** arrives as both a [chat-model sub-node](https://docs.n8n.io/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatmoonshot) for AI Agents (with a dynamic model list, defaulting to kimi-k2.5) and a [standalone node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-langchain.moonshot) with multi-turn chat, tool calling, built-in web search, thinking mode, JSON responses, and image analysis. **[Alibaba Cloud Model Studio](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-langchain.alibabacloud)** brings the Qwen family: chat with web search and agent-tool support, vision-language image analysis, text-to-image, and text- and image-to-video generation with automatic download of results.
 
 More providers followed in later releases:
 
@@ -266,7 +266,7 @@ More providers followed in later releases:
 
 _Released in 2.18 (2026-04-21)._
 
-A MiniMax chat-model sub-node (OpenAI-compatible API, default MiniMax-M2.7, with a Hide Thinking option that strips reasoning traces for clean responses) plus a standalone MiniMax node covering chat, image generation, asynchronous video generation, and text-to-speech with voice, emotion, speed, and pitch controls.
+A [MiniMax chat-model sub-node](https://docs.n8n.io/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatminimax) (OpenAI-compatible API, default MiniMax-M2.7, with a Hide Thinking option that strips reasoning traces for clean responses) plus a [standalone MiniMax node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-langchain.minimax) covering chat, image generation, asynchronous video generation, and text-to-speech with voice, emotion, speed, and pitch controls.
 
 ### NVIDIA Nemotron embeddings
 
@@ -336,11 +336,11 @@ This is the foundational T1 feature. It was extended across later releases: node
 
 **Released:** 2026-03-24
 
-n8n now connects natively to Databricks. The new node runs SQL with asynchronous polling and chunked results (each row arrives as its own item), manages Unity Catalog objects — catalogs, schemas, tables, volumes, and functions — calls Model Serving endpoints with automatic input detection and validation, interacts with Genie AI, handles file operations up to 5 GiB, and manages Vector Search indexes. Lakehouse data can flow through the same workflows as the rest of your stack, without custom HTTP wiring.
+n8n now connects natively to Databricks. The new node runs SQL with asynchronous polling and chunked results (each row arrives as its own item), manages Unity Catalog objects — catalogs, schemas, tables, volumes, and functions — calls Model Serving endpoints with automatic input detection and validation, interacts with Genie AI, handles file operations up to 5 GiB, and manages Vector Search indexes. Lakehouse data can flow through the same workflows as the rest of your stack, without custom HTTP wiring. Learn more in the [Databricks node documentation](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.databricks).
 
 ### Perplexity node v2
 
-The Perplexity node moves to v2 with full API coverage while keeping v1 workflows compatible: agent responses with third-party models, tools, and JSON-schema structured outputs; raw search with advanced filters; and embeddings, including contextualized embeddings.
+The [Perplexity node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-langchain.perplexity) moves to v2 with full API coverage while keeping v1 workflows compatible: agent responses with third-party models, tools, and JSON-schema structured outputs; raw search with advanced filters; and embeddings, including contextualized embeddings.
 
 ### See what depends on what
 

--- a/styles/config/vocabularies/default/accept.txt
+++ b/styles/config/vocabularies/default/accept.txt
@@ -6,6 +6,7 @@ Adalo
 [Aa]ggregate
 Airtable
 Airtop
+Alibaba
 [Aa]llowlists?
 Anthropic
 APIs
@@ -133,6 +134,7 @@ JumpCloud
 Keap
 Keycloak
 Kibana
+Kimi
 Kitemaker
 kubectl
 Kafka

--- a/styles/config/vocabularies/default/accept.txt
+++ b/styles/config/vocabularies/default/accept.txt
@@ -6,7 +6,6 @@ Adalo
 [Aa]ggregate
 Airtable
 Airtop
-Alibaba
 [Aa]llowlists?
 Anthropic
 APIs
@@ -134,7 +133,6 @@ JumpCloud
 Keap
 Keycloak
 Kibana
-Kimi
 Kitemaker
 kubectl
 Kafka


### PR DESCRIPTION
## What this adds

Backfills the [changelog](https://docs.n8n.io/changelog) with entries for 2.x releases that shipped changelog-worthy features but never got one, based on a comparison against the full 2.x release feed. Uses the new divider + version-badge format from #5004. Newest first:

- **n8n 2.30 — App-only authentication for Microsoft nodes** (folds in the 2.29 OneDrive/Outlook support, GitHub App authentication, and adds Kafka mTLS)
- **n8n 2.25 — Web search for AI agents** (+ Form Trigger n8n user auth, custom OAuth scopes for Microsoft credentials)
- **n8n 2.23 — Rebuilt Odoo node and Oracle vector search** (+ complete results from multi-run sub-workflows)
- **n8n 2.21 — Verified webhooks across fourteen trigger nodes** (+ Jira OAuth2/3LO)
- **n8n 2.18 — Favorites** (deliberately compact; + Slack `app_home_opened` event, Linear webhook verification)
- **n8n 2.17 — New model providers roundup** (Moonshot Kimi, Alibaba Cloud Model Studio; MiniMax attributed to 2.18, NVIDIA Nemotron embeddings to 2.26)
- **n8n 2.14 — Databricks node** (+ Perplexity v2, resource dependency visibility)

Also extends the existing **2.28** entry with two subsections: GitHub Pull Request resource and the Webhook node's *Only run if* filter.

## Decisions taken during review prep

- **No screenshots**: the docs repo has no reusable visuals for these features (integration pages are text-only by convention), and the entries were judged to work without them; the Favorites entry was trimmed to a deliberately compact form instead.
- **Docs links embedded and verified**: 21 links across the entries, all checked to return HTTP 200 on docs.n8n.io. Features without an existing docs page (Favorites, agent web search, Form Trigger user auth specifics, Nemotron embeddings) intentionally carry no link.
- Release dates use the `X.Y.0` GitHub publish date, matching the convention of most existing entries.

## Notes

- 2.24 was investigated: the `n8n@2.24.0` tag exists (2026-06-02) but no release was ever published — the version was skipped and its content shipped as 2.25.1. No entry needed.
- Docs-gap follow-up for the docs team: Favorites, agent web search, Form Trigger n8n User Auth, Webhook *Only run if*, and the GitHub PR resource are not yet documented anywhere in the docs.
- Open question: whether the 2.22 entry should also gain a subsection for parallel evaluation execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
