### PR TITLE
ci: post GitBook page-level preview links on docs PRs

### DIFF
--- a/.github/scripts/gitbook_preview_links.py
+++ b/.github/scripts/gitbook_preview_links.py
@@ -148,6 +148,18 @@ def deep_link(space_info: dict, rel: str) -> str:
     return base + rel if rel else base
 
 
+PROD_BASE = "https://docs.n8n.io/"
+
+
+def production_url(filename: str) -> str:
+    """Live docs URL for a page, derived from its path (top folder == URL
+    segment; README -> folder index). Used for pages GitBook doesn't build a
+    preview for (reusable-content fan-out)."""
+    rel = re.sub(r"\.md$", "", filename[len("docs/"):])
+    rel = re.sub(r"(^|/)README$", "", rel)
+    return PROD_BASE + rel.strip("/")
+
+
 def in_summary(space: str, filename: str) -> bool:
     summary = REPO / "docs" / space / "SUMMARY.md"
     try:
@@ -218,8 +230,8 @@ def page_line(space_info: dict, filename: str) -> str:
 
 
 def render(changed, spaces, index) -> str:
-    direct: dict = {}          # space -> [file]
-    reusable: dict = {}        # space -> [(name, [pages], total)]
+    direct: dict = {}          # space -> [file]  (pages with a real preview)
+    reusable_blocks = []       # (name, [affected page paths], total)
     non_pages = []             # files that aren't pages
     unresolved_reusable = []   # include files we couldn't map
 
@@ -235,17 +247,7 @@ def render(changed, spaces, index) -> str:
             if not pages:
                 unresolved_reusable.append(filename)
                 continue
-            # group resolved pages by the space that actually built a preview
-            by_space: dict = {}
-            for p in pages:
-                sp = space_of(p)
-                if sp in spaces and (REPO / p).exists():
-                    by_space.setdefault(sp, []).append(p)
-            if not by_space:
-                unresolved_reusable.append(filename)
-                continue
-            for sp, pgs in by_space.items():
-                reusable.setdefault(sp, []).append((name, pgs, len(pages)))
+            reusable_blocks.append((name, pages, len(pages)))
             continue
 
         if Path(filename).name == "SUMMARY.md" or "/.gitbook/" in filename:
@@ -260,40 +262,51 @@ def render(changed, spaces, index) -> str:
 
     out = [MARKER, "## 📖 GitBook preview for this PR", ""]
 
-    if not direct and not reusable:
+    if not direct and not reusable_blocks:
         out.append("No standalone page previews for this PR's changes.")
         _append_extras(out, spaces, non_pages, unresolved_reusable)
         return "\n".join(out).rstrip() + "\n"
 
-    out.append("Pages you changed, deep-linked into this PR's GitBook revision:")
-    out.append("")
-
-    for space in sorted(set(direct) | set(reusable)):
-        info = spaces[space]
-        out.append(f"### {space}")
-
-        lines = [page_line(info, f) for f in sorted(direct.get(space, []))]
-        if len(lines) > SPACE_COLLAPSE_AFTER:
-            out.append(f"<details><summary>{len(lines)} pages changed</summary>")
+    # Pages changed directly — deep-linked into this PR's GitBook revision.
+    if direct:
+        out.append("Pages you changed, deep-linked into this PR's GitBook revision:")
+        out.append("")
+        for space in sorted(direct):
+            info = spaces[space]
+            out.append(f"### {space}")
+            lines = [page_line(info, f) for f in sorted(direct[space])]
+            if len(lines) > SPACE_COLLAPSE_AFTER:
+                out.append(f"<details><summary>{len(lines)} pages changed</summary>")
+                out.append("")
+                out.extend(lines)
+                out.append("</details>")
+            else:
+                out.extend(lines)
             out.append("")
-            out.extend(lines)
-            out.append("</details>")
-        else:
-            out.extend(lines)
 
-        for name, pages, total in reusable.get(space, []):
+    # Reusable content: GitBook builds a preview for the reusable-content space
+    # only — NOT for the pages that embed the block. So we link the block's diff
+    # (the actual change) and list the live pages it renders on (blast radius).
+    if reusable_blocks:
+        diff = spaces.get("reusable-content", {}).get("editor_url")
+        out.append("### Reusable content")
+        out.append("GitBook previews the reusable block itself, not the pages that "
+                   "embed it. Links below are the block diff plus the **live** pages "
+                   "it renders on.")
+        out.append("")
+        for name, pages, total in reusable_blocks:
+            diff_md = f" · [view diff]({diff})" if diff else ""
+            out.append(f"**`{name}`** — renders on {total} page(s){diff_md}")
             shown = pages[:REUSABLE_CAP]
-            out.append(f"_Reusable block **`{name}`** changed — rendered on "
-                       f"{total} page(s):_")
-            out.append(f"<details><summary>Show {len(shown)} of {total} affected pages</summary>")
+            out.append(f"<details><summary>Show {len(shown)} of {total} pages</summary>")
             out.append("")
             for p in shown:
-                out.append(page_line(info, p))
-            if total > len(shown) and info.get("editor_url"):
-                out.append(f"- …and {total - len(shown)} more — see the "
-                           f"[space diff]({info['editor_url']})")
+                title = page_title(REPO / p, p)
+                out.append(f"- [{title}]({production_url(p)}) — `{p[len('docs/'):]}`")
+            if total > len(shown):
+                out.append(f"- …and {total - len(shown)} more")
             out.append("</details>")
-        out.append("")
+            out.append("")
 
     _append_extras(out, spaces, non_pages, unresolved_reusable)
     return "\n".join(out).rstrip() + "\n"
@@ -313,7 +326,7 @@ def _append_extras(out, spaces, non_pages, unresolved_reusable):
                    + ", ".join(f"`{p}`" for p in sorted(non_pages)[:10])
                    + (" …" if len(non_pages) > 10 else "") + "</sub>")
     out.append("")
-    out.append("<sub>Links point to this PR's GitBook revision · comment updates on each push</sub>")
+    out.append("<sub>Preview links follow this PR's GitBook revision · comment updates on each push</sub>")
 
 
 def main() -> int:

--- a/.github/scripts/gitbook_preview_links.py
+++ b/.github/scripts/gitbook_preview_links.py
@@ -97,6 +97,14 @@ def page_title(path: Path, rel: str) -> str:
     return fm.get("title") or fm.get("nodeTitle") or first_heading(path) or humanize(rel)
 
 
+def md_escape(s: str) -> str:
+    """Neutralize Markdown/HTML in PR-controlled text (page titles) before
+    embedding it in the trusted comment, so a crafted title can't inject links
+    or markup."""
+    s = re.sub(r"\s+", " ", s).strip()
+    return re.sub(r"([\\`*_\[\]()<>|])", r"\\\1", s)
+
+
 # --------------------------------------------------------------------------- #
 # GitBook statuses
 # --------------------------------------------------------------------------- #
