### PR TITLE
fix(changelog): add more info to v3 release page

### DIFF
--- a/docs/changelog/v30-breaking-changes.md
+++ b/docs/changelog/v30-breaking-changes.md
@@ -10,8 +10,58 @@ layout:
 
 # n8n v3.0 breaking changes <a href="#n8n-v30-breaking-changes" id="n8n-v30-breaking-changes"></a>
 
-This document highlights breaking changes and actions to prepare for the upcoming transition to n8n v3.0. These updates improve security, simplify configuration, and remove legacy features.
+This document highlights breaking changes and actions to prepare for the upcoming transition to n8n v3.0, scheduled for October 2026. These updates improve security, simplify configuration, and remove legacy features.
 
 The release of n8n 3.0 continues n8n's commitment to providing a secure, reliable, and production-ready automation platform. This major version includes important security enhancements and cleanup of deprecated features.
+
+## Deployment <a href="#deployment" id="deployment"></a>
+
+### Docker-based deployment required for self-hosted n8n <a href="#docker-based-deployment-required-for-self-hosted-n8n" id="docker-based-deployment-required-for-self-hosted-n8n"></a>
+
+- Self-hosted n8n will require a Docker-based deployment. Installations run via `npm` / `npx n8n` will no longer be supported.
+- **What to do:** If you currently run n8n with `npm` or `npx n8n`, plan a move to a Docker-based deployment before upgrading to v3. For local installations, Docker Compose is expected to be the easiest path.
+- *Step-by-step migration guidance will be coming soon*
+
+## Removed nodes and helpers <a href="#removed-nodes-and-helpers" id="removed-nodes-and-helpers"></a>
+
+Older nodes, modes, and helpers that have been replaced by newer patterns are being removed in v3.
+
+### Removed nodes <a href="#removed-nodes" id="removed-nodes"></a>
+
+- **Function** node (legacy)
+- **Function Item** node (legacy)
+- **Item Lists** node (legacy)
+- **What to do:** Migrate affected workflows to the current recommended alternatives before upgrading:
+  - Replace **Function** and **Function Item** nodes with the [Code](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.code) node. Use **Run Once for All Items** mode in place of **Function**, and **Run Once for Each Item** mode in place of **Function Item**.
+  - Replace the **Item Lists** node with the node matching the operation you use: [Split Out](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.splitout), [Aggregate](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.aggregate), [Sort](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.sort), [Limit](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.limit), [Remove Duplicates](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.removeduplicates), or [Summarize](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.summarize).
+
+### Changed node behavior <a href="#changed-node-behavior" id="changed-node-behavior"></a>
+
+- **Execute Workflow** node: older behavior is being removed.
+
+### Removed expression helpers <a href="#removed-expression-helpers" id="removed-expression-helpers"></a>
+
+- The deprecated `$getPairedItem` expression helper is being removed.
+- **What to do:** Use n8n's standard [item linking](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/work-with-data/reference-data/link-data-items/how-items-link-through-workflows) instead, for example the `pairedItem` property or `$("<node-name>").item`.
+
+## Security <a href="#security" id="security"></a>
+
+Security defaults are getting stronger to make n8n safer by default. These changes may affect existing workflows or credentials.
+
+- **Tighter handling of risky resource names.**
+- **More secure credential behavior.**  
+- **Key rotation enabled by default.** 
+
+## Retired capabilities <a href="#retired-capabilities" id="retired-capabilities"></a>
+
+Some legacy or lower-usage product capabilities are being retired in v3. Guidance will be provided where a migration path or alternative exists.
+
+- **Chat hub** — being retired.
+- **Workflow import from URL in the editor** — being removed. Other [import methods](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/export-and-import) remain supported: copy-paste, **Import from File** in the editor UI menu, the CLI, and the Public API.
+- **Non-functional nodes** — being removed.
+
+---
+
+_This page will be updated with full details, migration guides, and links as v3 approaches its release._
 
 


### PR DESCRIPTION
## Summary

- Fill in the v3.0 breaking changes page (previously just an intro) with the four announced change areas: **Deployment**, **Removed nodes and helpers**, **Security**, and **Retired capabilities** — each with concrete "What to do" migration guidance
    - Replacement nodes/modes for Function, Function Item, and Item Lists inferred from existing hint on code node pages and those doc node pages.
    - Recommendations for replacement for the removed `$getPairedItem` helper inferred from existing doc;
    - Recommendations for which import methods remain supported after URL import is removed inferred from current doc.
- Note the currently targeted **October 2026** release date, worded to match the parallel customer email.