### PR TITLE
docs: modify release label

### DIFF
--- a/.github/workflows/auto-handle-on-label.yml
+++ b/.github/workflows/auto-handle-on-label.yml
@@ -12,7 +12,7 @@ on:
       - labeled
 jobs:
   handle-labels:
-    if: contains(fromJSON('["block", "scope:old-course", "quality:unusable", "quality:low-effort-usable", "quality:disruptive", "status:duplicate", "status:dev-cancelled", "status:pending-dev", "status:in-next-release" ]'), github.event.label.name)
+    if: contains(fromJSON('["block", "scope:old-course", "quality:unusable", "quality:low-effort-usable", "quality:disruptive", "status:duplicate", "status:dev-cancelled", "status:pending-dev", "status:awaiting-release" ]'), github.event.label.name)
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -83,7 +83,7 @@ jobs:
               echo "comment=Thanks @${{ env.AUTHOR }}! We'll hold off on reviewing this until the PR is ready to go in the main repo." >> $GITHUB_OUTPUT
               echo "should_close=false" >> $GITHUB_OUTPUT
               ;;
-            "status:in-next-release")
+            "status:awaiting-release")
               echo "comment=Holding off on merging until this is released." >> $GITHUB_OUTPUT
               echo "should_close=false" >> $GITHUB_OUTPUT
               ;;

--- a/docs/contribute/contribution-guide-for-n8n-docs.md
+++ b/docs/contribute/contribution-guide-for-n8n-docs.md
@@ -194,7 +194,7 @@ Once you open a pull request, the n8n Docs team will review it and either merge 
 | `action:needs-review`       | Your PR is in the queue and waiting for a technical writer to review it                                                                                 |
 | `action:needs-sme`          | Your PR requires review from a subject matter expert before it can be merged                                                                            |
 | `status:pending-dev`        | Your PR is linked to an unmerged code change and will be reviewed once that merges                                                                      |
-| `status:in-next-release`    | The linked code change has merged and your PR will be reviewed shortly                                                                                  |
+| `status:awaiting-release`    | The linked code change has merged, but not yet been released. Your PR will be reviewed shortly                                                                                  |
 | `status:dev-cancelled`      | The code change your PR was linked to has been cancelled — the docs PR will be closed                                                                   |
 | `status:duplicate`          | Your PR covers the same ground as an existing PR or issue - the PR will be closed                                                                       |
 | `status:outdated`           | Your PR has been overtaken by subsequent changes to the docs - the PR will be closed                                                                    |


### PR DESCRIPTION
Modify label name from status:in-next-release to status:awaiting-release (for accuracy). Associated n8n workflows have been updated. 