### PR TITLE
AI Assistant: move Preview signal to a tag, drop "preview" from URLs

### DIFF
--- a/docs/build/SUMMARY.md
+++ b/docs/build/SUMMARY.md
@@ -21,7 +21,7 @@
   * [Create and edit credentials](understand-workflows/create-and-edit-credentials.md)
 * [Build and manage agents](build-and-manage-agents.md)
 * [Ways of building workflows](ways-of-building-workflows/README.md)
-  * [Use AI Assistant (Preview)](ways-of-building-workflows/ai-assistant-preview.md)
+  * [Use AI Assistant](ways-of-building-workflows/ai-assistant.md)
   * [Use n8n MCP server](ways-of-building-workflows/connect-to-n8n-mcp-server.md)
   * [Use templates](ways-of-building-workflows/use-templates.md)
   * [Use AI Workflow Builder](ways-of-building-workflows/ai-workflow-builder.md)

--- a/docs/build/build-and-manage-agents.md
+++ b/docs/build/build-and-manage-agents.md
@@ -84,7 +84,7 @@ Build agents in the Agent Builder. Start with a name and a model, add instructio
 {% hint style="info" %}
 **Use the AI Assistant**
 
-Describe what you want the agent to do to the [AI Assistant](ways-of-building-workflows/ai-assistant-preview.md). It suggests instructions, tools, and skills to add. Refine the suggestions in the Agent Builder as you go.
+Describe what you want the agent to do to the [AI Assistant](ways-of-building-workflows/ai-assistant.md). It suggests instructions, tools, and skills to add. Refine the suggestions in the Agent Builder as you go.
 {% endhint %}
 
 #### Choose a model

--- a/docs/build/ways-of-building-workflows/README.md
+++ b/docs/build/ways-of-building-workflows/README.md
@@ -21,8 +21,8 @@ layout:
 
 # Ways of building workflows
 
-{% content-ref url="ai-assistant-preview.md" %}
-[ai-assistant-preview.md](ai-assistant-preview.md)
+{% content-ref url="ai-assistant.md" %}
+[ai-assistant.md](ai-assistant.md)
 {% endcontent-ref %}
 
 {% content-ref url="connect-to-n8n-mcp-server.md" %}

--- a/docs/build/ways-of-building-workflows/ai-assistant.md
+++ b/docs/build/ways-of-building-workflows/ai-assistant.md
@@ -1,5 +1,5 @@
 ---
-title: Use AI Assistant (Preview)
+title: Use AI Assistant
 description: >-
   Use the AI Assistant to create, edit, test, and troubleshoot n8n workflows from
   a chat.
@@ -9,7 +9,7 @@ layout:
     visible: false
 ---
 
-# Use AI Assistant (Preview)
+# Use AI Assistant
 
 The AI Assistant is a chat-based agent in n8n that helps you create, edit, test, and troubleshoot workflows from natural language. It can also build agents and help with instance tasks, such as renaming or publishing workflows.
 

--- a/docs/build/ways-of-building-workflows/use-the-ai-assistant.md
+++ b/docs/build/ways-of-building-workflows/use-the-ai-assistant.md
@@ -29,7 +29,7 @@ layout:
 Ask n8n AI helps you build, debug, and optimize your workflows. From answering questions about n8n to providing help with coding and expressions[^1], Ask n8n AI supports you as you navigate n8n's capabilities.
 
 {% hint style="info" %}
-Ask n8n AI is n8n's built-in help assistant and is no longer actively developed. To build, edit, and run workflows from a chat, see [Use AI Assistant (Preview)](ai-assistant-preview.md).
+Ask n8n AI is n8n's built-in help assistant and is no longer actively developed. To build, edit, and run workflows from a chat, see [Use AI Assistant](ai-assistant.md).
 {% endhint %}
 
 ## Current capabilities <a href="#current-capabilities" id="current-capabilities"></a>

