### PR TITLE
docs: changelog says preview, not beta

### DIFF
--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -102,7 +102,7 @@ Imports are checked up front. If a conflict or an unresolved credential would bl
 This makes it easy to promote workflows from development to production, back up and restore an instance, hand a workflow to a teammate without sharing secrets, or migrate between instances.
 
 {% hint style="warning" %}
-This feature is in **beta**. The package format and APIs are still under development, and breaking changes may occur without a major version bump.
+This feature is in **preview**. The package format and APIs are still under development, and breaking changes may occur without a major version bump.
 {% endhint %}
 
 Learn more in the [n8n Packages documentation](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/n8n-packages).


### PR DESCRIPTION
Product terminology alignment (2026-07-09): pre-release features are called **preview**, never **beta**. One occurrence in the changelog, in the 2.27 packages warning hint — now fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)