### PR TITLE
docs: Note Kafka Trigger offset behavior when deactivating a workflow

### DIFF
--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.kafkatrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.kafkatrigger.md
@@ -41,6 +41,12 @@ The Kafka Trigger can consume uncompressed messages and messages compressed with
 {% endhint %}
 
 {% hint style="info" %}
+**Deactivating a workflow**
+
+If you set **Resolve Offset** to **On Execution Completion**, **On Execution Success**, or **On Allowed Execution Statuses**, deactivating the workflow stops the trigger without waiting for executions that are already running. n8n doesn't commit the offsets for those messages, so Kafka redelivers them the next time the workflow is active.
+{% endhint %}
+
+{% hint style="info" %}
 **Examples and templates**
 
 For usage examples and templates to help you get started, refer to n8n's [Kafka Trigger integrations](https://n8n.io/integrations/kafka-trigger/) page.


### PR DESCRIPTION
## Summary

Adds a short note to the Kafka Trigger page about what happens to in-flight messages when a workflow is deactivated.

This documents behavior clarified by https://github.com/n8n-io/n8n/pull/35069, which makes Kafka consumer teardown reliable. With `Resolve Offset` set to On Execution Completion, On Execution Success, or On Allowed Execution Statuses, deactivation no longer waits for executions that are already running. Their offsets are left uncommitted, so Kafka redelivers those messages the next time the workflow is active. This is standard at-least-once behavior and matches the existing execution-timeout path, but it was not written down anywhere.

No new parameters or options, so nothing else needed doc changes.

## Related

- https://linear.app/n8n/issue/ENT-104
- https://github.com/n8n-io/n8n/pull/35069

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an info note to the Kafka Trigger docs clarifying what happens to in-flight messages when a workflow is deactivated. With Resolve Offset set to On Execution Completion, On Execution Success, or On Allowed Execution Statuses, deactivation doesn’t wait for running executions; offsets aren’t committed, and Kafka redelivers on the next activation (ENT-104).

<sup>Written for commit 23e852f564bfecefb3e37dbdbdef60f40b1a8883. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

