### PR TITLE
DOC-2101 Vale: allowlist technical terms (healthz, winston, URLencoded, booleans)

### DIFF
--- a/styles/config/vocabularies/default/accept.txt
+++ b/styles/config/vocabularies/default/accept.txt
@@ -32,7 +32,7 @@ Bing
 Bitly
 Bitwarden
 blockquote
-[Bb]oolean
+[Bb]ooleans?
 [Bb]orderless
 bot
 Brandfetch
@@ -111,6 +111,7 @@ Groq
 GSuite
 Gumroad
 [Gg]zip
+healthz
 Hetzner
 Homeserver
 [Hh]ostnames?
@@ -286,6 +287,7 @@ uProc
 URI
 URIs
 URL
+URLencoded
 Venafi
 VERO
 Vhost
@@ -298,6 +300,7 @@ Webex
 Webflow
 [Ww]ebsockets?
 WeKan
+winston
 [Ww]ireframe
 WordPress
 Wufoo


### PR DESCRIPTION
The `runner / vale` CI gate runs at `level: error` and fails on any error-level finding in a file a PR modifies. Four legitimate technical terms are flagged as `Vale.Spelling` errors, which turns the GEO experiment PRs (#5039, #5041) red even though the experiment content itself is clean (the question-form headings only trip warning-level rules).

**Terms added to `styles/config/vocabularies/default/accept.txt`:**
| Term | Where |
|------|-------|
| `healthz` | health-check endpoint (monitor-n8n.md) |
| `winston` | logging library (set-up-logging.md) |
| `URLencoded` | HTTP Request node README |
| `booleans` | `[Bb]oolean` was allowlisted but not the plural |

This clears the check repo-wide, not just on the GEO PRs. Kept as a separate PR so the three GEO experiment PRs stay one-lever-each.

Verified locally: after this change, `vale --minAlertLevel=error` reports 0 errors on every file modified by #5039 and #5041.

Linear: [DOC-2101](https://linear.app/n8n/issue/DOC-2101)