### PR TITLE
Clarify AI Assistant availability for self-hosted Enterprise

### DIFF
--- a/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant-preview.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant-preview.md
@@ -26,6 +26,12 @@ layout:
 AI Assistant is a preview feature.
 {% endhint %}
 
+{% hint style="warning" %}
+AI Assistant isn't yet available for self-hosted Enterprise. Support for self-hosted Enterprise is coming soon.
+
+If you're an Enterprise customer and want to try AI Assistant before then, contact your Customer Success Manager (CSM) about preview access.
+{% endhint %}
+
 To run AI Assistant on a self-hosted instance, you need:
 
 * An API key for an LLM provider.


### PR DESCRIPTION
## What

Adds a callout to the [Set up AI Assistant (Preview)](https://docs.n8n.io/deploy/host-n8n/configure-n8n/set-up-ai-assistant-preview) page clarifying that AI Assistant **isn't yet available for self-hosted Enterprise** (support coming soon), and pointing Enterprise customers to their CSM for preview access.

## Why

The setup page reads as if any self-hosted instance can enable AI Assistant, which caused confusion for a self-hosted Enterprise customer. Per the internal discussion, self-hosted Enterprise isn't supported yet; the interim path is a CS-managed cloud sandbox preview that CSMs can enable.

Closes DOC-2143.