### PR TITLE
docs(changelog): fix non-GitBook link and generic anchor text

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -52,7 +52,7 @@ For Slack and Telegram, you can go further with the new **Advanced Interactivity
 
 To enable approvals in Slack, your n8n instance must be reachable from Slack over public HTTPS. You will need to turn on Interactivity in your Slack app, set the **Request URL** to `https://<your-n8n-instance>/webhook-waiting-slack`, and paste your app's signing secret into the **Signature Secret** field of your Slack credential. Then, in the Slack node, set **Response Type** to **Approval** and turn on **Capture Who Responded** under the **Advanced Interactivity** section. For Telegram, your instance must be reachable over public HTTPS on a port Telegram supports for webhooks (443, 80, 88, or 8443). Enable **Approve Within Chat** in the same section: n8n registers the webhook for you using your existing Telegram credential, with no additional setup on Telegram's side.
 
-Learn more in the [documentation](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.slack/approvals).
+Learn more in the [Approvals in Slack documentation](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.slack/approvals).
 
 ***
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -129,7 +129,7 @@ Three states guide you as you work with custom date ranges:
 
 To use this, open the Insights dashboard, choose a date range with the date range picker, and check the alert banner at the top of the dashboard. If you see a partial or no-data alert, adjust your range to align with the dates your retention policy covers. Note that the alerts reflect your current retention configuration and do not extend how long execution data is stored.
 
-Learn more in the [documentation](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/observe-and-log/track-usage-with-insights#disable-or-configure-insights-metrics-collection).
+Learn more in the [insights retention documentation](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/observe-and-log/track-usage-with-insights#disable-or-configure-insights-metrics-collection).
 
 {% hint style="info" %}
 **Availability:** Pro, Business, and Enterprise.
@@ -235,7 +235,7 @@ Connect to MCP servers with less setup
 
 You can now attach custom span attributes to OpenTelemetry traces at the node, workflow, and project level, letting you filter and group execution spans by tenant, environment, customer ID, or any other dimension. Attribute values support expressions, so they can pull live data from webhook payloads or API responses at runtime rather than relying on hardcoded values. Configure tags in node or workflow settings when tracing is enabled (`N8N_OTEL_ENABLED=true`).
 
-Learn more in the [documentation](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/keep-n8n-running/trace-executions-with-opentelemetry#custom-span-attributes).
+Learn more in the [custom span attributes documentation](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/keep-n8n-running/trace-executions-with-opentelemetry#custom-span-attributes).
 
 {% hint style="info" %}
 **Availability:** Enterprise.


### PR DESCRIPTION
## Summary

Fixes the one internal link on the changelog homepage that wasn't in GitBook cross-space format, plus two generic `[documentation]` anchors. Three lines, one file.

| Line | Change |
| --- | --- |
| 55 | `https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.slack/approvals` → `https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.slack/approvals`, anchor text `documentation` → `Approvals in Slack documentation` |
| 132 | anchor text `documentation` → `insights retention documentation` (URL unchanged) |
| 238 | anchor text `documentation` → `custom span attributes documentation` (URL unchanged) |

The line 55 link arrived via #5165. It rendered as a working link, but it bypassed the GitBook space format every other internal link on the page uses.

## Why CI didn't catch it

`lychee.toml` excludes `^https://docs\.n8n\.io/.*` outright, so the absolute link was never checked. Worth knowing more generally: `accept` includes `403`, and `app.gitbook.com` returns a login redirect for unauthenticated requests — so a space link with a valid host but a **wrong path** also passes `link-check` while 404ing for readers.

## Audit of the rest of the page

Since CI can't verify these, I checked all of them offline by mapping space ID → directory, appending `.md` or `/README.md`, and confirming every `#anchor` exists as a heading or `id="…"` in the target file.

**84 internal links, 0 problems** — 51 GitBook space links, 32 relative intra-space, 1 reusable-content include (`iFLUKG9zJaouigaM7IOo`, present in `REUSABLE_CONTENT_INDEX.md`). Two external links (`github.com`, `blog.n8n.io`) left alone.

Both anchors on lines 132 and 238 were verified as correct targets, so only their anchor text changed. In particular, the line 132 entry is about retention-window alerts and `#disable-or-configure-insights-metrics-collection` does document retention (`N8N_INSIGHTS_MAX_AGE_DAYS`) — the target is right despite the section title reading as if it's only about disabling collection.

## Anchor text rationale

`docs/contribute/style-guide-for-n8n-docs.md` asks for "descriptive anchor text that names the target". The new text also matches the dominant pattern already on the page — `Learn more in the [X documentation](…)`, used on lines 41, 91, 114, 152, 178, 184, 408, 622.

## Note for a separate look

Space ID `ukPPOMQ6NId4gpAIkPXa` appears 8 times elsewhere in the repo (not on this page) and is the one ID I couldn't pin to a directory — its paths resolve ambiguously. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)