### PR TITLE
preview-links: don't flag assets/nav as unpublished pages

### DIFF
--- a/.github/scripts/gitbook_preview_links.py
+++ b/.github/scripts/gitbook_preview_links.py
@@ -267,9 +267,14 @@ def render(changed, spaces, index, pending_spaces=frozenset()) -> str:
 
     for f in changed:
         filename = f.get("filename", "")
+        # Skip removals and non-page artifacts entirely. Assets (images, etc.),
+        # nav (SUMMARY.md), and GitBook config are *expected* not to be pages, so
+        # listing them under "not published as pages" is noise. The non-page note
+        # is reserved for real content pages a contributor forgot to add to nav.
         if f.get("status") == "removed" or not filename.endswith(".md"):
-            if f.get("status") != "removed" and filename:
-                non_pages.append(filename)
+            continue
+        is_gitbook_config = "/.gitbook/" in filename and "/.gitbook/includes/" not in filename
+        if Path(filename).name == "SUMMARY.md" or is_gitbook_config:
             continue
 
         if "/.gitbook/includes/" in filename:
@@ -280,12 +285,10 @@ def render(changed, spaces, index, pending_spaces=frozenset()) -> str:
             reusable_blocks.append((name, pages, len(pages)))
             continue
 
-        if Path(filename).name == "SUMMARY.md" or "/.gitbook/" in filename:
-            non_pages.append(filename)
-            continue
-
         space = space_of(filename)
         if not in_summary(space, filename):
+            # A real content .md that isn't in the space's SUMMARY.md — the one
+            # actionable case: GitBook won't publish it until it's added to nav.
             non_pages.append(filename)
         elif space in spaces:
             direct.setdefault(space, []).append(filename)
@@ -366,9 +369,9 @@ def _append_extras(out, spaces, non_pages, unresolved_reusable):
                    + ", ".join(f"`{p}`" for p in sorted(unresolved_reusable)))
     if non_pages:
         out.append("")
-        out.append(f"> ⚠️ **{len(non_pages)} changed file(s) aren't published as pages** — "
-                   f"they're not listed in the space's `SUMMARY.md` (nav), so GitBook "
-                   f"won't publish them until they're added there: "
+        out.append(f"> ⚠️ **{len(non_pages)} changed page(s) aren't in the nav** — "
+                   f"not listed in the space's `SUMMARY.md`, so GitBook won't publish "
+                   f"them until they're added there: "
                    + ", ".join(f"`{p}`" for p in sorted(non_pages)[:10])
                    + (" …" if len(non_pages) > 10 else ""))
     out.append("")

--- a/.github/scripts/tests/test_gitbook_preview_links.py
+++ b/.github/scripts/tests/test_gitbook_preview_links.py
@@ -94,9 +94,9 @@ def main():
     check("no unresolved reusable", "couldn't be mapped" not in out)
 
     # non-pages: orphan + SUMMARY + asset; NOT the removed file
-    check("orphan (unlisted) is a non-page", "orphan.md" in out and "aren't published as pages" in out)
-    check("SUMMARY.md is a non-page", "SUMMARY.md" in out)
-    check("asset is a non-page", "x.png" in out)
+    check("orphan (unlisted .md) is flagged as not-in-nav", "orphan.md" in out and "aren't in the nav" in out)
+    check("SUMMARY.md file is NOT reported (expected non-page)", "docs/spacea/SUMMARY.md" not in out)
+    check("asset is NOT reported (expected non-page)", "x.png" not in out)
     check("removed file never appears", "deleted.md" not in out)
 
     # Frontmatter `url:` is stale in this repo (pre-migration); URLs must be
@@ -157,7 +157,7 @@ def main():
     check("pending space detected", pend_pending == {"spaceb"})
     check("page in a building space shown as pending, not non-page",
           "still building the preview for `spaceb`" in out_pend
-          and "aren't published as pages" not in out_pend)
+          and "aren't in the nav" not in out_pend)
 
     # A FAILED build must not be treated as pending (would promise a never-coming
     # update); the space just isn't available.


### PR DESCRIPTION
## What

Follow-up to DOC-2166. The preview-links comment was listing **assets and nav files** under "⚠️ aren't published as pages" — e.g. on #5141 the added screenshot (`…/.gitbook/assets/gitbook-preview-links-comment.png`) got flagged. Those are *expected* not to be pages, so the warning was noise (and slightly alarming).

Now the ⚠️ note is reserved for the one **actionable** case: a real content `.md` page that isn't in the space's `SUMMARY.md` (so GitBook won't publish it until it's added to the nav). Images, other assets, `SUMMARY.md`, and `.gitbook/` config are skipped silently — reviewers can see them in the diff.

Also reworded the note to "**N changed page(s) aren't in the nav**".

## Tests
Updated the fixture suite (35 checks): asset and `SUMMARY.md` are asserted **absent** from the comment; a real unlisted `.md` is still flagged.

Related: DOC-2166 · surfaced on #5141
