### PR TITLE
docs: fix package export/import details raised in review

### DIFF
--- a/docs/build/manage-workflows/n8n-packages/export-a-package.md
+++ b/docs/build/manage-workflows/n8n-packages/export-a-package.md
@@ -170,7 +170,7 @@ Export needs no license feature. For the full matrix, see [Limits and permission
 
 A missing entity and an inaccessible one return the same `400` with the same message, so you can't use export to test whether an ID exists. Export never returns a `404`.
 
-Error bodies carry a `message` only, and it names how many entities were affected rather than which. The CLI prints the same message, and the log streaming event records only the failure reason and the IDs you asked for, so the offending IDs aren't surfaced anywhere.
+Error bodies carry a `message` only. For a missing or inaccessible entity, a blocked sub-workflow dependency, or a variable name collision, that message counts the affected entities rather than naming them: `2 workflow(s) not found or not accessible. Export aborted.` The offending IDs aren't in the response. The CLI prints the same message, and the log streaming event records only the failure reason and the IDs you asked for.
 
 To find which dependency is missing, export again with `--missing-workflow-dependency-policy=reference-only` and read `requirements.workflows` in the [manifest](package-format.md#manifestjson).
 
@@ -190,7 +190,11 @@ The failure event carries the user, the IDs you requested, and a `reason` of `ac
 Log streaming events carry IDs but no counts. The telemetry events carry the per-entity counts instead, and no IDs.
 
 {% hint style="info" %}
-n8n emits the success event before it streams the archive to you. If the download then fails part-way, the same request emits the failure event too, so one export can produce both. A client that disconnects before the download finishes emits neither an error nor a failure event.
+n8n emits the success event as soon as it finishes building the archive, before it sends the first byte. The event records what went into the archive, not what reached you.
+
+If the transfer then breaks, because you disconnect, the connection resets, or a proxy times out, n8n emits nothing further: no failure event and no error. The audit trail shows a successful export even though you received a partial file or none of it. Check the size of what you downloaded rather than trusting the `200`.
+
+One request emits both events only when n8n hits an error building or compressing the archive mid-transfer: the success event, then the failure event with a `reason` of `validation`. The response has already started with a `200` by then, so you get a truncated file rather than an error body.
 {% endhint %}
 
 ## Read next

--- a/docs/build/manage-workflows/n8n-packages/export-a-package.md
+++ b/docs/build/manage-workflows/n8n-packages/export-a-package.md
@@ -170,9 +170,7 @@ Export needs no license feature. For the full matrix, see [Limits and permission
 
 A missing entity and an inaccessible one return the same `400` with the same message, so you can't use export to test whether an ID exists. Export never returns a `404`.
 
-Error bodies carry a `message` only. For a missing or inaccessible entity, a blocked sub-workflow dependency, or a variable name collision, that message counts the affected entities rather than naming them: `2 workflow(s) not found or not accessible. Export aborted.` The offending IDs aren't in the response. The CLI prints the same message, and the log streaming event records only the failure reason and the IDs you asked for.
-
-To find which dependency is missing, export again with `--missing-workflow-dependency-policy=reference-only` and read `requirements.workflows` in the [manifest](package-format.md#manifestjson).
+Error bodies carry a `message` only. 
 
 ## Events
 

--- a/docs/build/manage-workflows/n8n-packages/export-a-package.md
+++ b/docs/build/manage-workflows/n8n-packages/export-a-package.md
@@ -185,17 +185,10 @@ Every export emits an event on both the log streaming and telemetry paths, so yo
 
 The success event carries the user and the `workflowIds`, `folderIds`, and `projectIds` that actually ended up in the package, so it reflects folder contents and auto-included sub-workflows rather than what you asked for. Each list is present only when it isn't empty.
 
-The failure event carries the user, the IDs you requested, and a `reason` of `access-denied`, `entity-not-found`, `blocked`, or `validation`.
+The failure event carries the user, the IDs requested, and a `reason` of `access-denied`, `entity-not-found`, `blocked`, or `validation`.
 
-Log streaming events carry IDs but no counts. The telemetry events carry the per-entity counts instead, and no IDs.
-
-{% hint style="info" %}
-n8n emits the success event as soon as it finishes building the archive, before it sends the first byte. The event records what went into the archive, not what reached you.
-
-If the transfer then breaks, because you disconnect, the connection resets, or a proxy times out, n8n emits nothing further: no failure event and no error. The audit trail shows a successful export even though you received a partial file or none of it. Check the size of what you downloaded rather than trusting the `200`.
-
-One request emits both events only when n8n hits an error building or compressing the archive mid-transfer: the success event, then the failure event with a `reason` of `validation`. The response has already started with a `200` by then, so you get a truncated file rather than an error body.
-{% endhint %}
+Log streaming events carry IDs. 
+Telemetry events emit counts to keep the data anonymized.
 
 ## Read next
 

--- a/docs/build/manage-workflows/n8n-packages/import-a-package.md
+++ b/docs/build/manage-workflows/n8n-packages/import-a-package.md
@@ -19,7 +19,7 @@ tags:
 n8n packages are in preview. The import options may change in future releases.
 {% endhint %}
 
-Import reads an [n8n package](README.md), a [`.n8np` archive](package-format.md), and writes its contents to the target instance. n8n checks the whole package first: if anything would block the import, it writes nothing and returns every problem at once. See [How import works](how-import-works.md) for the detail.
+Import reads an [n8n package](README.md), a [.n8np archive](package-format.md), and writes its contents to the target instance. n8n checks the whole package first: if anything would block the import, it writes nothing and returns every problem at once. See [How import works](how-import-works.md) for the detail.
 
 Use the [n8n CLI](https://app.gitbook.com/s/r7wKI4I1BgdBCuq5Cvcx/n8n-cli):
 
@@ -193,10 +193,10 @@ A successful import returns `200` with eight keys:
 	"workflows": [
 		{ "sourceWorkflowId": "wf9Zx1", "localId": "wf9Zx1", "name": "Send email",
 			"projectId": "prProd4", "parentFolderId": null,
-			"activeVersionId": "<version-id>", "publishing": { "state": "published" }, "status": "created" },
+			"activeVersionId": null, "publishing": { "state": "unchanged" }, "status": "created" },
 		{ "sourceWorkflowId": "wf7Kq2", "localId": "wf7Kq2", "name": "Triage inbound",
 			"projectId": "prProd4", "parentFolderId": null,
-			"activeVersionId": "<version-id>", "publishing": { "state": "published" }, "status": "created" }
+			"activeVersionId": null, "publishing": { "state": "unchanged" }, "status": "created" }
 	],
 	"folders": [],
 	"projects": [],
@@ -226,6 +226,8 @@ There's no data table summary in the response.
 A workflow's `localId` is its ID on the target instance: the package's ID under `--workflow-id-policy=source`, a fresh ID under `new`, and the existing workflow's ID when it was updated or skipped.
 
 `publishing.state` is one of `published`, `unpublished`, `unchanged`, `blocked`, or `failed`. For what each means, see [Publishing outcomes](how-import-works.md#publishing-outcomes).
+
+Both workflows in the example are new, and the default `preserve-published-state` never publishes a new workflow, so each reports `unchanged` with a null `activeVersionId`. `activeVersionId` is non-null exactly when the workflow ends up published. To have new workflows arrive published, use `--workflow-publishing-policy=publish-all`, or `match-source` when they were published in the package.
 
 ## Errors
 

--- a/docs/build/manage-workflows/n8n-packages/import-a-package.md
+++ b/docs/build/manage-workflows/n8n-packages/import-a-package.md
@@ -227,7 +227,7 @@ A workflow's `localId` is its ID on the target instance: the package's ID under 
 
 `publishing.state` is one of `published`, `unpublished`, `unchanged`, `blocked`, or `failed`. For what each means, see [Publishing outcomes](how-import-works.md#publishing-outcomes).
 
-Both workflows in the example are new, and the default `preserve-published-state` never publishes a new workflow, so each reports `unchanged` with a null `activeVersionId`. `activeVersionId` is non-null exactly when the workflow ends up published. To have new workflows arrive published, use `--workflow-publishing-policy=publish-all`, or `match-source` when they were published in the package.
+Both workflows in the example are new, and the default `preserve-published-state` never publishes a new workflow, so each reports `unchanged`. To have new workflows arrive published, use `--workflow-publishing-policy=publish-all`, or `match-source` when they are specified as `published` in the package.
 
 ## Errors
 

--- a/styles/config/vocabularies/default/accept.txt
+++ b/styles/config/vocabularies/default/accept.txt
@@ -42,8 +42,8 @@ buildpack
 [Bb]urstable
 Caddy
 Calendly
-camelCase
 [Cc]allout
+camelCase
 Capterra
 cartesian
 Chargebee
@@ -115,9 +115,9 @@ Groq
 GSuite
 Gumroad
 [Gg]zip(ped)?
+[Hh]ardlinks?
 healthz
 Hetzner
-[Hh]ardlinks?
 Homeserver
 [Hh]ostnames?
 howto
@@ -136,11 +136,11 @@ Jira
 Jina
 JMESPath
 JumpCloud
+[Kk]ebab-case
 Keap
 Keycloak
 Kibana
 Kitemaker
-[Kk]ebab-case
 kubectl
 Kafka
 Lemlist
@@ -167,8 +167,8 @@ Metabase
 Milvus('s)?
 Mindee
 [Mm]inimum
-[Mm]ultipart
 Mocean
+[Mm]ultipart
 Motorhead
 [Mm]ultiple
 [Mm]ultitenan(cy|t)
@@ -179,8 +179,8 @@ NASA
 Nemotron
 Netlify
 Netscaler
-Nextcloud
 [Nn]amespacing
+Nextcloud
 [Nn]ginx
 ngrok
 NIM
@@ -243,8 +243,8 @@ signup
 Splunk
 Spontit
 Spotify
-spreadsheetId
 [Ss]lug(ging|s)?
+spreadsheetId
 Stackby
 Stackshare
 stdout


### PR DESCRIPTION
Follow-up to #5176, which merged before the review comments were worked through. Each change below was verified against the code in `n8n` rather than against the previous docs.

## The import response example was unreachable

@ireneea asked whether the default is unpublished. She's right that the example was wrong, though the actual value is a third thing.

The example showed two workflows with `"status": "created"` and `"publishing": { "state": "published" }`, under a CLI command that passes no `--workflow-publishing-policy`. The default is `preserve-published-state`, and `workflow-publishing-policy.ts` returns `noop` for anything that isn't `status === 'updated' && currentlyPublished && sourcePublished`. A created workflow can never satisfy that, so it always gets `noop`, which maps to `state: 'unchanged'` with a null `activeVersionId`.

Not `unpublished`: that state is only reported after an actual `deactivateWorkflow`, which can happen to a workflow n8n updated or archived, never to one it created.

Fixed the example and added a sentence explaining why, plus which policy does publish new workflows.

## A broken download emits no failure event

The events hint said a part-way download failure emits the failure event too. That's wrong for every transport failure, and it contradicted the sentence right after it.

`streamPackageExport` rejects on exactly one thing, an `'error'` on the source archive stream:

```ts
stream.on('error', reject);
res.on('finish', () => resolve(res));
res.on('close', () => {
	if (!res.writableFinished) stream.destroy();
	resolve(res);
});
stream.pipe(res);
```

A client disconnect, a connection reset, or a proxy timeout all land on `'close'` and **resolve**, so nothing further is emitted. The only way one request emits both events is a server-side error while building or compressing the archive, which classifies as `validation`.

The practical consequence, now stated on the page: the audit trail records a successful export for a download the user never received, so check the size of what you downloaded rather than trusting the `200`.

## Export error IDs: keeping the claim, tightening the wording

@ireneea said some errors do show a subset of the offending IDs. The code splits them: the count goes in `message`, the IDs go in a separate `description`.

```ts
const message = `${missingIds.length} ${entityType}(s) not found or not accessible. Export aborted.`;
const description = `Missing ${entityType} IDs: ${displayedIds.join(', ')}...`;
```

But `description` never reaches the client. `classifyHttpError`'s `userError` variant is `{ kind, message }` with no room for it, and `serializePublicApiError` emits `{ message }` alone. The handler's `throw new UserError(error.message, { description: error.description })` looks like it should surface them and is almost certainly the source of the impression, but it's inert one layer later.

The existing integration test pins this: `n8n-packages-export.test.ts` asserts `deniedResponse.body` equals `notFoundResponse.body` across two requests carrying different IDs, which only holds because the description is absent.

Kept the claim, but narrowed "aren't surfaced anywhere" to "aren't in the response" and added the message shape so it's concrete. If the team wants the IDs returned, that's a serializer change, not a docs one.

## Also

- The `.n8np` link-formatting suggestion applied to the import page. The export page twin landed with the merge.
- `accept.txt` entries reordered alphabetically, per cubic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns n8n package import/export docs with actual behavior to prevent reviewers and users from chasing unreachable states.

- Import: Example now shows new workflows return publishing.state "unchanged" and activeVersionId null under the default preserve-published-state. Document how to publish new workflows with `--workflow-publishing-policy=publish-all` or `match-source`.
- Export: Removed the claim that a partial download emits a failure event. Clarified that failure events include the user, requested IDs, and a reason; log streaming carries IDs and telemetry emits counts. Error responses include only a message (no IDs).
- Docs polish: Adjusted the .n8np link text on the import page. Alphabetized `accept.txt`.

<sup>Written for commit a65f91ad595416877e03ae1ecdcbd5496aee1171. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

