### PR TITLE
fix(docs): raise postgres minimum

### DIFF
--- a/docs/deploy/host-n8n/configure-n8n/choose-n8ns-database.md
+++ b/docs/deploy/host-n8n/configure-n8n/choose-n8ns-database.md
@@ -35,7 +35,7 @@ The following environment variables get used by all databases:
 
 ## PostgresDB <a href="#postgresdb" id="postgresdb"></a>
 
-### Supported PostgreSQL versions
+### Supported PostgreSQL versions <a href="#supported-postgresql-versions" id="supported-postgresql-versions"></a>
 
 n8n supports:
 

--- a/docs/deploy/host-n8n/configure-n8n/choose-n8ns-database.md
+++ b/docs/deploy/host-n8n/configure-n8n/choose-n8ns-database.md
@@ -11,7 +11,7 @@ layout:
 
 # Supported databases <a href="#supported-databases" id="supported-databases"></a>
 
-By default, n8n uses SQLite to save credentials, past executions, and workflows. n8n also supports PostgresDB (only [actively maintained versions](https://www.postgresql.org/support/versioning/)).
+By default, n8n uses SQLite to save credentials, past executions, and workflows. n8n also supports PostgresDB. Refer to [Supported PostgreSQL versions](#supported-postgresql-versions) for n8n's PostgreSQL version policy.
 
 ## Database type by n8n installation <a href="#database-type-by-n8n-installation" id="database-type-by-n8n-installation"></a>
 
@@ -34,6 +34,19 @@ The following environment variables get used by all databases:
  - `DB_TABLE_PREFIX` (default: -) - Prefix for table names
 
 ## PostgresDB <a href="#postgresdb" id="postgresdb"></a>
+
+### Supported PostgreSQL versions
+
+n8n supports:
+
+- The latest two actively maintained PostgreSQL major versions (**17** and **18**, as of July 2026).
+- One additional major version for compatibility (**16**).
+
+Run the latest minor release within your major version.
+
+n8n doesn't officially support PostgreSQL-compatible derivatives, such as Amazon Aurora, AlloyDB, CockroachDB, or YugabyteDB.
+
+The PostgreSQL project retires its oldest maintained major version and releases a new one every November, so n8n's supported version range shifts each year. Check this page for the current supported versions, rather than relying on a specific version number you've seen elsewhere.
 
 To use PostgresDB as the database, you can provide the following environment variables:
 

--- a/docs/deploy/host-n8n/configure-n8n/scaling/enable-queue-mode.md
+++ b/docs/deploy/host-n8n/configure-n8n/scaling/enable-queue-mode.md
@@ -67,8 +67,9 @@ export N8N_ENCRYPTION_KEY=<main_instance_encryption_key>
 
 {% hint style="info" %}
 **Database considerations**
+Refer to [Supported PostgreSQL versions](../choose-n8ns-database.md#supported-postgresql-versions) for n8n's supported PostgreSQL versions.
 
-n8n recommends using PostgreSQL over SQLite. Refer to [Supported PostgreSQL versions](../choose-n8ns-database.md#supported-postgresql-versions) for n8n's supported PostgreSQL versions. Running n8n with execution mode set to `queue` with an SQLite database isn't recommended.
+Running n8n with execution mode set to `queue` with an SQLite database isn't recommended. 
 {% endhint %}
 
 Set the environment variable `EXECUTIONS_MODE` to `queue` on the main instance and any workers using the following command.

--- a/docs/deploy/host-n8n/configure-n8n/scaling/enable-queue-mode.md
+++ b/docs/deploy/host-n8n/configure-n8n/scaling/enable-queue-mode.md
@@ -68,7 +68,7 @@ export N8N_ENCRYPTION_KEY=<main_instance_encryption_key>
 {% hint style="info" %}
 **Database considerations**
 
-n8n recommends using Postgres 13+. Running n8n with execution mode set to `queue` with an SQLite database isn't recommended.
+n8n recommends using PostgreSQL over SQLite. Refer to [Supported PostgreSQL versions](../choose-n8ns-database.md#supported-postgresql-versions) for n8n's supported PostgreSQL versions. Running n8n with execution mode set to `queue` with an SQLite database isn't recommended.
 {% endhint %}
 
 Set the environment variable `EXECUTIONS_MODE` to `queue` on the main instance and any workers using the following command.

--- a/docs/deploy/host-n8n/install-options/use-a-cloud-provider/deploy-to-google-cloud-run.md
+++ b/docs/deploy/host-n8n/install-options/use-a-cloud-provider/deploy-to-google-cloud-run.md
@@ -117,7 +117,7 @@ Run this command to create the Postgres DB instance (it will take a few minutes 
 
 ```sh
 gcloud sql instances create n8n-db \
-    --database-version=POSTGRES_13 \
+    --database-version=POSTGRES_17 \
     --tier=db-f1-micro \
     --region=$REGION \
     --root-password="change-this-password" \


### PR DESCRIPTION
## Summary

Updates n8n's documented PostgreSQL support policy to a rolling two-major-plus-compatibility model, replacing the previous fixed minimum of PostgreSQL 13.

- **`choose-n8ns-database.md`**: adds a "Supported PostgreSQL versions" section stating n8n supports the latest two actively maintained majors (17 and 18, as of July 2026) plus one additional major for compatibility (16), recommends running the latest minor within your major, and clarifies that PostgreSQL-compatible derivatives (Amazon Aurora, AlloyDB, CockroachDB, YugabyteDB) aren't officially supported. Notes that the supported range shifts every November when the PostgreSQL project retires its oldest major and cuts a new one.
- **`scaling/enable-queue-mode.md`**: removes the stale "Postgres 13+" recommendation and links to the canonical policy section instead, so the version numbers aren't duplicated (and don't go stale) across pages.
- **`deploy-to-google-cloud-run.md`**: bumps the Cloud SQL tutorial's `--database-version` flag from `POSTGRES_13` to `POSTGRES_17`.

Swept the rest of the docs for other hardcoded Postgres 13 / fixed-minimum references (Azure, AWS, OpenShift, Heroku, and Docker install guides, OEM prerequisites, Postgres node/credentials pages) — no other changes needed; remaining mentions are generic and version-agnostic.
