### PR TITLE
docs: Document N8N_POSTMESSAGE_ALLOWED_ORIGINS environment variable

### DIFF
--- a/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/security.md
+++ b/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/security.md
@@ -35,6 +35,7 @@ layout:
 | `N8N_SAMESITE_COOKIE` | Enum string: `strict`, `lax`, `none` | `lax` | Controls cross-site cookie behavior ([learn more](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite)):<ul><li>`strict`: Sent only for first-party requests.</li><li>`lax` (default): Sent with top-level navigation requests.</li><li>`none`: Sent in all contexts (requires HTTPS).</li></ul> |
 | `N8N_GIT_NODE_DISABLE_BARE_REPOS` | Boolean | `false` | Set to `true` to prevent the [Git node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.git) from working with bare repositories, enhancing security. |
 | `N8N_GIT_NODE_ENABLE_HOOKS` | Boolean | `false` | Set to `true` to allow the [Git node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.git) to execute Git hooks. |
+| `N8N_POSTMESSAGE_ALLOWED_ORIGINS` | String |  | Origins allowed to exchange `postMessage` commands with the editor when it's embedded in another page. Only relevant when embedding the editor is possible, for example when running with `N8N_PREVIEW_MODE=true`. Provide multiple origins as a comma-separated list, for example `https://n8n.io,https://app.example.com`. When empty (the default), the editor accepts messages from any origin. |
 
 ## Security policy using environment variables <a href="#security-policy-using-environment-variables" id="security-policy-using-environment-variables"></a>
 


### PR DESCRIPTION
Adds the `N8N_POSTMESSAGE_ALLOWED_ORIGINS` environment variable to the security environment variables reference.

The variable was introduced in https://github.com/n8n-io/n8n/pull/34674. It lets self-hosted instances restrict which origins may exchange `postMessage` commands with the editor when it's embedded in another page (for example, the workflow preview). The default (empty) keeps the current behavior of accepting messages from any origin.

Linear ticket: https://linear.app/n8n/issue/ADO-5557

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add docs for `N8N_POSTMESSAGE_ALLOWED_ORIGINS` in the security environment variables reference. Explains the comma-separated allowlist for `postMessage` to the embedded editor (only when embedding, e.g. `N8N_PREVIEW_MODE=true`), includes examples, and notes the empty default allows any origin (ADO-5557).

<sup>Written for commit add5bf26f8d439cace4ac81dac38f8ba0ba6f40c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

