### PR TITLE
docs: bring both google cred pages in line with each other

### DIFF
--- a/docs/integrations/builtin/credentials/google/oauth-generic.md
+++ b/docs/integrations/builtin/credentials/google/oauth-generic.md
@@ -72,7 +72,13 @@ If you haven't used OAuth in your Google Cloud project before, you'll need to [c
 2. Open the left navigation menu and go to **APIs & Services > OAuth consent screen**. Google will redirect you to the Google Auth Platform overview page.
 3. Select **Get started** on the **Overview** tab to begin configuring OAuth consent.
 4. Enter an **App name** and **User support email** to include on the Oauth screen. Select **Next** to continue.
-5. For the **Audience**, select **Internal** for user access within your organization's Google workspace or **External** for any user with a Google account. Refer to Google's [User type documentation](https://support.google.com/cloud/answer/15549945?sjid=17061891731152303663-EU#user-type) for more information on user types. Select **Next** to continue.
+5.  For the **Audience**, select **Internal** for user access within your organization's Google workspace or **External** for any user with a Google account. Refer to Google's [User type documentation](https://support.google.com/cloud/answer/15549945?sjid=17061891731152303663-EU#user-type) for more information on user types. Select **Next** to continue.<br>
+
+    {% hint style="info" %}
+    **Testing mode and test users**
+
+    If you select **External**, your app will default to Testing mode. In this mode, only Google accounts you manually add as test users can complete the OAuth flow — everyone else will see an "access denied" screen. See [Google hasn't verified this app](oauth-generic.md#google-hasnt-verified-this-app) to learn how to add them.
+    {% endhint %}
 6. Select the **Email addresses** Google should use to contact you about changes to your project. Select **Next** to continue.
 7. Read and accept the Google's User Data Policy. Select **Continue** and then select **Create**.
 8. In the left-hand menu, select **Branding**.
@@ -90,7 +96,13 @@ Next, create the OAuth client credentials in Google:
 3. Select **+ Create credentials** > **OAuth client ID**.
 4. In the **Application type** dropdown, select **Web application**.
 5. Google automatically generates a **Name**. Update the **Name** to something you'll recognize in your console.
-6. From your n8n credential, copy the **OAuth Redirect URL**. Paste it into the **Authorized redirect URIs** in Google Console.
+6.  From your n8n credential, copy the **OAuth Redirect URL**. Paste it into the **Authorized redirect URIs** in Google Console.<br>
+
+    {% hint style="info" %}
+    **OAuth redirect URL for self-hosting**
+
+    If you're running n8n on your local machine, you don't need a public domain, SSL certificate, or port forwarding to use Google OAuth. Google allows localhost as a valid redirect URI for development purposes. Your n8n OAuth redirect URL will look something like this: `http://localhost:5678/rest/oauth2-credential/callback` For more details on acceptable redirect URIs, refer to [Google's redirect URI documentation](https://support.google.com/cloud/answer/15549257?hl=en#zippy=%2Cweb-applications).
+    {% endhint %}
 7. Select **Create**.
 
 ### Finish your n8n credential <a href="#finish-your-n8n-credential" id="finish-your-n8n-credential"></a>
@@ -156,3 +168,21 @@ n8n doesn't support all scopes. When creating a generic Google OAuth2 API creden
 ### Google Cloud app becoming unauthorized <a href="#google-cloud-app-becoming-unauthorized" id="google-cloud-app-becoming-unauthorized"></a>
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/PlbR0ntmBBE0DgjKiavq/" %}
+
+### redirect\_uri\_mismatch <a href="#redirecturimismatch" id="redirecturimismatch"></a>
+
+This error means the redirect URI n8n is sending doesn't match any of the URIs registered in your Google Cloud Console OAuth client.
+
+**Fix:** Copy the **OAuth Redirect URL** from your n8n credential panel and paste it exactly — including the protocol (`http` or `https`) and port number — into the **Authorized redirect URIs** field of your Google OAuth client.
+
+### Access denied / "app not verified" <a href="#access-denied-app-not-verified" id="access-denied-app-not-verified"></a>
+
+This usually happens when your app is still in Testing mode and the Google account you're trying to authenticate with hasn't been added as a test user.
+
+**Fix:** Go to **APIs & Services** > **OAuth consent screen** > **Test users** and add the account you're trying to use.
+
+### invalid\_client <a href="#invalidclient" id="invalidclient"></a>
+
+This error typically means the Client ID or Client Secret in your n8n credential doesn't match what's in Google Cloud Console.
+
+**Fix:** Go back to your OAuth client in Google Cloud Console, copy both values fresh, and re-enter them in n8n. Watch out for accidental spaces when copying.


### PR DESCRIPTION
## Summary

Adds the OAuth guidance a community member contributed to the [Google OAuth2 single service](https://docs.n8n.io/integrations/builtin/credentials/google/oauth-single-service) page (#4517) to the [Google OAuth2 generic](https://docs.n8n.io/integrations/builtin/credentials/google/oauth-generic) page, so the two credential pages stay in sync.

## Changes

- **Testing mode and test users** hint added to the *Configure your OAuth consent screen* step, explaining that External apps default to Testing mode and only added test users can complete the flow.
- **OAuth redirect URL for self-hosting** hint added to the *Create your Google OAuth client credentials* step, noting that Google accepts `localhost` as a redirect URI for local development.
- Three new **Troubleshooting** entries: `redirect_uri_mismatch`, *Access denied / "app not verified"*, and `invalid_client`.

Content matches the single service page. Callouts use GitBook `{% hint %}` syntax.
