### PR TITLE
docs(Tools Agent): Document binary data returned from tools

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/tools-agent.md
@@ -226,6 +226,22 @@ When enabled, the AI Agent sends data back to the user in real-time as it genera
 For streaming to work, your workflow must use a trigger that supports streaming responses, such as the [Chat Trigger](../../../core-nodes/n8n-nodes-langchain.chattrigger/README.md) or [Webhook](../../../core-nodes/n8n-nodes-base.webhook/README.md) node with **Response Mode** set to **Streaming**.
 {% endhint %}
 
+## Binary data from tools
+
+When a connected tool returns binary data, the Tools Agent forwards it to the model along with the tool's text output. This lets a tool hand images, documents, or other files to models that support multimodal input. This behavior is always on. It's separate from the **Automatically Passthrough Binary Images** option, which controls binary attached to the agent's own input.
+
+The agent handles each file based on its MIME type:
+
+- Text-based files, such as `text/*`, `application/json`, `application/xml`, `application/csv`, and YAML, are decoded and inlined as text.
+- Images (`image/*`) are passed as image content the model can view.
+- All other types are passed as file content.
+
+To keep requests within model limits, n8n skips any single file larger than the size set by the `N8N_AI_AGENT_MAX_PASSTHROUGH_BINARY_SIZE_BYTES` environment variable. The default is 50 MB. When n8n skips a file, it adds a note in the tool's output so the model knows a file was left out.
+
+{% hint style="info" %}
+The model must support the type of file you send. For example, sending an image only works with a multimodal model that can process images.
+{% endhint %}
+
 ## Templates and examples <a href="#templates-and-examples" id="templates-and-examples"></a>
 
 Refer to the main AI Agent node's [Templates and examples](./README.md#templates-and-examples) section.


### PR DESCRIPTION
## What
Documents that the **Tools Agent** now forwards binary data returned by a
connected tool (images, documents, other files) to the model, on the
`tools-agent.md` reference page.

Adds a new **Binary data from tools** section covering:

- The behavior is always on, and is distinct from the existing **Automatically
  Passthrough Binary Images** option (which governs binary on the agent's own
  input).
- How each file is handled by MIME type (text inlined, images as image content,
  everything else as file content).
- The `N8N_AI_AGENT_MAX_PASSTHROUGH_BINARY_SIZE_BYTES` size limit (default 50 MB)
  and what happens when a file exceeds it.

## Why
The capability was previously undocumented. It ships with n8n PR
https://github.com/n8n-io/n8n/pull/34161.

## Notes
- The `N8N_AI_AGENT_MAX_PASSTHROUGH_BINARY_SIZE_BYTES` variable is referenced
  inline here; other `N8N_AI_*` agent variables aren't yet in the environment
  variables reference, so a dedicated entry there could be a follow-up.
- Draft until the corresponding n8n PR lands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented that the Tools Agent now forwards binary data returned by tools to the model, separate from the “Automatically Passthrough Binary Images” option. Added a “Binary data from tools” section describing MIME-based handling (text inline, images as image content, others as file content) and the `N8N_AI_AGENT_MAX_PASSTHROUGH_BINARY_SIZE_BYTES` limit (50 MB default) with skip behavior.

<sup>Written for commit f062e1dcf9676421ad6184817438027c898d6341. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

