### PR TITLE
preview-links: show 'building' state for pages whose space isn't ready yet

### DIFF
--- a/.github/scripts/gitbook_preview_links.py
+++ b/.github/scripts/gitbook_preview_links.py
@@ -133,12 +133,15 @@ def load_spaces(status_json) -> dict:
 
 
 def gitbook_spaces(status_json) -> set:
-    """All spaces that have any GitBook status (success OR pending). Used to tell
-    'this space's preview is still building' apart from 'not a page' — a page
-    whose space is only pending must not be reported as a non-page."""
+    """Spaces whose GitBook build is success or pending (in progress). Used to
+    tell 'this space's preview is still building' apart from 'not a page'. Failed
+    builds are excluded — a page there shouldn't promise an update that never
+    lands (it falls through to the non-page footnote instead)."""
     statuses = status_json.get("statuses", status_json) if isinstance(status_json, dict) else status_json
     out = set()
     for s in statuses:
+        if s.get("state") not in ("success", "pending"):
+            continue
         m = LIVE_RE.match(s.get("context", "")) or EDIT_RE.match(s.get("context", ""))
         if m:
             out.add(m.group(1))
@@ -378,10 +381,11 @@ def main() -> int:
     changed = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
     status_json = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
     spaces = load_spaces(status_json)
-    if not spaces:
-        # No successful GitBook build yet: emit nothing so the workflow skips.
-        return 0
     pending_spaces = gitbook_spaces(status_json) - set(spaces)
+    if not spaces and not pending_spaces:
+        # No GitBook build in progress or done yet: emit nothing so the
+        # workflow skips (nothing to preview or promise).
+        return 0
     index = load_reusable_index()
     sys.stdout.write(render(changed, spaces, index, pending_spaces))
     return 0

--- a/.github/scripts/gitbook_preview_links.py
+++ b/.github/scripts/gitbook_preview_links.py
@@ -132,6 +132,19 @@ def load_spaces(status_json) -> dict:
     return spaces
 
 
+def gitbook_spaces(status_json) -> set:
+    """All spaces that have any GitBook status (success OR pending). Used to tell
+    'this space's preview is still building' apart from 'not a page' — a page
+    whose space is only pending must not be reported as a non-page."""
+    statuses = status_json.get("statuses", status_json) if isinstance(status_json, dict) else status_json
+    out = set()
+    for s in statuses:
+        m = LIVE_RE.match(s.get("context", "")) or EDIT_RE.match(s.get("context", ""))
+        if m:
+            out.add(m.group(1))
+    return out
+
+
 # --------------------------------------------------------------------------- #
 # Path -> URL mapping
 # --------------------------------------------------------------------------- #
@@ -242,8 +255,9 @@ def page_line(space_info: dict, filename: str) -> str:
     return f"- **[{safe_title}]({url})** — `{shown}`{edit_md}"
 
 
-def render(changed, spaces, index) -> str:
+def render(changed, spaces, index, pending_spaces=frozenset()) -> str:
     direct: dict = {}          # space -> [file]  (pages with a real preview)
+    pending: dict = {}         # space -> [file]  (page whose space is still building)
     reusable_blocks = []       # (name, [affected page paths], total)
     non_pages = []             # files that aren't pages
     unresolved_reusable = []   # include files we couldn't map
@@ -268,14 +282,19 @@ def render(changed, spaces, index) -> str:
             continue
 
         space = space_of(filename)
-        if space not in spaces or not in_summary(space, filename):
+        if not in_summary(space, filename):
             non_pages.append(filename)
-            continue
-        direct.setdefault(space, []).append(filename)
+        elif space in spaces:
+            direct.setdefault(space, []).append(filename)
+        elif space in pending_spaces:
+            # It IS a page; its space's GitBook build just hasn't finished yet.
+            pending.setdefault(space, []).append(filename)
+        else:
+            non_pages.append(filename)
 
     out = [MARKER, "## 📖 GitBook preview for this PR", ""]
 
-    if not direct and not reusable_blocks:
+    if not direct and not reusable_blocks and not pending:
         out.append("No standalone page previews for this PR's changes.")
         _append_extras(out, spaces, non_pages, unresolved_reusable)
         return "\n".join(out).rstrip() + "\n"
@@ -321,6 +340,16 @@ def render(changed, spaces, index) -> str:
             out.append("</details>")
             out.append("")
 
+    # Pages whose space is still building — not links yet. The comment updates on
+    # each push / status event, so these become deep links once the build lands.
+    if pending:
+        total_pending = sum(len(v) for v in pending.values())
+        spaces_list = ", ".join(f"`{s}`" for s in sorted(pending))
+        out.append(f"⏳ GitBook is still building the preview for {spaces_list} — "
+                   f"{total_pending} changed page(s). This comment updates when the "
+                   f"build finishes.")
+        out.append("")
+
     _append_extras(out, spaces, non_pages, unresolved_reusable)
     return "\n".join(out).rstrip() + "\n"
 
