### PR TITLE
Add details of Cloud storage-based pruning

### DIFF
--- a/docs/deploy/host-n8n/configure-n8n/scaling/manage-execution-data.md
+++ b/docs/deploy/host-n8n/configure-n8n/scaling/manage-execution-data.md
@@ -12,6 +12,12 @@ layout:
 
 # Execution data <a href="#execution-data" id="execution-data"></a>
 
+{% hint style="info" %}
+**Only for self-hosted n8n**
+
+This document discusses execution data for self-hosted n8n. On n8n Cloud, n8n manages execution data storage and pruning automatically. Read [Manage your data](../../../use-n8n-cloud/configure-cloud/manage-your-data.md) to learn how it works.
+{% endhint %}
+
 Depending on your executions settings and volume, your n8n database can grow in size and run out of storage.
 
 To avoid this, n8n recommends that you don't save unnecessary data, and enable pruning of old executions data.

--- a/docs/deploy/use-n8n-cloud/configure-cloud/manage-your-data.md
+++ b/docs/deploy/use-n8n-cloud/configure-cloud/manage-your-data.md
@@ -30,16 +30,16 @@ layout:
 There are two concerns when managing data on Cloud:
 
 * Memory usage: complex workflows processing large amounts of data can exceed n8n's memory limits. If this happens, the instance can crash and become inaccessible.
-* Data storage: depending on your execution settings and volume, your n8n database can grow in size and run out of storage.
+* Data storage: your plan includes a storage allowance for saved executions. When your instance exceeds it, n8n prunes the oldest execution data.
 
-To avoid these issues, n8n recommends that you build your workflows with memory efficiency in mind, and don't save unnecessary data
+To avoid these issues, n8n recommends that you build your workflows with memory efficiency in mind, and don't save unnecessary data.
 
 ## Memory limits on each Cloud plan <a href="#memory-limits-on-each-cloud-plan" id="memory-limits-on-each-cloud-plan"></a>
 
 Current plans:
 
-* Trial: 320MiB RAM, 10 millicore CPU burstable
-* Starter: 320MiB RAM, 10 millicore CPU burstable
+* Trial: 640MiB RAM, 10 millicore CPU burstable
+* Starter: 640MiB RAM, 10 millicore CPU burstable
 * Pro-1 (10k executions): 640MiB RAM, 20 millicore CPU burstable
 * Pro-2 (50k executions): 1280MiB RAM, 80 millicore CPU burstable
 * Enterprise: 4096MiB RAM, 80 millicore CPU burstable
@@ -49,17 +49,41 @@ Legacy plans:
 * Start: 320MiB RAM, 10 millicore CPU burstable
 * Power: 1280MiB RAM, 80 millicore CPU burstable
 
-n8n gives each instance up to 100GB of data storage.
-
 ## How to reduce memory consumption in your workflow <a href="#how-to-reduce-memory-consumption-in-your-workflow" id="how-to-reduce-memory-consumption-in-your-workflow"></a>
 
 The way you build workflows affects how much data they consume when executed. Although these guidelines aren't applicable to all cases, they provide a baseline of best practices to avoid exceeding instance memory.
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/EzVIOV8i2lmQ5HW3xFoo/" %}
 
-Note that n8n itself consumes memory to run. On average, the software alone uses around 180MiB RAM.
+Note that n8n itself consumes memory to run. On average, the software alone uses around 320MiB RAM.
 
 Interactions with the UI also consume memory. Playing around with the workflow UI while it performs heavy executions could also push the memory capacity over the limit.
