### PR TITLE
preview-links: clearer, more visible comment

### DIFF
--- a/.github/scripts/gitbook_preview_links.py
+++ b/.github/scripts/gitbook_preview_links.py
@@ -295,20 +295,20 @@ def render(changed, spaces, index, pending_spaces=frozenset()) -> str:
         else:
             non_pages.append(filename)
 
-    out = [MARKER, "## 📖 GitBook preview for this PR", ""]
+    out = [MARKER, "## 🔗 GitBook page previews", ""]
 
     if not direct and not reusable_blocks and not pending:
-        out.append("No standalone page previews for this PR's changes.")
+        out.append("No page previews to show for this PR's changes yet.")
         _append_extras(out, spaces, non_pages, unresolved_reusable)
         return "\n".join(out).rstrip() + "\n"
 
     # Pages changed directly — deep-linked into this PR's GitBook revision.
     if direct:
-        out.append("Pages you changed, deep-linked into this PR's GitBook revision:")
+        out.append("> 👉 **Jump straight to each page you changed** in this PR's GitBook preview:")
         out.append("")
         for space in sorted(direct):
             info = spaces[space]
-            out.append(f"### {space}")
+            out.append(f"### 📂 {space}")
             lines = [page_line(info, f) for f in sorted(direct[space])]
             if len(lines) > SPACE_COLLAPSE_AFTER:
                 out.append(f"<details><summary>{len(lines)} pages changed</summary>")
@@ -324,7 +324,7 @@ def render(changed, spaces, index, pending_spaces=frozenset()) -> str:
     # (the actual change) and list the live pages it renders on (blast radius).
     if reusable_blocks:
         diff = spaces.get("reusable-content", {}).get("editor_url")
-        out.append("### Reusable content")
+        out.append("### ♻️ Reusable content")
         out.append("GitBook previews the reusable block itself, not the pages that "
                    "embed it. Links below are the block diff plus the **live** pages "
                    "it renders on.")
@@ -348,7 +348,7 @@ def render(changed, spaces, index, pending_spaces=frozenset()) -> str:
     if pending:
         total_pending = sum(len(v) for v in pending.values())
         spaces_list = ", ".join(f"`{s}`" for s in sorted(pending))
-        out.append(f"⏳ GitBook is still building the preview for {spaces_list} — "
+        out.append(f"> ⏳ GitBook is still building the preview for {spaces_list} — "
                    f"{total_pending} changed page(s). This comment updates when the "
                    f"build finishes.")
         out.append("")
@@ -366,12 +366,13 @@ def _append_extras(out, spaces, non_pages, unresolved_reusable):
                    + ", ".join(f"`{p}`" for p in sorted(unresolved_reusable)))
     if non_pages:
         out.append("")
-        out.append(f"<sub>{len(non_pages)} other changed file(s) aren't standalone "
-                   f"pages (nav, assets, or unlisted): "
+        out.append(f"> ⚠️ **{len(non_pages)} changed file(s) aren't published as pages** — "
+                   f"they're not listed in the space's `SUMMARY.md` (nav), so GitBook "
+                   f"won't publish them until they're added there: "
                    + ", ".join(f"`{p}`" for p in sorted(non_pages)[:10])
-                   + (" …" if len(non_pages) > 10 else "") + "</sub>")
+                   + (" …" if len(non_pages) > 10 else ""))
     out.append("")
-    out.append("<sub>Preview links follow this PR's GitBook revision · comment updates on each push</sub>")
+    out.append("<sub>🔄 Links follow this PR's GitBook revision · this comment updates on every push</sub>")
 
 
 def main() -> int:

--- a/.github/scripts/tests/test_gitbook_preview_links.py
+++ b/.github/scripts/tests/test_gitbook_preview_links.py
@@ -67,8 +67,8 @@ def main():
     print("=" * 70)
 
     # section grouping + per-space revisions
-    check("spacea section", "### spacea" in out)
-    check("spaceb section", "### spaceb" in out)
+    check("spacea section", "### 📂 spacea" in out)
+    check("spaceb section", "### 📂 spaceb" in out)
     check("spacea uses REVA", "/spacea/~/revisions/REVA/" in out)
     check("spaceb uses REVB (distinct per-space revision)", "/spaceb/~/revisions/REVB/" in out)
 
@@ -83,7 +83,7 @@ def main():
           "[Other page](https://docs.n8n.io/spaceb/~/revisions/REVB/other)" in out)
 
     # reusable: basename match + cap, heading-fallback match, diff link
-    check("reusable section", "### Reusable content" in out)
+    check("reusable section", "### ♻️ Reusable content" in out)
     check("block-one resolved by basename to 12 pages", "renders on 12 page(s)" in out)
     check("reusable cap at 10 + remainder", "Show 10 of 12 pages" in out and "…and 2 more" in out)
     check("reusable pages use LIVE production URLs",
@@ -94,7 +94,7 @@ def main():
     check("no unresolved reusable", "couldn't be mapped" not in out)
 
     # non-pages: orphan + SUMMARY + asset; NOT the removed file
-    check("orphan (unlisted) is a non-page", "orphan.md" in out and "aren't standalone pages" in out)
+    check("orphan (unlisted) is a non-page", "orphan.md" in out and "aren't published as pages" in out)
     check("SUMMARY.md is a non-page", "SUMMARY.md" in out)
     check("asset is a non-page", "x.png" in out)
     check("removed file never appears", "deleted.md" not in out)
@@ -157,7 +157,7 @@ def main():
     check("pending space detected", pend_pending == {"spaceb"})
     check("page in a building space shown as pending, not non-page",
           "still building the preview for `spaceb`" in out_pend
-          and "aren't standalone pages" not in out_pend)
+          and "aren't published as pages" not in out_pend)
 
     # A FAILED build must not be treated as pending (would promise a never-coming
     # update); the space just isn't available.


### PR DESCRIPTION
## What

Small follow-up to DOC-2166: make the preview comment clearer and more visible.

- **Actionable non-page note.** The vague "aren't standalone pages (nav, assets, or unlisted)" becomes a ⚠️ callout that names the cause: *"not listed in the space's `SUMMARY.md` (nav), so GitBook won't publish them until they're added there."* Verified against a live preview revision that a page not in `SUMMARY.md` returns **404** while a listed sibling returns 200 — so this is the real reason, and it doubles as a "you forgot to add these to the nav" hint.
- **More scannable.** Title `🔗 GitBook page previews` (keeps "GitBook"), a `👉 Jump straight to each page you changed` lead, `📂` per-space and `♻️` reusable section headers, and `⏳`/`⚠️` blockquote callouts.

No behavior change — same links, clearer presentation. Fixture tests updated (35 checks).
