### PR TITLE
DOC-1992 GEO: answer-first sentence after H1 (5 pages)

### DIFF
--- a/docs/build/integrate-ai/README.md
+++ b/docs/build/integrate-ai/README.md
@@ -5,6 +5,8 @@ layout:
 ---
 # Integrate AI <a href="#integrate-ai" id="integrate-ai"></a>
 
+n8n lets you build AI workflows that connect different LLM providers such as OpenAI, Anthropic, and Google, add tools and memory, and combine several models in one workflow.
+
 {% content-ref url="understand-ai-components/README.md" %}
 [understand-ai-components/README.md](understand-ai-components/README.md)
 {% endcontent-ref %}

--- a/docs/deploy/host-n8n/README.md
+++ b/docs/deploy/host-n8n/README.md
@@ -19,6 +19,8 @@ layout:
 
 # Self-hosting n8n <a href="#self-hosting-n8n" id="self-hosting-n8n"></a>
 
+You can self-host n8n on your own infrastructure, on-premises or in a private cloud, using Docker, Kubernetes, or npm.
+
 All self-hosted installations use the same core product. Without a license key, n8n runs as the free [Community edition](community-edition-features.md). Adding a Business or Enterprise license key enables those editions.
 
 ## Choose your installation method <a href="#choose-your-installation-method" id="choose-your-installation-method"></a>

--- a/docs/deploy/host-n8n/configure-n8n/security.md
+++ b/docs/deploy/host-n8n/configure-n8n/security.md
@@ -12,6 +12,8 @@ layout:
 
 # Securing n8n <a href="#securing-n8n" id="securing-n8n"></a>
 
+You can secure a self-hosted n8n instance to protect credentials and workflow data: run a security audit, set up SSL and SSO, restrict nodes and the public API, and redact execution data.
+
 Securing your n8n instance can take several forms.
 
 At a high level, you can:

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/README.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/README.md
@@ -21,6 +21,8 @@ layout:
 
 # AI Agent node <a href="#ai-agent-node" id="ai-agent-node"></a>
 
+The AI Agent node lets you build an AI agent in n8n. Connect a chat model and one or more tools, and the agent decides which tools to call to complete a task.
+
 An [AI agent](#user-content-fn-1)[^1] is an autonomous system that receives data, makes rational decisions, and acts within its environment to achieve specific goals. The AI agent's environment is everything the agent can access that isn't the agent itself. This agent uses external tools[^2] and APIs to perform actions and retrieve information. It can understand the capabilities of different tools and determine which tool to use depending on the task. 
 
 {% hint style="info" %}

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.code/README.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.code/README.md
@@ -25,6 +25,8 @@ layout:
 
 # Code node <a href="#code-node" id="code-node"></a>
 
+The Code node lets you run your own JavaScript or Python inside a workflow, so you can transform data or add logic the built-in nodes don't cover.
+
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/A6AUEJWQnhjgrypgRNwY/" %}
 
 ## Common issues <a href="#common-issues" id="common-issues"></a>


### PR DESCRIPTION
GEO/AEO experiment (Experiment 4): add one short answer-first sentence as the first body line after the H1 on each page, so AI assistants (ChatGPT, Perplexity, Claude, Copilot) get a direct plain-language answer to the target prompt up front.

**Approach:** GEO experiment, additive/anchor-preserving; one experiment per page. Each page gets a single standalone sentence right after the H1, before the existing intro. No existing content is changed or reordered, and every fact is checked against the page.

**Pages touched (target prompt):**
- `docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/README.md` — "how to build an AI agent"
- `docs/integrations/builtin/core-nodes/n8n-nodes-base.code/README.md` — "extend AI workflows with custom code"
- `docs/build/integrate-ai/README.md` — "orchestrate multiple LLM providers"
- `docs/deploy/host-n8n/README.md` — "run workflow automation on-premises"
- `docs/deploy/host-n8n/configure-n8n/security.md` — "prevent sensitive data leaks to external AI models"

Linear: [DOC-1992](https://linear.app/n8n/issue/DOC-1992)
Execution plan: https://app.notion.com/p/3995b6e0c94f81bea163d48f1675cdac