### PR TITLE
ci: fix GitBook preview-links crash on non-docs .md files

### DIFF
--- a/.github/scripts/gitbook_preview_links.py
+++ b/.github/scripts/gitbook_preview_links.py
@@ -286,6 +286,11 @@ def render(changed, spaces, index, pending_spaces=frozenset()) -> str:
             continue
 
         space = space_of(filename)
+        if space is None:
+            # A .md file outside docs/ (e.g. skills/*.md, a top-level README).
+            # It isn't a docs-space page, so there's no preview to link — and
+            # in_summary() would choke on the None space. Nothing to do.
+            continue
         if not in_summary(space, filename):
             # A real content .md that isn't in the space's SUMMARY.md — the one
             # actionable case: GitBook won't publish it until it's added to nav.

--- a/.github/scripts/tests/test_gitbook_preview_links.py
+++ b/.github/scripts/tests/test_gitbook_preview_links.py
@@ -177,6 +177,22 @@ def main():
     check("all-pending still yields a building note",
           "still building the preview for `spaceb`" in out_allpend)
 
+    # Regression (DOC-2188): a changed .md file OUTSIDE docs/ (e.g. a skill file
+    # or top-level README) has no space. render() must skip it silently, never
+    # feeding a None space into in_summary() (which would raise TypeError).
+    check("space_of outside docs/ is None", gb.space_of("skills/n8n-docs-author/SKILL.md") is None)
+    out_nondocs = gb.render(
+        [{"status": "modified", "filename": "skills/n8n-docs-author/SKILL.md"},
+         {"status": "modified", "filename": "README.md"},
+         {"status": "modified", "filename": "docs/spacea/page-one.md"}],
+        spaces, gb.load_reusable_index())
+    check("non-docs .md doesn't crash and isn't reported",
+          "SKILL.md" not in out_nondocs
+          and "README.md" not in out_nondocs
+          and "aren't in the nav" not in out_nondocs)
+    check("a real docs page alongside it still renders",
+          "https://docs.n8n.io/spacea/~/revisions/REVA/page-one" in out_nondocs)
+
     failed = [n for n, ok in checks if not ok]
     for n, ok in checks:
         print(f"  {'PASS' if ok else 'FAIL'}  {n}")


### PR DESCRIPTION
## What

The GitBook preview-links workflow (`.github/scripts/gitbook_preview_links.py`) crashes and never posts its comment when a PR edits a Markdown file outside `docs/`.

`space_of()` returns `None` for any path not under `docs/<space>/`. The render loop passed that `None` into `in_summary()`, which does `REPO / "docs" / None / "SUMMARY.md"` and raises:

```
TypeError: unsupported operand type(s) for /: 'PosixPath' and 'NoneType'
```

The step fails before writing the comment body, so the sticky comment never appears.

## Repro

PR #5115 edits `skills/n8n-docs-author/SKILL.md` and `skills/n8n-docs-author/reference.md` alongside a `docs/` file. Those skill `.md` files pass every earlier filter, hit `space = None`, and crash `in_summary`. [Failing run.](https://github.com/n8n-io/n8n-docs/actions/runs/30826706654/job/91730015858)

## Fix

Guard the render loop: skip any changed file whose space is `None` (not a docs-space page) before it reaches `in_summary()`. One-line behavior change; `py_compile` clean.

Refs DOC-2188