### PR TITLE
Fix include statement for node-operations.md

### DIFF
--- a/docs/reusable-content/temporary-page-2.md
+++ b/docs/reusable-content/temporary-page-2.md
@@ -4,4 +4,4 @@
 
 
 
-{% include ".gitbook/includes/integrations/builtin/node-operations.md" %}
+{% include ".gitbook/includes/integrations/builtin/node-operations.md" %} 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the GitBook include in `docs/reusable-content/temporary-page-2.md` so `node-operations.md` renders correctly in the docs.
This resolves a broken include caused by incorrect include formatting.

<sup>Written for commit b29e720d55a08a4ff945082ac84e4c087b2e418a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

