### PR TITLE
docs: document $('node name').item.binary for referencing binary data

### DIFF
--- a/docs/build/work-with-data/reference-data/reference-previous-nodes.md
+++ b/docs/build/work-with-data/reference-data/reference-previous-nodes.md
@@ -23,6 +23,7 @@ The most frequently used methods for accessing data are:
 
 - **`$json`**: Access JSON data from the current input item
 - **`$('<node-name>').item.json`**: Access JSON data from a [linked item](link-data-items/README.md) in a previous node
+- **`$('<node-name>').item.binary`**: Access binary data (files, images) from a [linked item](link-data-items/README.md) in a previous node
 
 ## Other referencing methods <a href="#other-referencing-methods" id="other-referencing-methods"></a>
 
@@ -84,8 +85,23 @@ Methods for working with the output of other nodes. Some methods and variables a
 | `$("<node-name>").first(branchIndex?, runIndex?)` | The first item output by the given node. If `branchIndex` isn't given it will default to the output that connects `node-name` with the node where you use the expression or code. | ✅ |
 | `$("<node-name>").last(branchIndex?, runIndex?)` | The last item output by the given node. If `branchIndex` isn't given it will default to the output that connects `node-name` with the node where you use the expression or code. | ✅ |
 | `$("<node-name>").item` | The linked item. This is the item in the specified node used to produce the current item. Refer to [Item linking](link-data-items/README.md) for more information on item linking. | ✅ |
+| `$("<node-name>").item.binary` | Binary data from the linked item, keyed by binary property name (`data` by default). Refer to [`BinaryFile`](../transform-data/expression-reference/binaryfile.md) for the available properties. | ✅ |
 | `$("<node-name>").params` | Object containing the query settings of the given node. This includes data such as the operation it ran, result limits, and so on. | ✅ |
 | `$("<node-name>").context` | Boolean. Only available when working with the Loop Over Items node. Provides information about what's happening in the node. Use this to determine whether the node is still processing items. | ✅ |
 | `$("<node-name>").itemMatching(currentNodeInputIndex)` | Use instead of `$("<node-name>").item` in the Code node if you need to trace back from an input item. | ✅ |
 {% endtab %}
 {% endtabs %}
+
+## Reference binary data from a previous node
+
+`$('<node-name>').item` returns the whole [linked item](link-data-items/README.md), so you can read its binary data the same way you read its JSON data: use `.item.json` for the item's JSON object and `.item.binary` for its binary data (files, images, and other attachments).
+
+An item can hold several binary properties, each under its own name, so `.item.binary` returns an object of those properties rather than a single value. Most nodes output binary data under the property name `data`, but the name depends on the upstream node. Each binary property is a `BinaryFile` with fields such as `fileName`, `mimeType`, and `fileExtension`.
+
+For example, to get the file name of the binary property `data` produced by an **HTTP Request** node:
+
+```js
+{{ $('HTTP Request').item.binary.data.fileName }}
+```
+
+For more about binary data and the nodes that produce it, refer to [Binary data](../handle-special-data-types/work-with-files-and-images.md).


### PR DESCRIPTION
## What

Documents `$('<node-name>').item.binary` on the [Reference previous nodes](https://docs.n8n.io/build/work-with-data/reference-data/reference-previous-nodes) page — the binary counterpart to the already-documented `$('<node-name>').item.json`.

Three additions to `reference-previous-nodes.md`:
- A bullet under **Common ways of referencing**, mirroring the `.item.json` bullet.
- A row in the **Output of other nodes** table linking to the `BinaryFile` reference.
- A short **Reference binary data from a previous node** subsection explaining the `.item.json` vs `.item.binary` relationship, with a worked expression example.

## Why

The page is the canonical reference for pulling data from other nodes but only covered JSON, leaving users referencing files/images/attachments with no documented syntax (source of support requests). Requested in DOC-2160.

## Verified

`.item` returns the full linked item (`json` + `binary`), so this has worked since item linking shipped (~n8n 0.166) — no version note needed. Confirmed empirically on a throwaway workflow (Manual Trigger → Convert to File → intermediate Edit Fields that drops binary → Edit Fields reading `$('Convert to File').item.binary.data.fileName`): the final node resolved `fileName`/`mimeType`/`fileExtension` two nodes back through item linking. Vale clean on the changed lines; relative links to `BinaryFile` and Binary data verified.

Closes DOC-2160
