### PR TITLE
Document 'Create Extension' option for PGVector Vector Store node

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepgvector.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepgvector.md
@@ -43,6 +43,12 @@ On this page, you'll find the node parameters for the PGVector node, and links t
 You can find authentication information for this node [here](../../credentials/postgres.md).
 {% endhint %}
 
+{% hint style="warning" %}
+**Database privileges**
+
+If your Postgres database role isn't a superuser, leave **Create Extension** turned off (the default). The node no longer creates the `vector` extension automatically, so have a database administrator install the `pgvector` (`vector`) extension beforehand. This avoids the error *"Because vector isn't a trusted extension, only members of … are allowed to use CREATE EXTENSION vector"*.
+{% endhint %}
+
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/X6JM1Mgg5iwvZLDpGEB0/" %}
 
 ## Node usage patterns <a href="#node-usage-patterns" id="node-usage-patterns"></a>
@@ -124,6 +130,14 @@ The following options specify the names of the columns to store the vectors and 
 ### Metadata Filter <a href="#metadata-filter" id="metadata-filter"></a>
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/9OWZ8hSpVqky4D4xRnYP/" %}
+
+### Create Extension <a href="#create-extension" id="create-extension"></a>
+
+Whether to create the `pgvector` extension if it doesn't already exist. Off by default.
+
+Enabling this restores the previous behavior: the node runs `CREATE EXTENSION IF NOT EXISTS vector` (schema-qualified if you've configured a custom extension schema) before creating the table. This requires database superuser privileges.
+
+Turn this on only if you have superuser access and the extension isn't already installed. Otherwise, leave it off and ask a database administrator to install the `vector` extension ahead of time.
 
 ## Templates and examples <a href="#templates-and-examples" id="templates-and-examples"></a>
 

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepgvector.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepgvector.md
@@ -135,7 +135,7 @@ The following options specify the names of the columns to store the vectors and 
 
 Whether to create the `pgvector` extension if it doesn't already exist. Off by default.
 
-Enabling this restores the previous behavior: the node runs `CREATE EXTENSION IF NOT EXISTS vector` (schema-qualified if you've configured a custom extension schema) before creating the table. This requires database superuser privileges.
+Enabling this restores the previous behavior: the node runs `CREATE EXTENSION IF NOT EXISTS vector` before creating the table. This requires database superuser privileges.
 
 Turn this on only if you have superuser access and the extension isn't already installed. Otherwise, leave it off and ask a database administrator to install the `vector` extension ahead of time.
 


### PR DESCRIPTION
## Description

Documents the new **Create Extension** boolean option (under **Options**, default `false`) added to the PGVector Vector Store node by [n8n#33446](https://github.com/n8n-io/n8n/pull/33446), which addresses [n8n#15739](https://github.com/n8n-io/n8n/issues/15739).

Closes [n8n-docs#4961](https://github.com/n8n-io/n8n-docs/issues/4961).

## Changes

- Added a **Create Extension** entry to the *Node options* section explaining the new option's behavior and superuser requirement.
- Added a **Database privileges** warning callout near the top of the page, advising non-superuser roles to keep the option disabled and have an administrator install the `vector` extension beforehand (this is the fix for the *"Because vector isn't a trusted extension …"* error).

## Notes

- Source PR: https://github.com/n8n-io/n8n/pull/33446
- Related issue: https://github.com/n8n-io/n8n/issues/15739
- Community post: https://community.n8n.io/t/postgres-pgvector-store-got-created/151319

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the new Create Extension option (default off) for the PGVector Vector Store node; when enabled, the node runs `CREATE EXTENSION IF NOT EXISTS vector` (no schema qualification), restoring previous auto‑install behavior and requiring superuser privileges.
Added a database privileges warning advising non‑superusers to keep it off and have an admin pre‑install `pgvector` (`vector`) to avoid the “Because vector isn’t a trusted extension …” error.

<sup>Written for commit 350ec80415767cd5b9d8957a2d6495ca30d1c148. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