--- a/docs/deploy/SUMMARY.md
+++ b/docs/deploy/SUMMARY.md
@@ -78,7 +78,7 @@
     * [Manage settings using environment variables](host-n8n/configure-n8n/manage-settings-using-environment-variables.md)
     * [Set up task runners](host-n8n/configure-n8n/set-up-task-runners.md)
     * [Durable scheduler](host-n8n/configure-n8n/durable-scheduler.md)
-    * [Set up AI Assistant (Preview)](host-n8n/configure-n8n/set-up-ai-assistant-preview.md)
+    * [Set up AI Assistant](host-n8n/configure-n8n/set-up-ai-assistant.md)
     * [Manage your license](host-n8n/configure-n8n/manage-your-license.md)
     * [Security](host-n8n/configure-n8n/security.md)
       * [Manage security policies](host-n8n/configure-n8n/security/manage-security-policies.md)

--- a/docs/deploy/host-n8n/configure-n8n/README.md
+++ b/docs/deploy/host-n8n/configure-n8n/README.md
@@ -53,8 +53,8 @@ layout:
 [set-up-task-runners.md](set-up-task-runners.md)
 {% endcontent-ref %}
 
-{% content-ref url="set-up-ai-assistant-preview.md" %}
-[set-up-ai-assistant-preview.md](set-up-ai-assistant-preview.md)
+{% content-ref url="set-up-ai-assistant.md" %}
+[set-up-ai-assistant.md](set-up-ai-assistant.md)
 {% endcontent-ref %}
 
 {% content-ref url="manage-your-license.md" %}

--- a/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
@@ -1,5 +1,6 @@
 ---
 description: Set up the AI Assistant on self-hosted n8n using environment variables.
+status: preview
 layout:
   width: default
   title:
@@ -20,7 +21,7 @@ layout:
     visible: true
 ---
 
-# Set up AI Assistant (Preview)
+# Set up AI Assistant
 
 {% hint style="info" %}
 AI Assistant is a preview feature.
@@ -182,7 +183,7 @@ AI Assistant runs its work in an isolated sandbox, so a sandbox provider is requ
 
 ### Option A: Daytona
 
-If you follow [Quick setup with Daytona](set-up-ai-assistant-preview.md#quick-setup-with-daytona), you already have the required Daytona variables in place.
+If you follow [Quick setup with Daytona](set-up-ai-assistant.md#quick-setup-with-daytona), you already have the required Daytona variables in place.
 
 Daytona creates sandboxes on demand.
 


### PR DESCRIPTION
## What

Renames the two AI Assistant "preview" pages so "preview" is no longer baked into their URLs, and carries the Preview state via the removable `status: preview` frontmatter tag instead.

| Page | Old URL | New URL |
|---|---|---|
| Deploy setup | `.../configure-n8n/set-up-ai-assistant-preview` | `.../configure-n8n/set-up-ai-assistant` |
| Ways to build | `.../ways-of-building-workflows/ai-assistant-preview` | `.../ways-of-building-workflows/ai-assistant` |

Also:
- Deploy page: added `status: preview`, title → **Set up AI Assistant**.
- Ways-to-build page: title → **Use AI Assistant** (already carried the tag).
- Updated both `SUMMARY.md` nav entries, both `README.md` content-ref cards, and the inbound links from `use-the-ai-assistant.md` and `build-and-manage-agents.md`.

## Why

With "preview" in the URL, graduating the feature out of Preview later means renaming the pages and breaking the old links. Putting the Preview signal in a removable tag makes graduation a one-line change — just delete `status: preview` — with no rename, redirect, or 404.

## Redirects

Old URLs → new URLs will be added as **site-level redirects** via the GitBook API (not in this PR). These should be enabled at/after merge so the old links don't 404.

## Note

Touches the same deploy setup page as DOC-2143 (#5116) and DOC-2144 (#5117); depending on merge order one of these will need a quick rebase.

Closes DOC-2149.