### PR TITLE
docs: Document additional Airtop node operations and the Run an agent browser profile field

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.airtop.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.airtop.md
@@ -36,10 +36,13 @@ Refer to [Airtop credentials](../credentials/airtop.md) for guidance on setting 
     * Create session
     * Save profile on termination
     * Terminate session
+    * Wait for download
 * Window
     * Create a new browser window
     * Load URL
     * Take screenshot
+    * Get live view
+    * List windows
     * Close window
 * Extraction
     * Query page
@@ -47,8 +50,16 @@ Refer to [Airtop credentials](../credentials/airtop.md) for guidance on setting 
     * Smart scrape page
 * Interaction
     * Click an element
+    * Fill form
     * Hover on an element
+    * Scroll
     * Type
+* File
+    * Upload a file
+    * Get a file
+    * Get many files
+    * Load a file
+    * Delete a file
 
 
 ## Templates and examples <a href="#templates-and-examples" id="templates-and-examples"></a>
@@ -69,11 +80,21 @@ Contact [Airtop's Support](https://docs.airtop.ai/guides/misc/support) for assis
 
 ### Run an agent
 
-Run a published Airtop agent. In the **Agent** field, select the agent to run, then map its input parameters. To run against a specific browser profile, set the optional **Browser Profile ID** field. Leave it empty to use the agent's default profile.
+Run a published Airtop agent. In the **Agent** field, select the agent to run, then map its input parameters. To run the agent against a specific browser profile, enter its ID in the optional **Browser Profile ID** field. Leave it empty to use the agent's default profile.
 
 ### Create a session and window <a href="#create-a-session-and-window" id="create-a-session-and-window"></a>
 
 Create an Airtop browser session to get a **Session ID**, then use it to create a new browser window. After this, you can use any extraction or interaction operation.
+
+### Manage windows
+
+Work with the browser windows in a session:
+
+- **Load URL**: Navigate a window to a page.
+- **Get live view**: Get a Live View URL to watch and control a window in real time.
+- **Take screenshot**: Capture an image of a window.
+- **List windows**: List the windows open in a session.
+- **Close window**: Close a specific window.
 
 ### Extract content <a href="#extract-content" id="extract-content"></a>
 
@@ -87,7 +108,24 @@ Get JSON responses by using the **JSON Output Schema** parameter in query operat
 
 ### Interacting with pages <a href="#interacting-with-pages" id="interacting-with-pages"></a>
 
-Click, hover, or type on elements by describing the element you want to interact with.
+Interact with a page in a session by describing the element you want to act on in natural language:
+
+- **Click an element**, **Hover on an element**, or **Type** text.
+- **Fill form**: Fill several fields at once from a plain-language description of the values.
+- **Scroll**: Scroll to a described element, or by a set amount toward a page edge.
+
+### Work with files
+
+Upload files to Airtop and use them in your browser automations:
+
+- **Upload a file**: Upload a file from a URL or binary data, and optionally attach it to a page's file input in a session.
+- **Load a file**: Attach a previously uploaded file to a page's file input in an existing session.
+- **Get a file** and **Get many files**: Retrieve file details, or download a ready file as binary data.
+- **Delete a file**: Permanently remove an uploaded file by its **File ID**.
+
+### Wait for a download
+
+After you trigger a download in a session, use **Wait for download** to wait until the file is ready, then get its file ID and download URL.
 
 ### Terminate a session <a href="#terminate-a-session" id="terminate-a-session"></a>
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.airtop.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.airtop.md
@@ -30,6 +30,8 @@ Refer to [Airtop credentials](../credentials/airtop.md) for guidance on setting 
 
 ## Operations <a href="#operations" id="operations"></a>
 
+* Agent
+    * Run an agent
 * Session
     * Create session
     * Save profile on termination
@@ -64,6 +66,10 @@ Refer to [Airtop's documentation](https://docs.airtop.ai/api-reference/airtop-ap
 Contact [Airtop's Support](https://docs.airtop.ai/guides/misc/support) for assistance or to create a feature request.
 
 ## Node reference <a href="#node-reference" id="node-reference"></a>
+
+### Run an agent
+
+Run a published Airtop agent. In the **Agent** field, select the agent to run, then map its input parameters. To run against a specific browser profile, set the optional **Browser Profile ID** field. Leave it empty to use the agent's default profile.
 
 ### Create a session and window <a href="#create-a-session-and-window" id="create-a-session-and-window"></a>
 


### PR DESCRIPTION
## Summary

Fills gaps in the Airtop node documentation and documents the optional **Browser Profile ID** field on the **Run an agent** operation.

## What changed

- Adds previously-undocumented operations to the operations list and node reference: the **File** resource (Upload, Get, Get many, Load, Delete), plus **Wait for download**, **Get live view**, **List windows**, **Fill form**, and **Scroll**.
- Adds node-reference sections for managing windows and working with files, and expands the interactions section.
- Documents the optional **Browser Profile ID** field on **Run an agent**.

## Notes

- New headings are plain sentence-case per the style guide; existing migrated headings keep their anchor markup.
- Written against current `main` and using GitBook syntax.
- The **Browser Profile ID** field on *Run an agent* pairs with a corresponding node change. Opened as a draft — happy to split the operation-coverage updates into their own PR if you'd prefer to merge those independently of the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the Airtop node operations missing from the docs and adds guidance for the optional Browser Profile ID on Run an agent, completing AIR-5022.

- Adds node-reference sections for Run an agent, window management, file operations, and Wait for download.
- Covers Get live view, List windows, Fill form, Scroll, and the File resource operations (Upload, Get, Get many, Load, Delete).
- Explains that leaving Browser Profile ID empty uses the agent's default profile.

<sup>Written for commit 0de08943d279312eba9e3418c4d44458e3b51e99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



Relates to https://github.com/n8n-io/n8n/pull/34933