### PR TITLE
docs(Grist): Document the OAuth2 authentication method

### DIFF
--- a/docs/integrations/builtin/credentials/grist.md
+++ b/docs/integrations/builtin/credentials/grist.md
@@ -28,6 +28,7 @@ Create a [Grist](https://getgrist.com/) account.
 ## Supported authentication methods <a href="#supported-authentication-methods" id="supported-authentication-methods"></a>
 
 - API key
+- OAuth2
 
 ## Related resources <a href="#related-resources" id="related-resources"></a>
 
@@ -41,5 +42,44 @@ To configure this credential, you'll need:
 - A **Grist URL**. This points n8n at your Grist server:
     - The default, `https://api.getgrist.com`, works for any account on hosted Grist (getgrist.com).
     - To restrict the connection to a single team, use `https://YOUR_TEAM.getgrist.com`.
-    - For a self-managed instance, use its URL, without `/api` and without a trailing slash (for example `https://grist.example.com`).
+    - For a self-managed instance, use its URL (for example `https://grist.example.com`).
+
+## Using OAuth2 <a href="#using-oauth2" id="using-oauth2"></a>
+
+On self-managed Grist, OAuth apps are part of the [full Grist edition](https://support.getgrist.com/self-managed/#how-do-i-enable-the-full-edition-of-grist). If your instance doesn't offer them, use an API key.
+
+To configure this credential, you'll need:
+
+- A **Client ID**: Grist gives you this when you register an OAuth app.
+- A **Client Secret**: Grist gives you this when you register an OAuth app.
+- A **Grist URL**. This points n8n at your Grist server:
+    - The default, `https://api.getgrist.com`, works for any account on hosted Grist (getgrist.com).
+    - To restrict the connection to a single team, use `https://YOUR_TEAM.getgrist.com`.
+    - For a self-managed instance, use its URL (for example `https://grist.example.com`).
+
+To register the app and connect:
+
+1. In n8n, start creating a **Grist OAuth2 API** credential and copy the **OAuth Redirect URL**.
+2. In Grist, open the account menu (top right), then go to **Account settings** > **Developer**.
+3. In the **OAuth apps** section, select **Register app**. Enter an **Application name**, for example `n8n`, and paste the n8n redirect URL as the **Redirect URI**.
+4. Select these scopes: `offline_access`, `doc:read`, `doc:write`, and `doc:webhooks`.
+5. Select **Register**, then copy the **Client ID** and **Client Secret**. Grist shows the secret only once.
+6. Back in n8n, enter the Client ID and Client Secret, then select **Connect my account**.
+7. On Grist's authorization screen, choose what the credential can reach: **All documents (now and in the future)**, or **Selected resources** to pick individual documents, workspaces, or sites. Then select **Authorize**.
+
+The selection in step 7 narrows the credential further than the scopes do. Grist enforces it on every call: a request for a document outside the grant fails, even if you can open that document yourself. Pointing a credential at a single document is a good way to give a workflow access to only the data it needs. To change the selection later, or to revoke a credential's access on its own, go to **Account settings** > **Authorized apps** in Grist.
+
+Refer to [Grist's connected apps documentation](https://support.getgrist.com/connected-apps/) for how authorizations work and how to manage them, and [Grist's OAuth apps documentation](https://support.getgrist.com/oauth-apps/) for details on registering an app.
+
+{% hint style="info" %}
+**Register the app with all four scopes**
+
+Select all four scopes, including any you don't expect to use. Grist refuses an authorization that asks for a scope the app wasn't registered with, and connecting fails with an `invalid_scope` error.
+{% endhint %}
+
+{% hint style="info" %}
+**Use the credential at least once a month**
+
+Grist's refresh token expires after 60 days. A workflow that runs at least every 30 days keeps its credential working indefinitely. If a credential sits unused for longer, reconnect it with **Connect my account**. API key credentials don't expire.
+{% endhint %}
 


### PR DESCRIPTION
Documents OAuth2 as a second authentication method for the Grist credential.

- Works on hosted Grist, and on self-managed instances running the full Grist edition. Where OAuth apps aren't available, the API key method is unchanged.
- Grist's consent screen lets you limit the credential to specific documents, and revoke it on its own later. That's the main reason to prefer it over an API key, which carries your full account access.
- The connection needs periodic use. Grist's refresh token expires after 60 days, so an idle workflow will find its credential dead. API keys don't expire.

One line changes in the existing **Using API key** section, dropping advice about URL formatting that the node actually handles now. The rest of the diff is additive.

Companion docs for n8n-io/n8n#34798, part of splitting up n8n-io/n8n#33133.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Grist credential docs previously covered only API keys; they now document OAuth2 setup and access controls. API key behavior remains unchanged, while OAuth2 refresh tokens expire after 60 days without periodic use.

**Documentation**
- Covers hosted Grist and self-managed instances running the full edition, with API key fallback where OAuth apps aren't available.
- Explains app registration, redirect URLs, default scopes (`offline_access`, `doc:read`, `doc:write`), and custom scopes.
- Documents restricting access to selected documents, workspaces, or sites, plus changing or revoking authorization.
- Notes that OAuth2 credentials should be used at least every 30 days and explains how to reconnect them.
- Removes obsolete `/api` and trailing-slash guidance because the node normalizes Grist URLs.

<sup>Written for commit d38d39003cc025420c602ee81fb1c7ba6f97ecfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

