### PR TITLE
fix(docs): correct Microsoft Teams required scope to Group.Read.All

### DIFF
--- a/docs/integrations/builtin/credentials/microsoftentra.md
+++ b/docs/integrations/builtin/credentials/microsoftentra.md
@@ -187,7 +187,7 @@ The following scopes are required for each Microsoft integration as of March 202
 | **Microsoft OneDrive** | `openid`, `offline_access`, `Files.ReadWrite.All` |
 | **Microsoft Outlook** | `openid`, `offline_access`, `Contacts.Read`, `Contacts.ReadWrite`, `Calendars.Read`, `Calendars.Read.Shared`, `Calendars.ReadWrite`, `Mail.ReadWrite`, `Mail.ReadWrite.Shared`, `Mail.Send`, `Mail.Send.Shared`, `MailboxSettings.Read` |
 | **Microsoft SharePoint** | `openid`, `offline_access` |
-| **Microsoft Teams** | `openid`, `offline_access`, `User.Read.All`, `Group.ReadWrite.All`, `Chat.ReadWrite`, `ChannelMessage.Read.All` |
+| **Microsoft Teams** | `openid`, `offline_access`, `User.Read.All`, `Group.Read.All`, `Chat.ReadWrite`, `ChannelMessage.Read.All` |
 | **Microsoft To Do** | `openid`, `offline_access`, `Tasks.ReadWrite` |
 | **Additional permissions for triggers** | `Chat.Read.All`, `Team.ReadBasic.All`, `Subscription.Read.All` |
 


### PR DESCRIPTION
## Summary

The Microsoft Entra credentials doc listed `Group.ReadWrite.All` as a required scope for **Microsoft Teams**. The Teams OAuth2 credential changed its default scope from `Group.ReadWrite.All` to `Group.Read.All` (v2.29.0), so the docs were out of date.

Verified against source: [`MicrosoftTeamsOAuth2Api.credentials.ts`](https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/credentials/MicrosoftTeamsOAuth2Api.credentials.ts) `defaultScopes` now uses `Group.Read.All`.

## Change

Updated the *Required scopes by integration* table row for Microsoft Teams.

Fixes DOC-2187 / closes #5152

Reported by a community user via GitHub docs issue #5152.