### PR TITLE
Strengthen agent-building note on the AI Assistant page

### DIFF
--- a/docs/build/ways-of-building-workflows/ai-assistant.md
+++ b/docs/build/ways-of-building-workflows/ai-assistant.md
@@ -32,8 +32,8 @@ You interact with the AI Assistant in a chat. It can use tools inside n8n to hel
 You can ask the AI Assistant to:
 
 - **Create workflows:** describe the automation you want, and the AI Assistant can generate a workflow.
-- **Build agents:** describe the agent you want, and the AI Assistant can suggest instructions, tools, and skills to add.
-- **Edit workflows:** ask it to change a workflow, add nodes, update logic, or adjust configuration. See [Build and manage agents](../build-and-manage-agents.md).
+- **Build agents:** describe the agent you want, and the AI Assistant can suggest instructions, tools, and skills to add. Agents also run on self-hosted with the `agents` module. See [Build and manage agents](../build-and-manage-agents.md) and [Enable agents](../../deploy/host-n8n/configure-n8n/set-up-ai-assistant.md#enable-agents).
+- **Edit workflows:** ask it to change a workflow, add nodes, update logic, or adjust configuration.
 - **Test and troubleshoot workflows:** ask it to run checks, inspect relevant errors, and suggest fixes.
 - **Help with credentials:** prompt you to select an existing credential or create a new one, without pasting secrets into chat.
 - **Use n8n resources:** create or update supporting resources such as [Data Tables](../work-with-data/data-tables.md) when needed.

--- a/docs/build/ways-of-building-workflows/ai-assistant.md
+++ b/docs/build/ways-of-building-workflows/ai-assistant.md
@@ -32,7 +32,7 @@ You interact with the AI Assistant in a chat. It can use tools inside n8n to hel
 You can ask the AI Assistant to:
 
 - **Create workflows:** describe the automation you want, and the AI Assistant can generate a workflow.
-- **Build agents:** describe the agent you want, and the AI Assistant can suggest instructions, tools, and skills to add. Agents also run on self-hosted with the `agents` module. See [Build and manage agents](../build-and-manage-agents.md) and [Enable agents](../../deploy/host-n8n/configure-n8n/set-up-ai-assistant.md#enable-agents).
+- **Build agents:** describe the agent you want, and the AI Assistant can suggest instructions, tools, and skills to add. Agents also run on self-hosted with the `agents` module. See [Build and manage agents](../build-and-manage-agents.md) and [Enable agents](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-ai-assistant#enable-agents).
 - **Edit workflows:** ask it to change a workflow, add nodes, update logic, or adjust configuration.
 - **Test and troubleshoot workflows:** ask it to run checks, inspect relevant errors, and suggest fixes.
 - **Help with credentials:** prompt you to select an existing credential or create a new one, without pasting secrets into chat.


### PR DESCRIPTION
## What

Strengthens the existing "Build agents" item on the [Use AI Assistant](https://docs.n8n.io/build/ways-of-building-workflows/ai-assistant) page:

- Notes that agents also run on self-hosted with the `agents` module.
- Links the item to both [Build and manage agents](https://docs.n8n.io/build/build-and-manage-agents) and the setup page's `#enable-agents` section.
- Moves the misplaced *Build and manage agents* link off the unrelated "Edit workflows" item.

Small, targeted edit — the page already stated AI Assistant can build agents, so this sharpens rather than duplicates.

## Merge ordering

The `#enable-agents` anchor lives in #5125 (DOC-2145), so **merge #5125 first** for that fragment to resolve.

Closes DOC-2147.