@@ -352,8 +381,9 @@ def main() -> int:
     if not spaces:
         # No successful GitBook build yet: emit nothing so the workflow skips.
         return 0
+    pending_spaces = gitbook_spaces(status_json) - set(spaces)
     index = load_reusable_index()
-    sys.stdout.write(render(changed, spaces, index))
+    sys.stdout.write(render(changed, spaces, index, pending_spaces))
     return 0
 
 

--- a/.github/scripts/tests/test_gitbook_preview_links.py
+++ b/.github/scripts/tests/test_gitbook_preview_links.py
@@ -137,6 +137,28 @@ def main():
     check("missing index -> reusable unresolved (no stale pages)",
           "couldn't be mapped" in out_no_idx)
 
+    # A page whose space is still BUILDING (pending GitBook status) must be shown
+    # as pending, not misreported as a non-page.
+    pend_status = {"statuses": [
+        {"context": "GitBook (./docs/spacea) - docs.n8n.io/spacea/", "state": "success",
+         "target_url": "https://docs.n8n.io/spacea/~/revisions/REVA/"},
+        {"context": "GitBook (./docs/spacea)", "state": "success",
+         "target_url": "https://app.gitbook.com/s/SA/~/diff/~/revisions/REVA/"},
+        {"context": "GitBook (./docs/spaceb) - docs.n8n.io/spaceb/", "state": "pending",
+         "target_url": "https://docs.n8n.io/spaceb/~/revisions/REVB/"},
+        {"context": "GitBook (./docs/spaceb)", "state": "pending",
+         "target_url": "https://app.gitbook.com/s/SB/~/diff/~/revisions/REVB/"},
+    ]}
+    pend_spaces = gb.load_spaces(pend_status)
+    pend_pending = gb.gitbook_spaces(pend_status) - set(pend_spaces)
+    out_pend = gb.render(
+        [{"status": "modified", "filename": "docs/spaceb/other.md"}],
+        pend_spaces, gb.load_reusable_index(), pend_pending)
+    check("pending space detected", pend_pending == {"spaceb"})
+    check("page in a building space shown as pending, not non-page",
+          "still building the preview for `spaceb`" in out_pend
+          and "aren't standalone pages" not in out_pend)
+
     failed = [n for n, ok in checks if not ok]
     for n, ok in checks:
         print(f"  {'PASS' if ok else 'FAIL'}  {n}")

--- a/.github/scripts/tests/test_gitbook_preview_links.py
+++ b/.github/scripts/tests/test_gitbook_preview_links.py
@@ -159,6 +159,24 @@ def main():
           "still building the preview for `spaceb`" in out_pend
           and "aren't standalone pages" not in out_pend)
 
+    # A FAILED build must not be treated as pending (would promise a never-coming
+    # update); the space just isn't available.
+    fail_status = {"statuses": [
+        {"context": "GitBook (./docs/spacea) - docs.n8n.io/spacea/", "state": "failure",
+         "target_url": "https://docs.n8n.io/spacea/~/revisions/X/"},
+        {"context": "GitBook (./docs/spacea)", "state": "failure",
+         "target_url": "https://app.gitbook.com/s/SA/~/diff/~/revisions/X/"},
+    ]}
+    check("failed build not counted as pending", gb.gitbook_spaces(fail_status) == set())
+
+    # All-pending (no space succeeded yet): main() must still be able to render a
+    # building note rather than exit empty. Exercise via render with empty spaces.
+    out_allpend = gb.render(
+        [{"status": "modified", "filename": "docs/spaceb/other.md"}],
+        {}, gb.load_reusable_index(), {"spaceb"})
+    check("all-pending still yields a building note",
+          "still building the preview for `spaceb`" in out_allpend)
+
     failed = [n for n, ok in checks if not ok]
     for n, ok in checks:
         print(f"  {'PASS' if ok else 'FAIL'}  {n}")


### PR DESCRIPTION
## What

Follow-up to #5133 (DOC-2166). When a PR changes pages in a space whose GitBook preview build hasn't finished yet, those pages were reported as *"not standalone pages"* — misleading, since they're real pages the build just hadn't produced.

Now the script distinguishes three states for a changed page:
- space build **succeeded** → deep link (unchanged);
- space has a **pending** GitBook status → a `⏳ GitBook is still building the preview for <space>` note (the sticky comment updates when the build lands);
- space has **no** GitBook status and the file isn't in `SUMMARY.md` → genuinely unlisted / non-page.

## Why

Found by dry-running the live workflow on an open PR (#5111, deploy pages, `deploy` still building): 2 real pages (in `SUMMARY.md`) were lumped with 2 genuinely-unlisted added pages under "aren't standalone pages." After this change, the 2 real pages show as *building* and only the 2 not-in-SUMMARY pages are flagged.

## Changes
- `gitbook_spaces()` — set of spaces with any GitBook context (success or pending).
- `render()` — a `pending` bucket + note; only classifies as non-page when the space has no status at all.
- Tests: +2 checks (pending-space detection and rendering). 33 total.

Verified offline against #5111's real fixtures (with the workflow's overlay) and the fixture suite.