+
+## Data storage limits on each Cloud plan <a href="#cloud-data-pruning-and-out-of-memory-incident-prevention" id="cloud-data-pruning-and-out-of-memory-incident-prevention"></a>
+
+Each Cloud plan includes a storage allowance for saved executions. The allowance covers execution data and binary data combined:
+
+* Starter: 2.5 GB
+* Pro: 25 GB
+* Enterprise: 50 GB
+
+Each plan also limits how many executions n8n saves, and for how long:
+
+* Starter: 2,500 executions and 7 days of retention
+* Pro: 25,000 executions and 30 days of retention
+* Enterprise: 50,000 executions and unlimited retention
+
+### Automatic data pruning <a href="#automatic-data-pruning" id="automatic-data-pruning"></a>
+
+The limits never block your workflows from running or from saving new data. When your instance exceeds one of its limits, n8n prunes the oldest data until the instance is back under the limit. Whichever limit your instance reaches first applies.
+
+Pruning removes binary data first and execution data last, so you keep the longest possible execution history within your allowance.
+
+When n8n prunes an execution's data, the execution stays in your executions list with its status and timing, but its data is no longer available.
+
+## Backups and execution data <a href="#backups-and-execution-data" id="backups-and-execution-data"></a>
+
+Backups of your Cloud instance cover workflows, credentials, and settings. They don't include execution history or binary data. If n8n restores your instance from a backup as part of disaster recovery, or migrates it to an Enterprise plan, your execution history is not retained.
 
 ## How to manage execution data on Cloud <a href="#how-to-manage-execution-data-on-cloud" id="how-to-manage-execution-data-on-cloud"></a>
 
@@ -67,37 +91,18 @@ Execution data includes node data, parameters, variables, execution context, and
 
 Binary data is non-textual data that n8n can't represent as plain text. This is files and media such as images, documents, audio files, and videos. It's much larger than textual data.
 
-If a workflow consumes a large amounts of data and is past testing stage, it's a good option to stop saving the successful executions.
+There is nothing to configure for storage limits or pruning on Cloud. If you frequently experience executions being pruned, you can reduce how much data your instance stores, save fewer executions and avoid processing unnecessarily large payloads. Refer to [How to reduce memory consumption in your workflow](#how-to-reduce-memory-consumption-in-your-workflow) for guidance on keeping payloads small.
 
-There are two ways you can control how much execution data n8n stores in the database:
+If a workflow processes large amounts of data and is past the testing stage, stop saving its successful executions. There are two ways you can control which executions n8n saves:
 
-In the admin dashboard:
+In the admin dashboard, applies to all workflows:
 
 1. From your workspace or editor, navigate to **Admin Panel**.
 2. Select **Manage**.
 3. In **Executions to Save** deselect the executions you don't want to log.
 
-In your workflow settings:
+In your workflow settings, applies to each individual workflow:
 
 1. Select the **Options** <img src="../../.gitbook/assets/three-dot-options-menu (1).png" alt="Options menu" data-size="line"> menu.
 2. Select **Settings**. n8n opens the **Workflow settings** modal.
 3. Change **Save successful production executions** to **Do not save**.
-
-## Cloud data pruning and out of memory incident prevention <a href="#cloud-data-pruning-and-out-of-memory-incident-prevention" id="cloud-data-pruning-and-out-of-memory-incident-prevention"></a>
-
-### Automatic data pruning <a href="#automatic-data-pruning" id="automatic-data-pruning"></a>
-
-n8n automatically prunes execution logs after a certain time or once you reach the max storage limit, whichever comes first. The pruning always happens from oldest to newest and the limits depend on your Could plan:
-
-* Start and Starter plans: max 2500 executions saved and 7 days execution log retention;
-* Pro plans: max 25000 executions saved and 30 days execution log retention;
-* Enterprise plan: max 50000 executions saved and unlimited execution log retention time.
-
-### Manual data pruning <a href="#manual-data-pruning" id="manual-data-pruning"></a>
-
-Heavier executions and use cases can exceed database capacity despite the automatic pruning practices. In cases like this, n8n will manually prune data to protect instance stability.
-
-1. An alert system warns n8n if an instance is at 85% disk capacity.
-2. n8n prunes execution data. n8n does this by running a backup of the instance (workflows, users, credentials and execution data) and restoring it without execution data.
-
-Due to the human steps in this process, the alert system isn't perfect. If warnings are triggered after hours or if data consumption rates are high, there might not be time to prune the data before the remaining disk space fills up.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Documented Cloud’s automatic, storage-based pruning for execution data and updated plan limits to make retention behavior clear. Also updated Trial/Starter memory to 640MiB, base n8n usage to 320MiB, added per-plan storage/retention limits with binary-first pruning, clarified that backups exclude execution/binary data, and added a self-hosted hint linking to the Cloud page.

<sup>Written for commit 8a544644959a6ca21fc7c78e16c74fabb11e70b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

