### PR TITLE
fix(docs): add missing github node operations

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -103,7 +103,7 @@ Learn more in the [Canvas Groups documentation](https://app.gitbook.com/s/rPN1zU
 
 ### GitHub node: manage the full pull request lifecycle
 
-The [GitHub node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.github) now has a dedicated Pull Request resource. Create pull requests (including drafts and cross-fork PRs), update, close, and reopen them, read and add comments, fetch diffs and patches, and merge with merge, squash, or rebase. These native operations replace the custom HTTP Request setups that such tasks used to need. Errors are surfaced exactly as GitHub returns them, so failures are easy to diagnose.
+The [GitHub node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.github#operations) now has a dedicated Pull Request resource. Create pull requests (including drafts and cross-fork PRs), update, close, and reopen them, read and add comments, fetch diffs and patches, and merge with merge, squash, or rebase. These native operations replace the custom HTTP Request setups that such tasks used to need. Errors are surfaced exactly as GitHub returns them, so failures are easy to diagnose.
 
 ### Webhook node: Only Run If
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.github.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.github.md
@@ -18,7 +18,7 @@ layout:
 
 # GitHub node <a href="#github-node" id="github-node"></a>
 
-Use the GitHub node to automate work in GitHub, and integrate GitHub with other applications. n8n has built-in support for a wide range of GitHub features, including creating, updating, deleting, and editing files, repositories, issues, releases, and users. 
+Use the GitHub node to automate work in GitHub, and integrate GitHub with other applications. n8n has built-in support for a wide range of GitHub features, including creating, updating, deleting, and editing files, repositories, issues, pull requests, releases, and users. 
 
 On this page, you'll find a list of operations the GitHub node supports and links to more resources.
 
@@ -46,6 +46,17 @@ Refer to [GitHub credentials](../credentials/github.md) for guidance on setting 
 	* Lock
 * Organization
 	* Get Repositories
+* Pull Request
+	* Close
+	* Create
+	* Create Comment
+	* Edit Comment
+	* Get
+	* Get Diff
+	* Get Patch
+	* Merge
+	* Reopen
+	* Update
 * Release
 	* Create
 	* Delete


### PR DESCRIPTION
## Summary
- Document the GitHub node's Pull Request resource (`create`, `update`, `close`, `reopen`, `get`, `create comment`, `edit comment`, `get diff`, `get patch`, `merge`), which shipped but was never added to the node reference page.
- Point the existing changelog entry for this feature at the specific section (`#operations`) that now documents it, instead of just the top of the node page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
