### PR TITLE
Add "Daytona" to Vale accepted vocabulary

### DIFF
--- a/styles/config/vocabularies/default/accept.txt
+++ b/styles/config/vocabularies/default/accept.txt
@@ -67,6 +67,7 @@ Cron
 Datadog
 Databricks
 Datastore
+Daytona
 [Dd]atetimes?
 [Dd]edupe
 [Dd]eduplication


### PR DESCRIPTION
## What

Adds `Daytona` to the Vale accept list (`styles/config/vocabularies/default/accept.txt`).

## Why

Daytona is the recommended sandbox provider, referenced ~15+ times across the AI Assistant and agents setup docs, but `Vale.Spelling` flagged it as an error on every mention. This clears the noise so real spelling issues stand out.

Verified locally: Vale no longer flags `Daytona` on the setup page.

Closes DOC-2155.