### PR TITLE
Use real GitBook page tags for the AI Assistant Preview badge

### DIFF
--- a/docs/build/ways-of-building-workflows/ai-assistant.md
+++ b/docs/build/ways-of-building-workflows/ai-assistant.md
@@ -3,7 +3,9 @@ title: Use AI Assistant
 description: >-
   Use the AI Assistant to create, edit, test, and troubleshoot n8n workflows from
   a chat.
-status: preview
+tags:
+  - tag: preview
+    primary: true
 layout:
   description:
     visible: false

--- a/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
@@ -1,6 +1,8 @@
 ---
 description: Set up the AI Assistant on self-hosted n8n using environment variables.
-status: preview
+tags:
+  - tag: preview
+    primary: true
 layout:
   width: default
   title:


### PR DESCRIPTION
## What

Replaces the non-functional `status: preview` frontmatter on both AI Assistant pages with a real GitBook **page tag**, marked `primary` so the "preview" badge shows at the top of the page *and* in the table of contents.

```yaml
tags:
  - tag: preview
    primary: true
```

Pages:
- `docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md`
- `docs/build/ways-of-building-workflows/ai-assistant.md`

## Why

`status:` is not a field GitBook recognizes, so the tag added in DOC-2149 (#5119) rendered nothing — and the ways-to-build page's pre-existing `status: preview` was migration residue that never displayed either. GitBook's actual page-tags feature uses a `tags:` frontmatter list.

The Preview signal stays fully removable: graduating the feature out of preview is still just deleting these lines — no rename, no redirect.

## Note

GitBook page tags are a beta feature; the tag label/slug/icon are managed in the space Library. Worth confirming the badge renders as expected on the PR preview build.

Closes DOC-2151. Follow-up to DOC-2149.