### PR TITLE
Initial commit of v3.0 breaking changes doc

### DIFF
--- a/docs/changelog/SUMMARY.md
+++ b/docs/changelog/SUMMARY.md
@@ -5,6 +5,7 @@
 * [Release notes 2.x](release-notes-2.x.md)
 * [Release notes 1.x](release-notes-1.x.md)
 * [Release notes 0.x](release-notes-0.x.md)
+* [v3.0 Breaking changes](v30-breaking-changes.md)
 * [v2.0 Breaking changes](v20-breaking-changes.md)
 * [v2.0 Migration tool](v20-migration-tool.md)
 * [v1.0 Migration guide](v10-migration-guide.md)

--- a/docs/changelog/v30-breaking-changes.md
+++ b/docs/changelog/v30-breaking-changes.md
@@ -1,0 +1,17 @@
+---
+title: n8n v3.0 breaking changes
+description: Breaking changes coming in version 3.0
+contentType: reference
+nodeTitle: v3.0 breaking changes
+layout:
+  description:
+    visible: false
+---
+
+# n8n v3.0 breaking changes <a href="#n8n-v30-breaking-changes" id="n8n-v20-breaking-changes"></a>
+
+n8n v3.0 has been released, and with it came some important changes. This document highlights breaking changes and actions you should take to prepare for the transition. These updates improve security, simplify configuration, and remove legacy features.
+
+The release of n8n 3.0 continues n8n's commitment to providing a secure, reliable, and production-ready automation platform. This major version includes important security enhancements and cleanup of deprecated features.
+
+

--- a/docs/changelog/v30-breaking-changes.md
+++ b/docs/changelog/v30-breaking-changes.md
@@ -8,9 +8,9 @@ layout:
     visible: false
 ---
 
-# n8n v3.0 breaking changes <a href="#n8n-v30-breaking-changes" id="n8n-v20-breaking-changes"></a>
+# n8n v3.0 breaking changes <a href="#n8n-v30-breaking-changes" id="n8n-v30-breaking-changes"></a>
 
-This document highlights breaking changes and actions you should take to prepare for the upcoming transition to n8n v3.0. These updates improve security, simplify configuration, and remove legacy features.
+This document highlights breaking changes and actions to prepare for the upcoming transition to n8n v3.0. These updates improve security, simplify configuration, and remove legacy features.
 
 The release of n8n 3.0 continues n8n's commitment to providing a secure, reliable, and production-ready automation platform. This major version includes important security enhancements and cleanup of deprecated features.
 

--- a/docs/changelog/v30-breaking-changes.md
+++ b/docs/changelog/v30-breaking-changes.md
@@ -10,7 +10,7 @@ layout:
 
 # n8n v3.0 breaking changes <a href="#n8n-v30-breaking-changes" id="n8n-v20-breaking-changes"></a>
 
-n8n v3.0 has been released, and with it came some important changes. This document highlights breaking changes and actions you should take to prepare for the transition. These updates improve security, simplify configuration, and remove legacy features.
+This document highlights breaking changes and actions you should take to prepare for the upcoming transition to n8n v3.0. These updates improve security, simplify configuration, and remove legacy features.
 
 The release of n8n 3.0 continues n8n's commitment to providing a secure, reliable, and production-ready automation platform. This major version includes important security enhancements and cleanup of deprecated features.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a v3.0 breaking changes page with intro content and linked it in the changelog index. Includes minor formatting fixes; aligns with Linear DOC-2105 pre-announcement and gives teams one place to add entries via follow-up PRs.

<sup>Written for commit c9cb3dca76bb3dc67fbb23fb206cef7a476b27ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

