### PR TITLE
Label Daytona sandbox option as "Option A" for consistency

### DIFF
--- a/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant-preview.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant-preview.md
@@ -174,7 +174,7 @@ AI Assistant runs its work in an isolated sandbox, so a sandbox provider is requ
 | `daytona`     | Recommended setup for most self-hosted instances.                  |
 | `n8n-sandbox` | Advanced setup when you want to host the sandbox service yourself. |
 
-### Daytona
+### Option A: Daytona
 
 If you follow [Quick setup with Daytona](set-up-ai-assistant-preview.md#quick-setup-with-daytona), you already have the required Daytona variables in place.
 


### PR DESCRIPTION
## What

Renames the `Daytona` heading to `Option A: Daytona` in the "Configure a sandbox provider" section of the [Set up AI Assistant (Preview)](https://docs.n8n.io/deploy/host-n8n/configure-n8n/set-up-ai-assistant-preview) page.

## Why

The section already had `Option B: n8n Sandbox Service`, but the Daytona provider heading wasn't labeled — so the page had an "Option B" with no "Option A", reading as a missing option. No links point to the old `#daytona` anchor, so the rename is safe.

Closes DOC-2144.