@@ -127,20 +135,31 @@ def load_spaces(status_json) -> dict:
 # --------------------------------------------------------------------------- #
 # Path -> URL mapping
 # --------------------------------------------------------------------------- #
+PROD_BASE = "https://docs.n8n.io/"
+
+
 def space_of(filename: str):
     parts = filename.split("/")
     return parts[1] if len(parts) >= 3 and parts[0] == "docs" else None
 
 
-def rel_path(filename: str, space: str) -> str:
-    """Space-relative slug, derived from the file path — which is how GitBook
-    Git Sync builds page URLs. (Frontmatter `url:` exists but is unreliable
-    migration residue: some pages point it at the space root.) README maps to
-    the folder index."""
-    rel = filename[len(f"docs/{space}/"):]
-    rel = re.sub(r"\.md$", "", rel)
+def _rel(filename: str, prefix: str) -> str:
+    rel = re.sub(r"\.md$", "", filename[len(prefix):])
     rel = re.sub(r"(^|/)README$", "", rel)
     return rel.strip("/")
+
+
+# NOTE: URLs are derived from the file path (top folder == URL segment), which is
+# how GitBook Git Sync publishes. Frontmatter `url:` is deliberately NOT used: in
+# this repo it holds the pre-migration URL and is stale. Verified against the live
+# site — path-derived URLs return 200 while `url:`-derived ones 404 or redirect:
+#   changelog/release-notes-2.x        -> 200   (url: release-notes/release-notes -> 404)
+#   changelog/release-notes-1.x        -> 200   (url: release-notes/1.x -> 301 to canonical)
+#   build/manage-workflows/n8n-packages-> 200   (url: manage-workflows/export-and-import/... -> 404)
+#   contribute                          -> 200   (url: contribute-to-n8n -> 404)
+def rel_path(filename: str, space: str) -> str:
+    """Space-relative slug (no space segment, no domain), from the file path."""
+    return _rel(filename, f"docs/{space}/")
 
 
 def deep_link(space_info: dict, rel: str) -> str:
@@ -148,16 +167,10 @@ def deep_link(space_info: dict, rel: str) -> str:
     return base + rel if rel else base
 
 
-PROD_BASE = "https://docs.n8n.io/"
-
-
 def production_url(filename: str) -> str:
-    """Live docs URL for a page, derived from its path (top folder == URL
-    segment; README -> folder index). Used for pages GitBook doesn't build a
-    preview for (reusable-content fan-out)."""
-    rel = re.sub(r"\.md$", "", filename[len("docs/"):])
-    rel = re.sub(r"(^|/)README$", "", rel)
-    return PROD_BASE + rel.strip("/")
+    """Live docs URL for a page GitBook doesn't build a preview for (reusable
+    fan-out), path-derived (top folder == URL segment)."""
+    return PROD_BASE + _rel(filename, "docs/")
 
 
 def in_summary(space: str, filename: str) -> bool:
@@ -221,7 +234,7 @@ def resolve_reusable(filename: str, index: dict):
 def page_line(space_info: dict, filename: str) -> str:
     space = space_of(filename)
     rel = rel_path(filename, space)
-    title = page_title(REPO / filename, rel)
+    title = md_escape(page_title(REPO / filename, rel))
     url = deep_link(space_info, rel)
     edit = space_info.get("editor_url")
     edit_md = f" · [edit]({edit})" if edit else ""
@@ -301,7 +314,7 @@ def render(changed, spaces, index) -> str:
             out.append(f"<details><summary>Show {len(shown)} of {total} pages</summary>")
             out.append("")
             for p in shown:
-                title = page_title(REPO / p, p)
+                title = md_escape(page_title(REPO / p, p))
                 out.append(f"- [{title}]({production_url(p)}) — `{p[len('docs/'):]}`")
             if total > len(shown):
                 out.append(f"- …and {total - len(shown)} more")

--- a/.github/scripts/gitbook_preview_links.py
+++ b/.github/scripts/gitbook_preview_links.py
@@ -234,12 +234,12 @@ def resolve_reusable(filename: str, index: dict):
 def page_line(space_info: dict, filename: str) -> str:
     space = space_of(filename)
     rel = rel_path(filename, space)
-    title = md_escape(page_title(REPO / filename, rel))
+    safe_title = md_escape(page_title(REPO / filename, rel))  # PR-controlled -> escaped
     url = deep_link(space_info, rel)
     edit = space_info.get("editor_url")
     edit_md = f" · [edit]({edit})" if edit else ""
     shown = rel or "(home)"
-    return f"- **[{title}]({url})** — `{shown}`{edit_md}"
+    return f"- **[{safe_title}]({url})** — `{shown}`{edit_md}"
 
 
 def render(changed, spaces, index) -> str:
@@ -314,8 +314,8 @@ def render(changed, spaces, index) -> str:
             out.append(f"<details><summary>Show {len(shown)} of {total} pages</summary>")
             out.append("")
             for p in shown:
-                title = md_escape(page_title(REPO / p, p))
-                out.append(f"- [{title}]({production_url(p)}) — `{p[len('docs/'):]}`")
+                safe_title = md_escape(page_title(REPO / p, p))  # PR-controlled -> escaped
+                out.append(f"- [{safe_title}]({production_url(p)}) — `{p[len('docs/'):]}`")
             if total > len(shown):
                 out.append(f"- …and {total - len(shown)} more")
             out.append("</details>")

