### PR TITLE
Add callout: agents not supported in queue mode yet (DOC-2192)

### DIFF
--- a/docs/build/build-and-manage-agents.md
+++ b/docs/build/build-and-manage-agents.md
@@ -235,6 +235,10 @@ Agents run on self-hosted n8n from version `2.32.3` (Beta). There are two ways t
 Agents aren't ready for self-hosted Enterprise yet. Support for self-hosted Enterprise is coming soon.
 {% endhint %}
 
+{% hint style="warning" %}
+Agents aren't supported in queue mode yet. Agents run in queue mode, but we haven't tested it, and connecting channels (such as Telegram) can fail. Run agents in regular mode for now.
+{% endhint %}
+
 For the environment variables and setup steps, see [Enable agents](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-ai-assistant#enable-agents).
 
 ### Agent executions and pricing

--- a/docs/build/build-and-manage-agents.md
+++ b/docs/build/build-and-manage-agents.md
@@ -236,7 +236,7 @@ Agents aren't ready for self-hosted Enterprise yet. Support for self-hosted Ente
 {% endhint %}
 
 {% hint style="warning" %}
-Agents aren't supported in queue mode yet. Agents run in queue mode, but we haven't tested it, and connecting channels (such as Telegram) can fail. Run agents in regular mode for now.
+Queue mode isn't supported for agents yet, and connecting channels (such as Telegram) can fail. Run agents in regular mode for now.
 {% endhint %}
 
 For the environment variables and setup steps, see [Enable agents](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-ai-assistant#enable-agents).


### PR DESCRIPTION
## What

Adds a warning callout to the **Self-hosted** section of the agents doc: agents aren't supported in queue mode yet.

## Why

An ambassador hit a **404** connecting a Telegram channel to an agent on self-hosted v2.34.0 in queue mode / multi-main (works in regular mode). Michael Drury (Agents team) confirmed in-thread that agents *operate* in queue mode but it's **untested and unsupported** for now.

- Slack thread: https://n8nio.slack.com/archives/C0AMSF4HVBP/p1785852489227289
- Linear: DOC-2192

Wording deliberately uses the team-endorsed "queue mode not supported yet" framing rather than an unproven "multi-main is broken" claim.

## Remove this callout when

Queue mode support for agents is tested and shipped. Related Agents-team tickets: AGENT-554, AGENT-549, AGENT-558. See DOC-2192 for tracking.