### PR TITLE
Add "Enable agents" section to the AI Assistant setup page

### DIFF
--- a/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
@@ -357,7 +357,7 @@ If an instance admin selects a Brave Search or SearXNG credential in the AI sett
 
 ### Enable agents
 
-Agents run on the same self-hosted stack as AI Assistant. Once AI Assistant works, add the `agents` module to build and run agents on your instance. Agents need n8n `2.32.3` (Beta) or later.
+Agents run on the same self-hosted stack as AI Assistant. Once AI Assistant works, add the `agents` module to [build and run agents on your instance](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/build-and-manage-agents). Agents need n8n `2.32.3` (Beta) or later.
 
 {% hint style="warning" %}
 Agents aren't ready for self-hosted Enterprise yet. Support for self-hosted Enterprise is coming soon.

--- a/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
@@ -386,7 +386,7 @@ WEBHOOK_URL=https://your-public-url
 The knowledge base is a preview feature on self-hosted and needs the Daytona sandbox. Without it, the rest of the agent still works.
 {% endhint %}
 
-For a full deployment example, see [Installation options](../install-options/README.md). After you enable the module, see [Build and manage agents](../../../build/build-and-manage-agents.md).
+For a full deployment example, see [Installation options](../install-options/README.md). After you enable the module, see [Build and manage agents](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/build-and-manage-agents).
 
 ### Disable AI Assistant
 

--- a/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
@@ -359,6 +359,10 @@ If an instance admin selects a Brave Search or SearXNG credential in the AI sett
 
 Agents run on the same self-hosted stack as AI Assistant. Once AI Assistant works, add the `agents` module to build and run agents on your instance. Agents need n8n `2.32.3` (Beta) or later.
 
+{% hint style="warning" %}
+Agents aren't ready for self-hosted Enterprise yet. Support for self-hosted Enterprise is coming soon.
+{% endhint %}
+
 You build agents manually with just the `agents` module: you pick the model, write the instructions, and attach the tools and skills yourself. AI Assistant (`instance-ai`) is optional and adds AI-assisted building, where you describe an agent and n8n scaffolds it for you.
 
 Add `agents` to `N8N_ENABLED_MODULES`, alongside `instance-ai` if you want AI-assisted building:

--- a/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
@@ -355,6 +355,39 @@ Free or unauthenticated providers, including SearXNG, can hit rate limits. Use B
 
 If an instance admin selects a Brave Search or SearXNG credential in the AI settings UI, n8n uses that credential instead of these environment variables.
 
+### Enable agents
+
+Agents run on the same self-hosted stack as AI Assistant. Once AI Assistant works, add the `agents` module to build and run agents on your instance. Agents need n8n `2.32.3` (Beta) or later.
+
+You build agents manually with just the `agents` module: you pick the model, write the instructions, and attach the tools and skills yourself. AI Assistant (`instance-ai`) is optional and adds AI-assisted building, where you describe an agent and n8n scaffolds it for you.
+
+Add `agents` to `N8N_ENABLED_MODULES`, alongside `instance-ai` if you want AI-assisted building:
+
+```bash
+# Enable the agents module (keep instance-ai for AI-assisted building)
+N8N_ENABLED_MODULES=instance-ai,agents
+
+# Knowledge base, optional: reuses the Daytona sandbox you set up for AI Assistant
+N8N_AGENTS_AI_SANDBOX_ENABLED=true
+N8N_AGENTS_AI_SANDBOX_PROVIDER=daytona
+
+# Channels, optional: public URL so Slack, Telegram, and Linear can reach your instance
+WEBHOOK_URL=https://your-public-url
+```
+
+| Variable                        | Description                                                                                                                    |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `N8N_ENABLED_MODULES`           | Include `agents` to enable the module. Keep `instance-ai` for AI-assisted building.                                            |
+| `N8N_AGENTS_AI_SANDBOX_ENABLED` | Set to `true` to enable the knowledge base, so agents can search uploaded files. Requires a Daytona sandbox.                    |
+| `N8N_AGENTS_AI_SANDBOX_PROVIDER`| Sandbox provider for the knowledge base. Use `daytona`. Reuses the Daytona keys you set for AI Assistant.                       |
+| `WEBHOOK_URL`                   | Public, secure URL for your instance. Required to connect agents to channels such as Slack, Telegram, and Linear.              |
+
+{% hint style="info" %}
+The knowledge base is a preview feature on self-hosted and needs the Daytona sandbox. Without it, the rest of the agent still works.
+{% endhint %}
+
+For a full deployment example, see [Installation options](../install-options/README.md). After you enable the module, see [Build and manage agents](../../../build/build-and-manage-agents.md).
+
 ### Disable AI Assistant
 
 To disable AI Assistant, remove `instance-ai` from `N8N_ENABLED_MODULES`.


### PR DESCRIPTION
## What

Adds an **Enable agents** section to the [Set up AI Assistant](https://docs.n8n.io/deploy/host-n8n/configure-n8n/set-up-ai-assistant) page, documenting how to enable agents on self-hosted:

- `agents` in `N8N_ENABLED_MODULES` (manual building needs only this).
- `instance-ai` optional, for AI-assisted building.
- `N8N_AGENTS_AI_SANDBOX_ENABLED` / `_PROVIDER=daytona` for the knowledge base (preview), reusing the AI Assistant Daytona keys.
- `WEBHOOK_URL` for connecting channels (Slack, Telegram, Linear).

Env-var block + variable table matching the page's existing convention. Anchor: `#enable-agents`. Also notes that agents aren't ready for self-hosted Enterprise yet (per product).

## Source of truth

Content follows the team-confirmed Notion doc ("Agents (Preview) - Public Feedback"), aligned in Slack (Sindhuja: go for self-hosted; Robin: knowledge-base setup approved). Requires n8n `2.32.3` (Beta) or later.

**Env vars verified against source** (`@n8n/config` `AgentsConfig`, n8n v2.33.0): `N8N_AGENTS_AI_SANDBOX_ENABLED` (default `false`) and `N8N_AGENTS_AI_SANDBOX_PROVIDER` (only `daytona` supported) are the exact names. The knowledge base gate needs only those two plus the shared `DAYTONA_API_URL`/`DAYTONA_API_KEY` — no separate volume-ID variable.

## Notes / follow-ups

- **Merge gate:** the end-to-end self-hosted agents Docker deployment is still being verified (tracks with #5111). Env vars are confirmed; the full setup walkthrough is not yet tested end to end.
- **Cross-link:** points to the stable `install-options/README.md` for now. Once #5111 lands its dedicated `install-using-docker-compose.md`, repoint there.

Closes DOC-2145.