--- a/.github/scripts/gitbook_preview_links.py
+++ b/.github/scripts/gitbook_preview_links.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Build a Markdown comment that deep-links each page a PR changed into its
+GitBook preview revision.
+
+GitBook posts a commit status per space whose target_url points at the revision
+*root* (the space landing page), not the changed page. This script takes the
+PR's changed files plus those statuses and produces per-page deep links, so
+reviewers land on the exact page. See .github/workflows/gitbook-preview-links.yml.
+
+Usage:
+    gitbook_preview_links.py <changed_files.json> <combined_status.json>
+
+- changed_files.json: output of `gh api repos/:repo/pulls/:n/files --paginate`
+  (a JSON array of {filename, status, previous_filename?}).
+- combined_status.json: output of `gh api repos/:repo/commits/:sha/status`
+  (one latest entry per context under `.statuses`).
+
+Reads the checked-out repo (CWD = repo root) for SUMMARY.md membership, page
+frontmatter/titles, and REUSABLE_CONTENT_INDEX.md. Stdlib only. Prints the
+comment body to stdout; the marker on the first line makes it a sticky comment.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+MARKER = "<!-- gitbook-preview-links -->"
+REUSABLE_CAP = 10          # max pages listed for a single reusable block
+SPACE_COLLAPSE_AFTER = 15  # collapse a space's direct-page list past this many
+
+REPO = Path.cwd()
+
+
+# --------------------------------------------------------------------------- #
+# Frontmatter / title helpers
+# --------------------------------------------------------------------------- #
+def read_frontmatter(path: Path) -> dict:
+    """Parse the minimal set of frontmatter keys we need (title, nodeTitle,
+    url). Handles simple `key: value` and folded `key: >-` blocks. No YAML dep."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    block = text[3:end].splitlines()
+    fm: dict = {}
+    i = 0
+    wanted = ("title", "nodeTitle", "url")
+    while i < len(block):
+        line = block[i]
+        m = re.match(r"^([A-Za-z0-9_]+):\s*(.*)$", line)
+        if not m:
+            i += 1
+            continue
+        key, val = m.group(1), m.group(2).strip()
+        if key in wanted:
+            if val in (">-", ">", "|", "|-", ""):
+                # folded/empty: gather following indented lines
+                parts = []
+                j = i + 1
+                while j < len(block) and (block[j].startswith((" ", "\t")) or block[j] == ""):
+                    if block[j].strip():
+                        parts.append(block[j].strip())
+                    j += 1
+                fm[key] = " ".join(parts).strip().strip("'\"")
+                i = j
+                continue
+            fm[key] = val.strip("'\"")
+        i += 1
+    return fm
+
+
+def first_heading(path: Path) -> str:
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            m = re.match(r"^#{1,3}\s+(.*)$", line)
+            if m:
+                h = re.sub(r"<a\b[^>]*></a>", "", m.group(1))  # strip anchor tags
+                return h.strip()
+    except (OSError, UnicodeDecodeError):
+        pass
+    return ""
+
+
+def humanize(slug: str) -> str:
+    last = slug.rstrip("/").split("/")[-1] or slug
+    return last.replace("-", " ").replace("_", " ").strip().capitalize()
+
+
+def page_title(path: Path, rel: str) -> str:
+    fm = read_frontmatter(path)
+    return fm.get("title") or fm.get("nodeTitle") or first_heading(path) or humanize(rel)
+
+
+# --------------------------------------------------------------------------- #
+# GitBook statuses
+# --------------------------------------------------------------------------- #
+LIVE_RE = re.compile(r"^GitBook \(\./docs/([^)]+)\) - ")
+EDIT_RE = re.compile(r"^GitBook \(\./docs/([^)]+)\)$")
+
+
+def load_spaces(status_json) -> dict:
+    """space -> {live_base, site_prefix, editor_url}. Only successful builds."""
+    statuses = status_json.get("statuses", status_json) if isinstance(status_json, dict) else status_json
+    spaces: dict = {}
+    for s in statuses:
+        if s.get("state") != "success":
+            continue
+        ctx, url = s.get("context", ""), (s.get("target_url") or "").strip()
+        m = LIVE_RE.match(ctx)
+        if m:
+            base = url if url.endswith("/") else url + "/"
+            spaces.setdefault(m.group(1), {})["live_base"] = base
+            spaces[m.group(1)]["site_prefix"] = base.split("/~/revisions/")[0] + "/"
+            continue
+        m = EDIT_RE.match(ctx)
+        if m:
+            spaces.setdefault(m.group(1), {})["editor_url"] = url
+    return spaces
+
+
+# --------------------------------------------------------------------------- #
+# Path -> URL mapping
+# --------------------------------------------------------------------------- #
+def space_of(filename: str):
+    parts = filename.split("/")
+    return parts[1] if len(parts) >= 3 and parts[0] == "docs" else None
+
+
+def rel_path(filename: str, space: str) -> str:
+    """Space-relative slug, derived from the file path — which is how GitBook
+    Git Sync builds page URLs. (Frontmatter `url:` exists but is unreliable
+    migration residue: some pages point it at the space root.) README maps to
+    the folder index."""
+    rel = filename[len(f"docs/{space}/"):]
+    rel = re.sub(r"\.md$", "", rel)
+    rel = re.sub(r"(^|/)README$", "", rel)
+    return rel.strip("/")
+
+
+def deep_link(space_info: dict, rel: str) -> str:
+    base = space_info["live_base"]
+    return base + rel if rel else base
+
+
+def in_summary(space: str, filename: str) -> bool:
+    summary = REPO / "docs" / space / "SUMMARY.md"
+    try:
+        text = summary.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    rel_md = filename[len(f"docs/{space}/"):]
+    return f"]({rel_md})" in text
+
+
+# --------------------------------------------------------------------------- #
+# Reusable content index
+# --------------------------------------------------------------------------- #
+def norm(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", s.lower()).strip("-")
+
+
+def load_reusable_index() -> dict:
+    """Return {normalized-key: [used_in paths]} keyed by both the index Name and
+    each block's rendered heading, so include files whose basename differs from
+    the Name still resolve."""
+    idx = REPO / "REUSABLE_CONTENT_INDEX.md"
+    out: dict = {}
+    try:
+        lines = idx.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return out
+    for line in lines:
+        if not line.startswith("| `"):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) < 3:
+            continue
+        name = cells[1].strip("` ").strip()
+        used_in = [p.strip() for p in cells[-1].split(",") if p.strip().endswith(".md")]
+        if not used_in:
+            continue
+        out.setdefault(norm(name), used_in)
+    return out
+
+
+def resolve_reusable(filename: str, index: dict):
+    """Map a changed include file to its including pages. Try normalized
+    basename, then the file's own first heading/title. Returns (name, pages) or
+    (None, None) if unresolved."""
+    path = REPO / filename
+    base_key = norm(Path(filename).stem)
+    if base_key in index:
+        return Path(filename).stem, index[base_key]
+    heading = first_heading(path) or read_frontmatter(path).get("title", "")
+    if heading and norm(heading) in index:
+        return Path(filename).stem, index[norm(heading)]
+    return None, None
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+def page_line(space_info: dict, filename: str) -> str:
+    space = space_of(filename)
+    rel = rel_path(filename, space)
+    title = page_title(REPO / filename, rel)
+    url = deep_link(space_info, rel)
+    edit = space_info.get("editor_url")
+    edit_md = f" · [edit]({edit})" if edit else ""
+    shown = rel or "(home)"
+    return f"- **[{title}]({url})** — `{shown}`{edit_md}"
+
+
+def render(changed, spaces, index) -> str:
+    direct: dict = {}          # space -> [file]
+    reusable: dict = {}        # space -> [(name, [pages], total)]
+    non_pages = []             # files that aren't pages
+    unresolved_reusable = []   # include files we couldn't map
+
+    for f in changed:
+        filename = f.get("filename", "")
+        if f.get("status") == "removed" or not filename.endswith(".md"):
+            if f.get("status") != "removed" and filename:
+                non_pages.append(filename)
+            continue
+
+        if "/.gitbook/includes/" in filename:
+            name, pages = resolve_reusable(filename, index)
+            if not pages:
+                unresolved_reusable.append(filename)
+                continue
+            # group resolved pages by the space that actually built a preview
+            by_space: dict = {}
+            for p in pages:
+                sp = space_of(p)
+                if sp in spaces and (REPO / p).exists():
+                    by_space.setdefault(sp, []).append(p)
+            if not by_space:
+                unresolved_reusable.append(filename)
+                continue
+            for sp, pgs in by_space.items():
+                reusable.setdefault(sp, []).append((name, pgs, len(pages)))
+            continue
+
+        if Path(filename).name == "SUMMARY.md" or "/.gitbook/" in filename:
+            non_pages.append(filename)
+            continue
+
+        space = space_of(filename)
+        if space not in spaces or not in_summary(space, filename):
+            non_pages.append(filename)
+            continue
+        direct.setdefault(space, []).append(filename)
+
+    out = [MARKER, "## 📖 GitBook preview for this PR", ""]
+
+    if not direct and not reusable:
+        out.append("No standalone page previews for this PR's changes.")
+        _append_extras(out, spaces, non_pages, unresolved_reusable)
+        return "\n".join(out).rstrip() + "\n"
+
+    out.append("Pages you changed, deep-linked into this PR's GitBook revision:")
+    out.append("")
+
+    for space in sorted(set(direct) | set(reusable)):
+        info = spaces[space]
+        out.append(f"### {space}")
+
+        lines = [page_line(info, f) for f in sorted(direct.get(space, []))]
+        if len(lines) > SPACE_COLLAPSE_AFTER:
+            out.append(f"<details><summary>{len(lines)} pages changed</summary>")
+            out.append("")
+            out.extend(lines)
+            out.append("</details>")
+        else:
+            out.extend(lines)
+
+        for name, pages, total in reusable.get(space, []):
+            shown = pages[:REUSABLE_CAP]
+            out.append(f"_Reusable block **`{name}`** changed — rendered on "
+                       f"{total} page(s):_")
+            out.append(f"<details><summary>Show {len(shown)} of {total} affected pages</summary>")
+            out.append("")
+            for p in shown:
+                out.append(page_line(info, p))
+            if total > len(shown) and info.get("editor_url"):
+                out.append(f"- …and {total - len(shown)} more — see the "
+                           f"[space diff]({info['editor_url']})")
+            out.append("</details>")
+        out.append("")
+
+    _append_extras(out, spaces, non_pages, unresolved_reusable)
+    return "\n".join(out).rstrip() + "\n"
+
+
+def _append_extras(out, spaces, non_pages, unresolved_reusable):
+    if unresolved_reusable:
+        out.append("")
+        out.append(f"> ⚠️ {len(unresolved_reusable)} reusable block(s) changed but "
+                   f"couldn't be mapped to pages — check "
+                   f"[`REUSABLE_CONTENT_INDEX.md`](../blob/main/REUSABLE_CONTENT_INDEX.md): "
+                   + ", ".join(f"`{p}`" for p in sorted(unresolved_reusable)))
+    if non_pages:
+        out.append("")
+        out.append(f"<sub>{len(non_pages)} other changed file(s) aren't standalone "
+                   f"pages (nav, assets, or unlisted): "
+                   + ", ".join(f"`{p}`" for p in sorted(non_pages)[:10])
+                   + (" …" if len(non_pages) > 10 else "") + "</sub>")
+    out.append("")
+    out.append("<sub>Links point to this PR's GitBook revision · comment updates on each push</sub>")
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        sys.stderr.write(__doc__)
+        return 2
+    changed = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+    status_json = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+    spaces = load_spaces(status_json)
+    if not spaces:
+        # No successful GitBook build yet: emit nothing so the workflow skips.
+        return 0
+    index = load_reusable_index()
+    sys.stdout.write(render(changed, spaces, index))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/fixtures/repo/REUSABLE_CONTENT_INDEX.md
+++ b/.github/scripts/tests/fixtures/repo/REUSABLE_CONTENT_INDEX.md
@@ -1,0 +1,6 @@
+# Reusable content index
+
+| ID | Name | Parent space | Include snippet | Preview | Used in |
+|----|------|--------------|-----------------|---------|---------|
+| `id1` | block-one | `SP` | `{% include "x" %}` | preview | docs/spacea/bulk/p01.md, docs/spacea/bulk/p02.md, docs/spacea/bulk/p03.md, docs/spacea/bulk/p04.md, docs/spacea/bulk/p05.md, docs/spacea/bulk/p06.md, docs/spacea/bulk/p07.md, docs/spacea/bulk/p08.md, docs/spacea/bulk/p09.md, docs/spacea/bulk/p10.md, docs/spacea/bulk/p11.md, docs/spacea/bulk/p12.md |
+| `id2` | Tricky heading name | `SP` | `{%% include "y" %%}` | preview | docs/spaceb/other.md |

--- a/.github/scripts/tests/fixtures/repo/docs/reusable-content/.gitbook/includes/block-one.md
+++ b/.github/scripts/tests/fixtures/repo/docs/reusable-content/.gitbook/includes/block-one.md
@@ -1,0 +1,1 @@
+## Block one content

--- a/.github/scripts/tests/fixtures/repo/docs/reusable-content/.gitbook/includes/tricky.md
+++ b/.github/scripts/tests/fixtures/repo/docs/reusable-content/.gitbook/includes/tricky.md
@@ -1,0 +1,4 @@
+---
+title: tricky
+---
+## Tricky heading name

--- a/.github/scripts/tests/fixtures/repo/docs/spacea/README.md
+++ b/.github/scripts/tests/fixtures/repo/docs/spacea/README.md
@@ -1,0 +1,4 @@
+---
+nodeTitle: Space A home
+---
+# Space A

--- a/.github/scripts/tests/fixtures/repo/docs/spacea/SUMMARY.md
+++ b/.github/scripts/tests/fixtures/repo/docs/spacea/SUMMARY.md
@@ -1,0 +1,5 @@
+# Table of contents
+
+* [Space A home](README.md)
+* [Page one](page-one.md)
+* [Page two](sub/page-two.md)

--- a/.github/scripts/tests/fixtures/repo/docs/spacea/SUMMARY.md
+++ b/.github/scripts/tests/fixtures/repo/docs/spacea/SUMMARY.md
@@ -3,3 +3,5 @@
 * [Space A home](README.md)
 * [Page one](page-one.md)
 * [Page two](sub/page-two.md)
+* [Custom slug page](custom.md)
+* [Nested group](nested/README.md)

--- a/.github/scripts/tests/fixtures/repo/docs/spacea/custom.md
+++ b/.github/scripts/tests/fixtures/repo/docs/spacea/custom.md
@@ -1,0 +1,5 @@
+---
+title: 'Weird ]( title [x]'
+url: https://docs.n8n.io/spacea/real/custom-slug
+---
+# Some heading

--- a/.github/scripts/tests/fixtures/repo/docs/spacea/nested/README.md
+++ b/.github/scripts/tests/fixtures/repo/docs/spacea/nested/README.md
@@ -1,0 +1,5 @@
+---
+nodeTitle: Nested group
+url: https://docs.n8n.io/spacea/
+---
+# Nested

--- a/.github/scripts/tests/fixtures/repo/docs/spacea/orphan.md
+++ b/.github/scripts/tests/fixtures/repo/docs/spacea/orphan.md
@@ -1,0 +1,4 @@
+---
+title: Orphan
+---
+# Orphan not in SUMMARY

--- a/.github/scripts/tests/fixtures/repo/docs/spacea/page-one.md
+++ b/.github/scripts/tests/fixtures/repo/docs/spacea/page-one.md
@@ -1,0 +1,5 @@
+---
+title: Page one
+---
+# Something else
+Body.

--- a/.github/scripts/tests/fixtures/repo/docs/spacea/sub/page-two.md
+++ b/.github/scripts/tests/fixtures/repo/docs/spacea/sub/page-two.md
@@ -1,0 +1,2 @@
+# Page two heading <a href="#x" id="x"></a>
+No frontmatter title here.

--- a/.github/scripts/tests/fixtures/repo/docs/spaceb/SUMMARY.md
+++ b/.github/scripts/tests/fixtures/repo/docs/spaceb/SUMMARY.md
@@ -1,0 +1,3 @@
+# Table of contents
+
+* [Other page](other.md)

--- a/.github/scripts/tests/fixtures/repo/docs/spaceb/custom-live.md
+++ b/.github/scripts/tests/fixtures/repo/docs/spaceb/custom-live.md
@@ -1,0 +1,5 @@
+---
+title: Custom live
+url: https://docs.n8n.io/spaceb-real/live/custom
+---
+# Custom live

--- a/.github/scripts/tests/fixtures/repo/docs/spaceb/other.md
+++ b/.github/scripts/tests/fixtures/repo/docs/spaceb/other.md
@@ -1,0 +1,4 @@
+---
+title: Other page
+---
+# Other

--- a/.github/scripts/tests/test_gitbook_preview_links.py
+++ b/.github/scripts/tests/test_gitbook_preview_links.py
@@ -120,6 +120,23 @@ def main():
     check("md_escape neutralizes link breakout",
           gb.md_escape("a](http://evil) b") == r"a\]\(http://evil\) b")
 
+    # Removed reusable index (workflow deletes it from the checkout): the script
+    # must degrade gracefully to an empty index -> reusable changes go unresolved
+    # rather than reporting stale affected pages.
+    saved = gb.REPO
+    try:
+        gb.REPO = HERE  # a dir with no REUSABLE_CONTENT_INDEX.md
+        empty_idx = gb.load_reusable_index()
+        out_no_idx = gb.render(
+            [{"status": "modified",
+              "filename": "docs/reusable-content/.gitbook/includes/block-one.md"}],
+            spaces, empty_idx)
+    finally:
+        gb.REPO = saved
+    check("missing index -> empty mapping", empty_idx == {})
+    check("missing index -> reusable unresolved (no stale pages)",
+          "couldn't be mapped" in out_no_idx)
+
     failed = [n for n, ok in checks if not ok]
     for n, ok in checks:
         print(f"  {'PASS' if ok else 'FAIL'}  {n}")

--- a/.github/scripts/tests/test_gitbook_preview_links.py
+++ b/.github/scripts/tests/test_gitbook_preview_links.py
@@ -39,6 +39,8 @@ CHANGED = [
     {"status": "modified", "filename": "docs/spacea/README.md"},
     {"status": "modified", "filename": "docs/spacea/page-one.md"},
     {"status": "added", "filename": "docs/spacea/sub/page-two.md"},
+    {"status": "modified", "filename": "docs/spacea/custom.md"},         # custom slug
+    {"status": "modified", "filename": "docs/spacea/nested/README.md"},  # stale-root url
     {"status": "modified", "filename": "docs/spacea/orphan.md"},      # not in SUMMARY
     {"status": "modified", "filename": "docs/spacea/SUMMARY.md"},     # nav
     {"status": "modified", "filename": "docs/spaceb/other.md"},
@@ -96,6 +98,27 @@ def main():
     check("SUMMARY.md is a non-page", "SUMMARY.md" in out)
     check("asset is a non-page", "x.png" in out)
     check("removed file never appears", "deleted.md" not in out)
+
+    # Frontmatter `url:` is stale in this repo (pre-migration); URLs must be
+    # PATH-derived. These pages carry a misleading `url:` and must ignore it.
+    check("stale frontmatter url ignored (custom.md -> path slug)",
+          "https://docs.n8n.io/spacea/~/revisions/REVA/custom" in out
+          and "real/custom-slug" not in out)
+    check("stale space-root url ignored (nested README -> path)",
+          "https://docs.n8n.io/spacea/~/revisions/REVA/nested" in out)
+
+    # unit-level checks on the slug/URL helpers (path derivation only)
+    check("rel_path custom.md is path-derived", gb.rel_path("docs/spacea/custom.md", "spacea") == "custom")
+    check("rel_path nested README -> folder", gb.rel_path("docs/spacea/nested/README.md", "spacea") == "nested")
+    check("rel_path space README -> empty", gb.rel_path("docs/spacea/README.md", "spacea") == "")
+    check("production_url is path-derived (folder == segment)",
+          gb.production_url("docs/spaceb/custom-live.md") == "https://docs.n8n.io/spaceb/custom-live")
+
+    # markdown injection in title is escaped
+    check("title markdown escaped (no raw ']( ' breakout)",
+          "Weird \\]\\( title \\[x\\]" in out and "[Weird ](" not in out)
+    check("md_escape neutralizes link breakout",
+          gb.md_escape("a](http://evil) b") == r"a\]\(http://evil\) b")
 
     failed = [n for n, ok in checks if not ok]
     for n, ok in checks:

--- a/.github/scripts/tests/test_gitbook_preview_links.py
+++ b/.github/scripts/tests/test_gitbook_preview_links.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Network-free tests for gitbook_preview_links.py, run against a checked-in
+fake repo tree under tests/fixtures/repo. Locks in path->URL mapping, SUMMARY
+membership, per-space revisions, title extraction, reusable resolution
+(basename + heading), the fan-out cap, and non-page classification.
+
+Run: python3 .github/scripts/tests/test_gitbook_preview_links.py
+"""
+import importlib.util
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "gitbook_preview_links.py"
+FIXTURE_REPO = HERE / "fixtures" / "repo"
+
+spec = importlib.util.spec_from_file_location("gb", SCRIPT)
+gb = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gb)
+gb.REPO = FIXTURE_REPO  # functions read the module global at call time
+
+STATUS = {"statuses": [
+    {"context": "GitBook (./docs/spacea) - docs.n8n.io/spacea/", "state": "success",
+     "target_url": "https://docs.n8n.io/spacea/~/revisions/REVA/"},
+    {"context": "GitBook (./docs/spacea)", "state": "success",
+     "target_url": "https://app.gitbook.com/s/SA/~/diff/~/revisions/REVA/"},
+    {"context": "GitBook (./docs/spaceb) - docs.n8n.io/spaceb/", "state": "success",
+     "target_url": "https://docs.n8n.io/spaceb/~/revisions/REVB/"},
+    {"context": "GitBook (./docs/spaceb)", "state": "success",
+     "target_url": "https://app.gitbook.com/s/SB/~/diff/~/revisions/REVB/"},
+    {"context": "GitBook (./docs/reusable-content)", "state": "success",
+     "target_url": "https://app.gitbook.com/s/RS/~/diff/~/revisions/RREV/"},
+    # A non-GitBook and a still-pending status must be ignored:
+    {"context": "cubic", "state": "success", "target_url": "https://x"},
+    {"context": "GitBook (./docs/spacea) - docs.n8n.io/spacea/", "state": "pending",
+     "target_url": "https://docs.n8n.io/spacea/~/revisions/OLD/"},
+]}
+
+CHANGED = [
+    {"status": "modified", "filename": "docs/spacea/README.md"},
+    {"status": "modified", "filename": "docs/spacea/page-one.md"},
+    {"status": "added", "filename": "docs/spacea/sub/page-two.md"},
+    {"status": "modified", "filename": "docs/spacea/orphan.md"},      # not in SUMMARY
+    {"status": "modified", "filename": "docs/spacea/SUMMARY.md"},     # nav
+    {"status": "modified", "filename": "docs/spaceb/other.md"},
+    {"status": "modified", "filename": "docs/spacea/.gitbook/assets/x.png"},  # asset
+    {"status": "removed", "filename": "docs/spacea/deleted.md"},      # gone
+    {"status": "modified", "filename": "docs/reusable-content/.gitbook/includes/block-one.md"},
+    {"status": "modified", "filename": "docs/reusable-content/.gitbook/includes/tricky.md"},
+]
+
+checks = []
+
+
+def check(name, cond):
+    checks.append((name, bool(cond)))
+
+
+def main():
+    spaces = gb.load_spaces(STATUS)
+    check("only successful GitBook spaces loaded", set(spaces) == {"spacea", "spaceb", "reusable-content"})
+    check("pending status ignored (REVA not OLD)", "OLD" not in spaces["spacea"]["live_base"])
+
+    out = gb.render(CHANGED, spaces, gb.load_reusable_index())
+    print(out)
+    print("=" * 70)
+
+    # section grouping + per-space revisions
+    check("spacea section", "### spacea" in out)
+    check("spaceb section", "### spaceb" in out)
+    check("spacea uses REVA", "/spacea/~/revisions/REVA/" in out)
+    check("spaceb uses REVB (distinct per-space revision)", "/spaceb/~/revisions/REVB/" in out)
+
+    # titles + slugs
+    check("page-one title from frontmatter",
+          "[Page one](https://docs.n8n.io/spacea/~/revisions/REVA/page-one)" in out)
+    check("page-two title from H1 (anchor stripped)",
+          "[Page two heading](https://docs.n8n.io/spacea/~/revisions/REVA/sub/page-two)" in out)
+    check("README maps to space home",
+          "[Space A home](https://docs.n8n.io/spacea/~/revisions/REVA/)" in out and "`(home)`" in out)
+    check("spaceb other page linked",
+          "[Other page](https://docs.n8n.io/spaceb/~/revisions/REVB/other)" in out)
+
+    # reusable: basename match + cap, heading-fallback match, diff link
+    check("reusable section", "### Reusable content" in out)
+    check("block-one resolved by basename to 12 pages", "renders on 12 page(s)" in out)
+    check("reusable cap at 10 + remainder", "Show 10 of 12 pages" in out and "…and 2 more" in out)
+    check("reusable pages use LIVE production URLs",
+          "(https://docs.n8n.io/spacea/bulk/p01)" in out)
+    check("tricky resolved via H2 heading fallback", "**`tricky`** — renders on 1 page(s)" in out)
+    check("reusable diff link uses reusable-content editor revision",
+          "app.gitbook.com/s/RS/~/diff/~/revisions/RREV/" in out)
+    check("no unresolved reusable", "couldn't be mapped" not in out)
+
+    # non-pages: orphan + SUMMARY + asset; NOT the removed file
+    check("orphan (unlisted) is a non-page", "orphan.md" in out and "aren't standalone pages" in out)
+    check("SUMMARY.md is a non-page", "SUMMARY.md" in out)
+    check("asset is a non-page", "x.png" in out)
+    check("removed file never appears", "deleted.md" not in out)
+
+    failed = [n for n, ok in checks if not ok]
+    for n, ok in checks:
+        print(f"  {'PASS' if ok else 'FAIL'}  {n}")
+    if failed:
+        print(f"\n{len(failed)} FAILED")
+        return 1
+    print(f"\nAll {len(checks)} checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/gitbook-preview-links.yml
+++ b/.github/workflows/gitbook-preview-links.yml
@@ -1,0 +1,111 @@
+name: GitBook preview links
+# GitBook's own PR checks link to the space landing page, not the page a PR
+# changed. When a GitBook preview build succeeds, this posts (and keeps updated)
+# a single PR comment with a deep link to each changed page. See
+# .github/scripts/gitbook_preview_links.py.
+#
+# Security: triggered by `status`, this job has a write token, so it must never
+# execute code from the (possibly forked) PR head. It checks out the trusted
+# default branch (the script + reusable index come from there) and overlays only
+# the PR's changed *file contents* via the API — data, never code.
+on:
+  status: {}
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: PR head commit SHA to build preview links for (dry-run)
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  # All per-space GitBook statuses for one commit share this group and run
+  # serially, so the sticky-comment upsert can't race itself into duplicates.
+  group: gitbook-preview-${{ github.event.sha || github.event.inputs.sha }}
+  cancel-in-progress: false
+
+jobs:
+  preview-links:
+    # Only for a successful GitBook status, or a manual dry-run.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.state == 'success' && startsWith(github.event.context, 'GitBook ('))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve the open PR for this commit
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          SHA: ${{ github.event.sha || github.event.inputs.sha }}
+        run: |
+          set -euo pipefail
+          PR=$(gh api "repos/$GH_REPO/commits/$SHA/pulls" \
+                --jq '[.[] | select(.state=="open")][0].number // empty')
+          if [ -z "$PR" ]; then
+            echo "No open PR for $SHA; nothing to do."
+            exit 0
+          fi
+          echo "pr=$PR" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      # Trusted checkout: the default branch, NOT the PR head. This is the code
+      # (script) and the reusable-content index we run against.
+      - name: Checkout default branch (trusted)
+        if: steps.resolve.outputs.pr != ''
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build the comment body
+        id: build
+        if: steps.resolve.outputs.pr != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ steps.resolve.outputs.pr }}
+          SHA: ${{ steps.resolve.outputs.sha }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$GH_REPO/pulls/$PR/files" --paginate > /tmp/files.json
+          gh api "repos/$GH_REPO/commits/$SHA/status" > /tmp/status.json
+
+          # Overlay the PR's version of each changed docs file onto the trusted
+          # tree, so titles / SUMMARY membership reflect the PR (incl. added
+          # pages) — fetching data only, never executing PR code.
+          jq -r '.[] | select(.status != "removed") | .filename' /tmp/files.json \
+            | while read -r f; do
+                case "$f" in
+                  docs/*.md)
+                    mkdir -p "$(dirname "$f")"
+                    gh api "repos/$GH_REPO/contents/$f?ref=$SHA" --jq '.content' \
+                      | tr -d '\n' | base64 -d > "$f" || true
+                    ;;
+                esac
+              done
+
+          python3 .github/scripts/gitbook_preview_links.py /tmp/files.json /tmp/status.json > /tmp/body.md || true
+          if [ -s /tmp/body.md ]; then
+            echo "has_body=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "No preview body (GitBook build not ready yet); skipping."
+          fi
+
+      - name: Upsert the sticky comment
+        if: steps.build.outputs.has_body == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ steps.resolve.outputs.pr }}
+        run: |
+          set -euo pipefail
+          MARKER='<!-- gitbook-preview-links -->'
+          CID=$(gh api "repos/$GH_REPO/issues/$PR/comments" --paginate \
+                 --jq "[.[] | select(.body | startswith(\"$MARKER\"))][0].id // empty")
+          if [ -n "$CID" ]; then
+            gh api -X PATCH "repos/$GH_REPO/issues/comments/$CID" -F body=@/tmp/body.md >/dev/null
+            echo "Updated comment $CID on PR #$PR"
+          else
+            gh api -X POST "repos/$GH_REPO/issues/$PR/comments" -F body=@/tmp/body.md >/dev/null
+            echo "Created comment on PR #$PR"
+          fi

--- a/.github/workflows/gitbook-preview-links.yml
+++ b/.github/workflows/gitbook-preview-links.yml
@@ -9,7 +9,7 @@ name: GitBook preview links
 # default branch (the script + reusable index come from there) and overlays only
 # the PR's changed *file contents* via the API — data, never code.
 on:
-  status: {}
+  status:
   workflow_dispatch:
     inputs:
       sha:
@@ -67,24 +67,39 @@ jobs:
           SHA: ${{ steps.resolve.outputs.sha }}
         run: |
           set -euo pipefail
-          gh api "repos/$GH_REPO/pulls/$PR/files" --paginate > /tmp/files.json
+          # --slurp + `add`: a multi-page PR paginates into several JSON arrays;
+          # merge them into one array the script can parse.
+          gh api "repos/$GH_REPO/pulls/$PR/files" --paginate --slurp | jq 'add' > /tmp/files.json
           gh api "repos/$GH_REPO/commits/$SHA/status" > /tmp/status.json
 
-          # Overlay the PR's version of each changed docs file onto the trusted
-          # tree, so titles / SUMMARY membership reflect the PR (incl. added
-          # pages) — fetching data only, never executing PR code.
-          jq -r '.[] | select(.status != "removed") | .filename' /tmp/files.json \
-            | while read -r f; do
-                case "$f" in
-                  docs/*.md)
-                    mkdir -p "$(dirname "$f")"
-                    gh api "repos/$GH_REPO/contents/$f?ref=$SHA" --jq '.content' \
-                      | tr -d '\n' | base64 -d > "$f" || true
-                    ;;
-                esac
-              done
+          # Overlay the PR's version of each changed docs file (and the reusable
+          # index, if changed) onto the trusted tree, so titles / SUMMARY
+          # membership / reusable resolution reflect the PR incl. added pages.
+          # Data only — never executing PR code. Fetch to a temp file and replace
+          # only on a clean, non-empty decode, so a failed fetch can't overwrite
+          # the trusted base-branch copy with an empty/corrupt file.
+          overlay() {
+            local f="$1" tmp
+            tmp="$(mktemp)"
+            if gh api "repos/$GH_REPO/contents/$f?ref=$SHA" --jq '.content' 2>/dev/null \
+                 | tr -d '\n' | base64 -d > "$tmp" 2>/dev/null && [ -s "$tmp" ]; then
+              mkdir -p "$(dirname "$f")"
+              mv "$tmp" "$f"
+            else
+              rm -f "$tmp"
+              echo "warn: could not fetch $f at $SHA; using base-branch version"
+            fi
+          }
+          while read -r f; do
+            case "$f" in
+              docs/*.md|REUSABLE_CONTENT_INDEX.md) overlay "$f" ;;
+            esac
+          done < <(jq -r '.[] | select(.status != "removed") | .filename' /tmp/files.json)
 
-          python3 .github/scripts/gitbook_preview_links.py /tmp/files.json /tmp/status.json > /tmp/body.md || true
+          # No `|| true`: a real script error should fail the step (visible,
+          # rerunnable). A legitimate "nothing to post yet" is an empty stdout
+          # with exit 0, handled by the has_body check below.
+          python3 .github/scripts/gitbook_preview_links.py /tmp/files.json /tmp/status.json > /tmp/body.md
           if [ -s /tmp/body.md ]; then
             echo "has_body=1" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/gitbook-preview-links.yml
+++ b/.github/workflows/gitbook-preview-links.yml
@@ -72,29 +72,38 @@ jobs:
           gh api "repos/$GH_REPO/pulls/$PR/files" --paginate --slurp | jq 'add' > /tmp/files.json
           gh api "repos/$GH_REPO/commits/$SHA/status" > /tmp/status.json
 
-          # Overlay the PR's version of each changed docs file (and the reusable
-          # index, if changed) onto the trusted tree, so titles / SUMMARY
-          # membership / reusable resolution reflect the PR incl. added pages.
-          # Data only — never executing PR code. Fetch to a temp file and replace
-          # only on a clean, non-empty decode, so a failed fetch can't overwrite
-          # the trusted base-branch copy with an empty/corrupt file.
+          # Reflect the PR precisely on the trusted checkout before running the
+          # script: overlay changed files' PR-head *content* (data, never code),
+          # and delete files the PR removes so stale base-branch copies aren't
+          # read (e.g. a removed SUMMARY.md or reusable index). Fetch failure is
+          # detected by gh's exit code (keep the base copy), so a legitimately
+          # emptied file — a valid zero-byte decode — is still applied.
           overlay() {
-            local f="$1" tmp
+            local f="$1" b64 tmp
+            if ! b64="$(gh api "repos/$GH_REPO/contents/$f?ref=$SHA" --jq '.content' 2>/dev/null)"; then
+              echo "warn: could not fetch $f at $SHA; using base-branch version"
+              return
+            fi
             tmp="$(mktemp)"
-            if gh api "repos/$GH_REPO/contents/$f?ref=$SHA" --jq '.content' 2>/dev/null \
-                 | tr -d '\n' | base64 -d > "$tmp" 2>/dev/null && [ -s "$tmp" ]; then
+            if printf '%s' "$b64" | tr -d '\n' | base64 -d > "$tmp" 2>/dev/null; then
               mkdir -p "$(dirname "$f")"
-              mv "$tmp" "$f"
+              mv "$tmp" "$f"     # zero-byte decode is valid (file cleared in the PR)
             else
               rm -f "$tmp"
-              echo "warn: could not fetch $f at $SHA; using base-branch version"
+              echo "warn: could not decode $f at $SHA; using base-branch version"
             fi
           }
-          while read -r f; do
+          while IFS="$(printf '\t')" read -r st f; do
             case "$f" in
-              docs/*.md|REUSABLE_CONTENT_INDEX.md) overlay "$f" ;;
+              docs/*.md|REUSABLE_CONTENT_INDEX.md) ;;
+              *) continue ;;
             esac
-          done < <(jq -r '.[] | select(.status != "removed") | .filename' /tmp/files.json)
+            if [ "$st" = "removed" ]; then
+              rm -f "$f"
+            else
+              overlay "$f"
+            fi
+          done < <(jq -r '.[] | [.status, .filename] | @tsv' /tmp/files.json)
 
           # No `|| true`: a real script error should fail the step (visible,
           # rerunnable). A legitimate "nothing to post yet" is an empty stdout

--- a/.github/workflows/gitbook-preview-links.yml
+++ b/.github/workflows/gitbook-preview-links.yml
@@ -93,17 +93,19 @@ jobs:
               echo "warn: could not decode $f at $SHA; using base-branch version"
             fi
           }
-          while IFS="$(printf '\t')" read -r st f; do
-            case "$f" in
-              docs/*.md|REUSABLE_CONTENT_INDEX.md) ;;
-              *) continue ;;
-            esac
+          tracked() { case "$1" in docs/*.md|REUSABLE_CONTENT_INDEX.md) return 0 ;; *) return 1 ;; esac; }
+          while IFS="$(printf '\t')" read -r st f prev; do
             if [ "$st" = "removed" ]; then
-              rm -f "$f"
-            else
-              overlay "$f"
+              tracked "$f" && rm -f "$f"
+              continue
             fi
-          done < <(jq -r '.[] | [.status, .filename] | @tsv' /tmp/files.json)
+            # A rename leaves the old path in the checkout — delete it so a moved
+            # SUMMARY/index/page isn't read stale.
+            if [ "$st" = "renamed" ] && [ -n "$prev" ]; then
+              tracked "$prev" && rm -f "$prev"
+            fi
+            tracked "$f" && overlay "$f"
+          done < <(jq -r '.[] | [.status, .filename, (.previous_filename // "")] | @tsv' /tmp/files.json)
 
           # No `|| true`: a real script error should fail the step (visible,
           # rerunnable). A legitimate "nothing to post yet" is an empty stdout

--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -1,0 +1,21 @@
+name: Script tests
+# Runs the network-free unit tests for .github/scripts helpers.
+on:
+  pull_request:
+    paths:
+      - .github/scripts/**
+      - .github/workflows/script-tests.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  gitbook-preview-links:
+    name: runner / gitbook-preview-links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Run gitbook_preview_links tests
+        run: python3 .github/scripts/tests/test_gitbook_preview_links.py


### PR DESCRIPTION
## What

Adds a GitHub Action that posts (and keeps updated) a single PR comment with a **deep link to each page a PR changed** in its GitBook preview. GitBook's own checks only link the space landing page, so reviewers currently hunt through the nav to find the edited page.

## How it works

- **Trigger:** `on: status`. Fires when a GitBook preview build succeeds (no polling), resolves the open PR for the commit, and upserts one sticky comment.
- **Only real pages:** a changed `.md` is linked only if it's listed in its space's `SUMMARY.md`. Nav (`SUMMARY.md`), `.gitbook/` assets, non-`.md`, and unlisted files are reported in a footnote, not linked.
- **Reusable content:** changes under `/.gitbook/includes/` are resolved to the pages that include them via `REUSABLE_CONTENT_INDEX.md` (matched by name, then the block's heading), capped for high-fan-out blocks (some are used in 150+ pages).
- **Readable:** link text is the page **title** (frontmatter `title`/`nodeTitle` → first heading), grouped by space, long lists collapsed in `<details>`.

## Security

`on: status` runs with a write token, so the job must not execute code from a (possibly forked) PR head. It checks out the **trusted default branch** (script + reusable index) and overlays only the PR's changed file **contents** via the API — data, never code.

## Caveat: activates after merge

`status`-triggered workflows only run from the default branch, so this can't be exercised from its own PR branch — it takes effect once merged to `main`.

## Verification

Tested offline against **PR #5132**'s real fixtures (statuses + changed files): produces the exact working deep link
`https://docs.n8n.io/build/~/revisions/<rev>/work-with-data/reference-data/reference-previous-nodes` with the page title. Plus synthetic cases: README/group page, 16-page-one-space collapse, multi-space, removed file, small- and large-fan-out reusable blocks (incl. the heading-fallback match resolving to 153 pages, capped at 10 + "…143 more"), `SUMMARY.md`-only, and assets. A `workflow_dispatch` (SHA input) is included for a post-merge dry run on `main`.

Closes DOC-2166
