### PR TITLE
DOC-1991 GEO: heading rewrite to questions (4 guide pages)

### DIFF
--- a/docs/build/flow-logic/handle-errors-gracefully.md
+++ b/docs/build/flow-logic/handle-errors-gracefully.md
@@ -23,7 +23,7 @@ To investigate failed executions, you can:
 * Enable [Log streaming](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/observe-and-log/stream-logs-to-external-systems).
 {% endhint %}
 
-## Create and set an error workflow <a href="#create-and-set-an-error-workflow" id="create-and-set-an-error-workflow"></a>
+## How do I set up an error workflow? <a href="#create-and-set-an-error-workflow" id="create-and-set-an-error-workflow"></a>
 
 For each workflow, you can set an error workflow in **Workflow Settings**. It runs if an execution fails. This means you can, for example, send email or Slack alerts when a workflow execution errors. The error workflow must start with the [Error Trigger](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.errortrigger).
 
@@ -31,11 +31,11 @@ You can use the same error workflow for multiple workflows.
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/odStQfuU7M0KPowwye9k/" %}
 
-## Error data <a href="#error-data" id="error-data"></a>
+## What data does an error workflow receive? <a href="#error-data" id="error-data"></a>
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/rAiMowL1bA7C4GcH8FyS/" %}
 
-## Cause a workflow execution failure using Stop And Error <a href="#cause-a-workflow-execution-failure-using-stop-and-error" id="cause-a-workflow-execution-failure-using-stop-and-error"></a>
+## How do I make a workflow fail on purpose with the Stop and Error node? <a href="#cause-a-workflow-execution-failure-using-stop-and-error" id="cause-a-workflow-execution-failure-using-stop-and-error"></a>
 
 When you create and set an error workflow, n8n runs it when an execution fails. Usually, this is due to things like errors in node settings, or the workflow running out of memory.
 

--- a/docs/deploy/host-n8n/configure-n8n/security/run-security-audits.md
+++ b/docs/deploy/host-n8n/configure-n8n/security/run-security-audits.md
@@ -15,7 +15,7 @@ layout:
 
 You can run a security audit on your n8n instance, to detect common security issues.
 
-## Run an audit <a href="#run-an-audit" id="run-an-audit"></a>
+## How do I run a security audit in n8n? <a href="#run-an-audit" id="run-an-audit"></a>
 
 You can run an audit using the CLI, the public API, or the n8n node.
 
@@ -32,7 +32,7 @@ Make a `POST` call to the `/audit` endpoint. You must authenticate as the instan
 
 Add the [n8n node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.n8n) to your workflow. Select **Resource** > **Audit** and **Operation** > **Generate**.
 
-## Report contents <a href="#report-contents" id="report-contents"></a>
+## What's in the security audit report? <a href="#report-contents" id="report-contents"></a>
 
 The audit generates five risk reports:
 

--- a/docs/deploy/host-n8n/keep-n8n-running/monitor-n8n.md
+++ b/docs/deploy/host-n8n/keep-n8n-running/monitor-n8n.md
@@ -56,7 +56,7 @@ The `/metrics` endpoint isn't available on n8n Cloud.
 {% endhint %}
 
 
-## Enable metrics and health checks for self-hosted n8n <a href="#enable-metrics-and-health-checks-for-self-hosted-n8n" id="enable-metrics-and-health-checks-for-self-hosted-n8n"></a>
+## How do I enable metrics and health checks? <a href="#enable-metrics-and-health-checks-for-self-hosted-n8n" id="enable-metrics-and-health-checks-for-self-hosted-n8n"></a>
 
 The `/metrics` endpoint is disabled by default. The health endpoint is always enabled on the main n8n server. For worker servers in [queue mode](../configure-n8n/scaling/enable-queue-mode.md), the health endpoint is disabled by default.
 

--- a/docs/deploy/host-n8n/keep-n8n-running/set-up-logging.md
+++ b/docs/deploy/host-n8n/keep-n8n-running/set-up-logging.md
@@ -18,7 +18,7 @@ Logging is an important feature for debugging. n8n uses the [winston](https://ww
 
 n8n Self-hosted Enterprise tier includes [Log streaming](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/observe-and-log/stream-logs-to-external-systems), in addition to the logging options described in this document.
 {% endhint %}
-## Setup <a href="#setup" id="setup"></a>
+## How do I set up logging in n8n? <a href="#setup" id="setup"></a>
 
 To set up logging in n8n, you need to set the following environment variables (you can also set the values in the [configuration file](../configure-n8n/basic-configuration/use-environment-variables/README.md))
 
@@ -59,7 +59,7 @@ n8n uses standard log levels to report:
 - `debug`: the most verbose output. n8n outputs a lot of information to help you debug issues.
 
 
-## Development <a href="#development" id="development"></a>
+## How do I add logging during development? <a href="#development" id="development"></a>
 
 During development, adding log messages is a good practice. It assists in debugging errors. To configure logging for development, follow the guide below.
 
@@ -100,6 +100,6 @@ When creating new loggers, some useful standards to keep in mind are:
 - Include multiple IDs (for example, `executionId`, `workflowId`, and `sessionId`) throughout all logs.
 - Use node types instead of node names (or both) as this is more consistent, and so easier to search.
 
-## Front-end logs <a href="#front-end-logs" id="front-end-logs"></a>
+## Are front-end logs available? <a href="#front-end-logs" id="front-end-logs"></a>
 
 As of now, front-end logs aren't available. Using `Logger` or `LoggerProxy` would yield errors in the `editor-ui` package. This functionality will get implemented in the future versions.


### PR DESCRIPTION
GEO/AEO experiment (Experiment 3): rewrite prose/task headings into the question a user would ask, so AI assistants (ChatGPT, Perplexity, Claude, Copilot) cite these pages more often.

**Approach:** GEO experiment, additive/anchor-preserving; one experiment per page. Only the visible heading text changes. Every existing heading anchor (`<a href id>`) is kept exactly, so links and deep links keep working. Technical headings (healthz, metrics, CLI, API, n8n node, Log levels, Implementation details, report-category names) are left alone.

**Pages touched:**
- `docs/build/flow-logic/handle-errors-gracefully.md`
- `docs/deploy/host-n8n/keep-n8n-running/set-up-logging.md`
- `docs/deploy/host-n8n/configure-n8n/security/run-security-audits.md`
- `docs/deploy/host-n8n/keep-n8n-running/monitor-n8n.md`

Linear: [DOC-1991](https://linear.app/n8n/issue/DOC-1991)
Execution plan: https://app.notion.com/p/3995b6e0c94f81bea163d48f1675cdac