### PR TITLE
fix(versions): apply guidance on stating versions to all doc

### DIFF
--- a/docs/administer/manage-credentials/use-external-secret-stores.md
+++ b/docs/administer/manage-credentials/use-external-secret-stores.md
@@ -18,8 +18,8 @@ layout:
 
 * External secrets are available on Enterprise Self-hosted and Enterprise Cloud plans.
 * n8n supports the following secret providers: 1Password (via [Connect Server](https://developer.1password.com/docs/connect/get-started/)), AWS Secrets Manager, Azure Key Vault, GCP Secrets Manager, HashiCorp Vault, and Infisical.
-* From n8n version 2.10.0 you can connect multiple vaults per secret provider. Older versions only support one vault per provider.
-* From version `2.13.0`, if enabled, project editors can use external secrets within their projects, and project admins can also manage project vaults.
+* From n8n 2.10.0 you can connect multiple vaults per secret provider. Older versions only support one vault per provider.
+* From n8n `2.13.0`, if enabled, project editors can use external secrets within their projects, and project admins can also manage project vaults.
 * n8n doesn't support [HashiCorp Vault Secrets](https://developer.hashicorp.com/hcp/docs/vault-secrets).
 {% endhint %}
 

--- a/docs/administer/manage-credentials/use-external-secret-stores.md
+++ b/docs/administer/manage-credentials/use-external-secret-stores.md
@@ -19,7 +19,7 @@ layout:
 * External secrets are available on Enterprise Self-hosted and Enterprise Cloud plans.
 * n8n supports the following secret providers: 1Password (via [Connect Server](https://developer.1password.com/docs/connect/get-started/)), AWS Secrets Manager, Azure Key Vault, GCP Secrets Manager, HashiCorp Vault, and Infisical.
 * From n8n 2.10.0 you can connect multiple vaults per secret provider. Older versions only support one vault per provider.
-* From n8n `2.13.0`, if enabled, project editors can use external secrets within their projects, and project admins can also manage project vaults.
+* From n8n 2.13.0, if enabled, project editors can use external secrets within their projects, and project admins can also manage project vaults.
 * n8n doesn't support [HashiCorp Vault Secrets](https://developer.hashicorp.com/hcp/docs/vault-secrets).
 {% endhint %}
 
@@ -190,9 +190,9 @@ path "kv/*" {
 ### Infisical <a href="#infisical" id="infisical"></a>
 
 {% hint style="info" %}
-**Version `2.26.0` and later**
+**n8n 2.26.0 and later**
 
-Infisical secrets management support is only available from version `2.26.0`.
+Infisical secrets management support is only available from n8n 2.26.0.
 {% endhint %}
 
 
@@ -249,17 +249,17 @@ For example, you have two n8n instances, one for development and one for product
 
 ## Using external secrets in projects <a href="#using-external-secrets-in-projects" id="using-external-secrets-in-projects"></a>
 
-You can share a vault with a project so that only that project's credentials can reference its secrets. Refer to [Project vaults](#project-vaults) for setup steps. Project-scoped vaults are available from version `2.11.0`.
+You can share a vault with a project so that only that project's credentials can reference its secrets. Refer to [Project vaults](#project-vaults) for setup steps. Project-scoped vaults are available from n8n 2.11.0.
 
 ### Access for project roles <a href="#access-for-project-roles" id="access-for-project-roles"></a>
 
 {% hint style="info" %}
-**Version `2.13.0` and later**
+**n8n 2.13.0 and later**
 
-Before version `2.13.0`, using external secrets in an [RBAC project](../manage-users-and-access/set-permissions-and-roles-rbac/README.md) required an [instance owner or instance admin](../manage-users-and-access/understand-instance-roles.md) as a member of the project.
+Before n8n 2.13.0, using external secrets in an [RBAC project](../manage-users-and-access/set-permissions-and-roles-rbac/README.md) required an [instance owner or instance admin](../manage-users-and-access/understand-instance-roles.md) as a member of the project.
 {% endhint %}
 
-From version `2.13.0`, instance owners and admins can grant [project editors](../manage-users-and-access/set-permissions-and-roles-rbac/see-available-roles.md#project-editor) and [project admins](../manage-users-and-access/set-permissions-and-roles-rbac/see-available-roles.md#project-admin) access to external secrets.
+From n8n 2.13.0, instance owners and admins can grant [project editors](../manage-users-and-access/set-permissions-and-roles-rbac/see-available-roles.md#project-editor) and [project admins](../manage-users-and-access/set-permissions-and-roles-rbac/see-available-roles.md#project-admin) access to external secrets.
 
 To enable this:
 
@@ -296,9 +296,9 @@ Both permissions are independent. For example, a role may need only the **Secret
 ### Secrets don't resolve in production <a href="#secrets-dont-resolve-in-production" id="secrets-dont-resolve-in-production"></a>
 
 {% hint style="info" %}
-**Version `2.13.0` and later**
+**n8n 2.13.0 and later**
 
-From version `2.13.0`, project editors and admins with [secrets access enabled](#access-for-project-roles) can use external secrets in their own credentials. The restriction below applies only to older versions or when the opt-in toggle is off.
+From n8n 2.13.0, project editors and admins with [secrets access enabled](#access-for-project-roles) can use external secrets in their own credentials. The restriction below applies only to older versions or when the opt-in toggle is off.
 {% endhint %}
 
 In versions before `2.13.0` (or when **Enable external secrets for project roles** is off), only instance owners and admins can resolve secrets at runtime. If an owner or admin updates another user's credential with a secrets expression, it may appear to work in preview but fail in production.

--- a/docs/administer/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-instance-roles.md
+++ b/docs/administer/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-instance-roles.md
@@ -17,7 +17,7 @@ layout:
 
 Custom instance roles are available on Self-hosted Enterprise and Cloud Enterprise plans. Refer to n8n's [pricing page](https://n8n.io/pricing/) for plan details.
 
-**Available from:** n8n version 2.30.0 (released July 7, 2026)
+**Available from:** n8n 2.30.0 (released July 7, 2026)
 {% endhint %}
 
 {% hint style="info" %}

--- a/docs/administer/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-project-roles.md
+++ b/docs/administer/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-project-roles.md
@@ -19,9 +19,9 @@ layout:
 
 Custom roles are available on Self-hosted Enterprise and Cloud Enterprise plans. Refer to n8n's [pricing page](https://n8n.io/pricing/) for plan details.
 
-**Available from:** n8n version 1.122.0 (released November 24, 2025)
+**Available from:** n8n 1.122.0 (released November 24, 2025)
 
-Secret vault scopes are available from n8n version `2.13.0`.
+Secret vault scopes are available from n8n `2.13.0`.
 {% endhint %}
 
 {% hint style="info" %}

--- a/docs/administer/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-project-roles.md
+++ b/docs/administer/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-project-roles.md
@@ -21,7 +21,7 @@ Custom roles are available on Self-hosted Enterprise and Cloud Enterprise plans.
 
 **Available from:** n8n 1.122.0 (released November 24, 2025)
 
-Secret vault scopes are available from n8n `2.13.0`.
+Secret vault scopes are available from n8n 2.13.0.
 {% endhint %}
 
 {% hint style="info" %}

--- a/docs/administer/manage-users-and-access/set-permissions-and-roles-rbac/see-available-roles.md
+++ b/docs/administer/manage-users-and-access/set-permissions-and-roles-rbac/see-available-roles.md
@@ -61,6 +61,6 @@ n8n has two levels of roles. [Instance roles](../understand-instance-roles.md) c
 | Use external secrets in credentials | ✅* | ✅* | ❌ |
 | Manage project secret vaults | ✅* | ❌ | ❌ |
 
-\* Requires **Enable external secrets for project roles** to be enabled by an instance owner or admin. Refer to [Access for project roles](../../manage-credentials/use-external-secret-stores.md#access-for-project-roles). This is available from n8n `2.13.0`.
+\* Requires **Enable external secrets for project roles** to be enabled by an instance owner or admin. Refer to [Access for project roles](../../manage-credentials/use-external-secret-stores.md#access-for-project-roles). This is available from n8n 2.13.0.
 
 [Variables](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/code-in-n8n/define-custom-variables) and [tags](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/tag-workflows) aren't affected by RBAC: they're global across the n8n instance.

--- a/docs/administer/manage-users-and-access/set-permissions-and-roles-rbac/see-available-roles.md
+++ b/docs/administer/manage-users-and-access/set-permissions-and-roles-rbac/see-available-roles.md
@@ -61,6 +61,6 @@ n8n has two levels of roles. [Instance roles](../understand-instance-roles.md) c
 | Use external secrets in credentials | ✅* | ✅* | ❌ |
 | Manage project secret vaults | ✅* | ❌ | ❌ |
 
-\* Requires **Enable external secrets for project roles** to be enabled by an instance owner or admin. Refer to [Access for project roles](../../manage-credentials/use-external-secret-stores.md#access-for-project-roles). This is available from n8n version `2.13.0`.
+\* Requires **Enable external secrets for project roles** to be enabled by an instance owner or admin. Refer to [Access for project roles](../../manage-credentials/use-external-secret-stores.md#access-for-project-roles). This is available from n8n `2.13.0`.
 
 [Variables](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/code-in-n8n/define-custom-variables) and [tags](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/tag-workflows) aren't affected by RBAC: they're global across the n8n instance.

--- a/docs/administer/manage-users-and-access/verify-user-identity/use-oidc/set-up-oidc.md
+++ b/docs/administer/manage-users-and-access/verify-user-identity/use-oidc/set-up-oidc.md
@@ -50,7 +50,7 @@ You can also configure OIDC from environment variables instead of the UI. Availa
 
 n8n supports provisioning the instance role and project roles via SSO. When a user signs in via OIDC, n8n can assign their instance role and project access automatically based on claims in the IdP response.
 
-Role provisioning was introduced in version `1.122.2`.
+Role provisioning was introduced in n8n 1.122.2.
 
 #### Choose how roles are assigned <a href="#choose-how-roles-are-assigned" id="choose-how-roles-are-assigned"></a>
 
@@ -116,7 +116,7 @@ For new projects, get the project ID from the URL when viewing the project in yo
 
 #### Map rules inside n8n <a href="#map-rules-inside-n8n" id="map-rules-inside-n8n"></a>
 
-**Map rules inside n8n** is available from version `2.19.0` upwards.
+**Map rules inside n8n** is available from n8n 2.19.0 upwards.
 
 Use this option to define group-to-role mappings inside n8n rather than in your IdP. Each rule is an expression that n8n evaluates against the OIDC claims in the IdP response.
 

--- a/docs/administer/manage-users-and-access/verify-user-identity/use-oidc/set-up-oidc.md
+++ b/docs/administer/manage-users-and-access/verify-user-identity/use-oidc/set-up-oidc.md
@@ -19,7 +19,7 @@ layout:
 {% hint style="info" %}
 **Configure using environment variables**
 
-You can also configure OIDC from environment variables instead of the UI. Available from n8n v2.18.0. See [SSO environment variables](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/basic-configuration/use-environment-variables/sso).
+You can also configure OIDC from environment variables instead of the UI. Available from n8n 2.18.0. See [SSO environment variables](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/basic-configuration/use-environment-variables/sso).
 {% endhint %}
 
 ## Setting up and enabling OIDC <a href="#setting-up-and-enabling-oidc" id="setting-up-and-enabling-oidc"></a>

--- a/docs/administer/manage-users-and-access/verify-user-identity/use-saml/set-up-saml.md
+++ b/docs/administer/manage-users-and-access/verify-user-identity/use-saml/set-up-saml.md
@@ -19,7 +19,7 @@ layout:
 {% hint style="info" %}
 **Configure using environment variables**
 
-You can also configure SAML from environment variables instead of the UI. Available from n8n v2.18.0. See [SSO environment variables](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/basic-configuration/use-environment-variables/sso).
+You can also configure SAML from environment variables instead of the UI. Available from n8n 2.18.0. See [SSO environment variables](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/basic-configuration/use-environment-variables/sso).
 {% endhint %}
 
 ## Enable SAML <a href="#enable-saml" id="enable-saml"></a>

--- a/docs/administer/manage-users-and-access/verify-user-identity/use-saml/set-up-saml.md
+++ b/docs/administer/manage-users-and-access/verify-user-identity/use-saml/set-up-saml.md
@@ -60,7 +60,7 @@ The steps to configure the IdP vary depending on your chosen IdP. These are some
 
 n8n supports provisioning the instance role and project roles via SSO. When a user signs in via SAML, n8n can assign their instance role and project access automatically based on attributes in the SAML response.
 
-Role provisioning was introduced in version `1.122.2`.
+Role provisioning was introduced in n8n 1.122.2.
 
 #### Choose how roles are assigned <a href="#choose-how-roles-are-assigned" id="choose-how-roles-are-assigned"></a>
 
@@ -124,7 +124,7 @@ For new projects, get the project ID from the URL when viewing the project in yo
 
 #### Map rules inside n8n <a href="#map-rules-inside-n8n" id="map-rules-inside-n8n"></a>
 
-**Map rules inside n8n** is available from version `2.19.0` upwards.
+**Map rules inside n8n** is available from n8n 2.19.0 upwards.
 
 Use this option to define group-to-role mappings inside n8n rather than in your IdP. Each rule is an expression that n8n evaluates against the SAML attributes in the IdP response.
 

--- a/docs/administer/observe-and-log/stream-logs-to-external-systems.md
+++ b/docs/administer/observe-and-log/stream-logs-to-external-systems.md
@@ -180,7 +180,7 @@ n8n supports three destination types:
 
 ## Configure using environment variables <a href="#configure-using-environment-variables" id="configure-using-environment-variables"></a>
 
-If you self-host n8n, you can manage log streaming destinations from environment variables instead of the UI. Available from n8n v2.19.0. Set `N8N_LOG_STREAMING_MANAGED_BY_ENV` to `true` and provide your destinations as a JSON array in `N8N_LOG_STREAMING_DESTINATIONS`. n8n reapplies these on every startup and locks the **Log Streaming** UI as read-only. See [Manage instance settings using environment variables](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/manage-settings-using-environment-variables) for the full pattern.
+If you self-host n8n, you can manage log streaming destinations from environment variables instead of the UI. Available from n8n 2.19.0. Set `N8N_LOG_STREAMING_MANAGED_BY_ENV` to `true` and provide your destinations as a JSON array in `N8N_LOG_STREAMING_DESTINATIONS`. n8n reapplies these on every startup and locks the **Log Streaming** UI as read-only. See [Manage instance settings using environment variables](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/manage-settings-using-environment-variables) for the full pattern.
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/JvN9TDUUWTwpWaT83YrH/" %}
 

--- a/docs/administer/observe-and-log/track-usage-with-insights.md
+++ b/docs/administer/observe-and-log/track-usage-with-insights.md
@@ -118,4 +118,4 @@ n8n records an error workflow execution's own outcome and run time against the e
 
 ### Does n8n use historic execution data when upgrading to a version with insights? <a href="#does-n8n-use-historic-execution-data-when-upgrading-to-a-version-with-insights" id="does-n8n-use-historic-execution-data-when-upgrading-to-a-version-with-insights"></a>
 
-n8n only starts collecting data for insights once you update to the first supported version (1.89.0). This means it only reports on executions from that point forward and you won't see execution data in insights from prior periods.
+n8n only starts collecting data for insights once you update to n8n 1.89.0, the first supported version. This means it only reports on executions from that point forward and you won't see execution data in insights from prior periods.

--- a/docs/build/build-and-manage-agents.md
+++ b/docs/build/build-and-manage-agents.md
@@ -226,7 +226,7 @@ You can use agents within your workflows in two ways:
 
 ### Self-hosted
 
-Agents run on self-hosted n8n from version `2.32.3` (Beta). There are two ways to set them up:
+Agents run on self-hosted n8n from `2.32.3` (Beta). There are two ways to set them up:
 
 * **Build manually**: enable the `agents` module (add `agents` to `N8N_ENABLED_MODULES`). You pick the model, write the instructions, and attach tools and skills yourself. This is all you need to build and run agents.
 * **Full experience**: also set up [AI Assistant](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-ai-assistant) (`instance-ai`) for AI-assisted building, where you describe an agent and n8n scaffolds it. The knowledge base needs a Daytona sandbox, and connecting channels needs a public `WEBHOOK_URL`.

--- a/docs/build/build-and-manage-agents.md
+++ b/docs/build/build-and-manage-agents.md
@@ -226,7 +226,7 @@ You can use agents within your workflows in two ways:
 
 ### Self-hosted
 
-Agents run on self-hosted n8n from `2.32.3` (Beta). There are two ways to set them up:
+Agents run on self-hosted n8n from 2.32.3 (Beta). There are two ways to set them up:
 
 * **Build manually**: enable the `agents` module (add `agents` to `N8N_ENABLED_MODULES`). You pick the model, write the instructions, and attach tools and skills yourself. This is all you need to build and run agents.
 * **Full experience**: also set up [AI Assistant](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-ai-assistant) (`instance-ai`) for AI-assisted building, where you describe an agent and n8n scaffolds it. The knowledge base needs a Daytona sandbox, and connecting channels needs a public `WEBHOOK_URL`.

--- a/docs/build/flow-logic/convert-to-sub-workflows.md
+++ b/docs/build/flow-logic/convert-to-sub-workflows.md
@@ -16,7 +16,7 @@ layout:
 {% hint style="info" %}
 **Feature availability**
 
-Available on all plans from n8n version 1.97.0.
+Available on all plans from n8n 1.97.0.
 {% endhint %}
 
 Use sub-workflow conversion to refactor your workflows into reusable parts. Expressions referencing other nodes are automatically updated and added as parameters in the [Execute Workflow Trigger](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.executeworkflowtrigger) node.

--- a/docs/build/flow-logic/understand-execution-order.md
+++ b/docs/build/flow-logic/understand-execution-order.md
@@ -15,8 +15,8 @@ layout:
 
 n8n's node execution order depends on the version of n8n you're using:
 
-* For workflows created before version 1.0: n8n executes the first node of each branch, then the second node of each branch, and so on.
-* For workflows created in version 1.0 and above: executes each branch in turn, completing one branch before starting another. n8n orders the branches based on their position on the canvas[^1], from topmost to bottommost. If two branches are at the same height, the leftmost branch executes first.
+* For workflows created before n8n 1.0: n8n executes the first node of each branch, then the second node of each branch, and so on.
+* For workflows created in n8n 1.0 and above: executes each branch in turn, completing one branch before starting another. n8n orders the branches based on their position on the canvas[^1], from topmost to bottommost. If two branches are at the same height, the leftmost branch executes first.
 
 You can change the execution order in your [workflow settings](../manage-workflows/configure-workflow-settings.md).
 

--- a/docs/build/understand-workflows/workflow-components/canvas-groups.md
+++ b/docs/build/understand-workflows/workflow-components/canvas-groups.md
@@ -16,7 +16,7 @@ layout:
 {% hint style="info" %}
 **Feature availability**
 
-Canvas Groups rolled out gradually from version `2.28.0` and are available on all instances from version `2.31.0`.
+Canvas Groups rolled out gradually from n8n `2.28.0` and are available on all instances from n8n `2.31.0`.
 {% endhint %}
 
 Canvas Groups let you organize related nodes into a single named group on the canvas. Group the nodes that handle one part of a workflow, name it, and collapse it when you want a cleaner view. A Canvas Group saves with the workflow, so anyone who opens it sees the same structure. You can collapse a Canvas Group for a cleaner view, which is a personal preference saved in your browser. And you can also give a Canvas Group a description, so anyone reading the workflow can see what that part does at a glance.

--- a/docs/build/understand-workflows/workflow-components/canvas-groups.md
+++ b/docs/build/understand-workflows/workflow-components/canvas-groups.md
@@ -16,7 +16,7 @@ layout:
 {% hint style="info" %}
 **Feature availability**
 
-Canvas Groups rolled out gradually from n8n `2.28.0` and are available on all instances from n8n `2.31.0`.
+Canvas Groups rolled out gradually from n8n 2.28.0 and are available on all instances from n8n 2.31.0.
 {% endhint %}
 
 Canvas Groups let you organize related nodes into a single named group on the canvas. Group the nodes that handle one part of a workflow, name it, and collapse it when you want a cleaner view. A Canvas Group saves with the workflow, so anyone who opens it sees the same structure. You can collapse a Canvas Group for a cleaner view, which is a personal preference saved in your browser. And you can also give a Canvas Group a description, so anyone reading the workflow can see what that part does at a glance.

--- a/docs/build/ways-of-building-workflows/use-the-ai-assistant.md
+++ b/docs/build/ways-of-building-workflows/use-the-ai-assistant.md
@@ -57,7 +57,7 @@ Ask n8n AI offers a range of tools to support you:
 ## AI usage settings <a href="#ai-usage-settings" id="ai-usage-settings"></a>
 
 {% hint style="info" %}
-Available in n8n v2.7.0 and above.
+Available in n8n 2.7.0 and above.
 {% endhint %}
 
 You can manage your AI usage settings by navigating to **Settings** > **AI Usage** in your n8n instance. Here, you can control what data is shared with Ask n8n AI.

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -24,7 +24,7 @@ Your queue mode workers can now return a webhook response however large the payl
 
 Set `N8N_WEBHOOK_RESPONSE_RELAY_OFFLOAD_ENABLED=true` on your workers and n8n stores a response body above that limit in [binary data storage](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/scaling/handle-binary-data) instead. The queue message then carries only a reference, the main instance streams the body from storage to the client, and n8n deletes the stored copy once it delivers the response, so nothing accumulates. Redis memory stays flat no matter how large the response gets.
 
-Offloading needs a `N8N_DEFAULT_BINARY_DATA_MODE` that stores data (any mode except `default`) and storage that every instance can read. n8n recommends `s3` or `azure`, since both stream the body a chunk at a time. Only a main instance running 2.34.0 or later can read an offloaded body, so the variable ships turned off: upgrade your main and webhook instances first, then enable it on your workers.
+Offloading needs a `N8N_DEFAULT_BINARY_DATA_MODE` that stores data (any mode except `default`) and storage that every instance can read. n8n recommends `s3` or `azure`, since both stream the body a chunk at a time. Only a main instance running n8n 2.34.0 or later can read an offloaded body, so the variable ships turned off: upgrade your main and webhook instances first, then enable it on your workers.
 
 Refer to [Large webhook responses](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/scaling/enable-queue-mode#large-webhook-responses) for the full configuration, upgrade order, and troubleshooting.
 
@@ -60,11 +60,11 @@ Learn more in the [Approvals in Slack documentation](https://app.gitbook.com/s/B
 
 **Released:** 2026-07-07 in [n8n 2.30](release-notes.md#n8n230)
 
-You can now authenticate Microsoft nodes with a [Microsoft Entra Service Principal](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/credentials/microsoftentraserviceprincipal), so workflows run as an application instead of a signed-in user. OneDrive and Outlook gained the option in 2.29; Excel 365, Microsoft Teams, and Microsoft To Do follow in 2.30, all sharing a single app-only credential.
+You can now authenticate Microsoft nodes with a [Microsoft Entra Service Principal](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/credentials/microsoftentraserviceprincipal), so workflows run as an application instead of a signed-in user. OneDrive and Outlook gained the option in n8n 2.29; Excel 365, Microsoft Teams, and Microsoft To Do follow in n8n 2.30, all sharing a single app-only credential.
 
 Until now, Microsoft automations were tied to a person's OAuth session: when that person left the company or their token expired, the workflow broke. With app-only authentication, the workflow authenticates non-interactively with tenant-level permissions and targets the user, mailbox, drive, or site you specify: read a shared mailbox, process files in any user's drive, or post to Teams channels with nobody logged in. OAuth2 remains the default everywhere, so existing workflows are untouched, and operations that only make sense for a signed-in user are disabled per node with a clear error.
 
-_OneDrive and Outlook support released in 2.29 (2026-06-30)._
+_OneDrive and Outlook support released in n8n 2.29 (2026-06-30)._
 
 ### mTLS authentication for Kafka
 
@@ -102,14 +102,14 @@ Learn more in the [AI Assistant documentation](https://app.gitbook.com/s/rPN1zU5
 
 We've shipped a number of updates to the n8n MCP server over the past few weeks. Here's a roundup, with the version each change landed in.
 
-* **Build with custom and community nodes.** You can now use your installed custom and community nodes in the workflows you build, not just the built-in ones (v2.29).
-* **Read and change workflow settings.** Workflow settings are now editable through the MCP server, so you can connect an error workflow, set the timezone, or adjust execution options (v2.29).
-* **View and restore workflow history.** You can now browse a workflow's version history and restore an earlier version (v2.29).
-* **More reliable credential assignment.** Fixed a bug where the server could assign a credential that wasn't valid for a node (v2.28).
-* **Look up real field values.** Dynamic fields like Slack channels or Google Sheets tabs now resolve to live values, so nodes are configured with valid selections instead of placeholder IDs (v2.27).
-* **Work with tags.** Tags are now supported, so you can filter a workflow search by tag and apply tags when creating or updating workflows (v2.27).
-* **Faster, targeted edits.** Workflow updates now change only the nodes that need to change instead of rewriting the whole thing (v2.22).
-* **List and choose credentials.** You can now list the credentials on your instance and pick the right one when several could apply, for example among five Gmail credentials (v2.21).
+* **Build with custom and community nodes.** You can now use your installed custom and community nodes in the workflows you build, not just the built-in ones (n8n 2.29).
+* **Read and change workflow settings.** Workflow settings are now editable through the MCP server, so you can connect an error workflow, set the timezone, or adjust execution options (n8n 2.29).
+* **View and restore workflow history.** You can now browse a workflow's version history and restore an earlier version (n8n 2.29).
+* **More reliable credential assignment.** Fixed a bug where the server could assign a credential that wasn't valid for a node (n8n 2.28).
+* **Look up real field values.** Dynamic fields like Slack channels or Google Sheets tabs now resolve to live values, so nodes are configured with valid selections instead of placeholder IDs (n8n 2.27).
+* **Work with tags.** Tags are now supported, so you can filter a workflow search by tag and apply tags when creating or updating workflows (n8n 2.27).
+* **Faster, targeted edits.** Workflow updates now change only the nodes that need to change instead of rewriting the whole thing (n8n 2.22).
+* **List and choose credentials.** You can now list the credentials on your instance and pick the right one when several could apply, for example among five Gmail credentials (n8n 2.21).
 
 Learn more in the [n8n MCP server documentation](https://app.gitbook.com/s/r7wKI4I1BgdBCuq5Cvcx/connect-to-n8n-mcp-server).
 
@@ -167,7 +167,7 @@ Set the credential's **Scope** field to the space-separated permissions the node
 
 Nothing changes for existing workflows. On saved nodes the **Authentication** dropdown stays on the node-specific credential, so credentials like Microsoft Excel OAuth2 API keep working untouched. The generic credential is an additive option, not a replacement.
 
-_Microsoft OneDrive support released in 2.27 (2026-06-16)._
+_Microsoft OneDrive support released in n8n 2.27 (2026-06-16)._
 
 Learn more in the [Microsoft credentials documentation](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/credentials/microsoft).
 
@@ -263,7 +263,7 @@ Fourteen trigger nodes now verify the signatures of incoming webhooks, so forged
 
 Verification uses each service's own signing mechanism, typically an HMAC signature header, with constant-time comparison and, where the service supports it, replay protection. Signing secrets are generated and registered automatically when n8n creates the webhook and stored with the workflow. Existing webhooks without a stored secret keep working, so nothing breaks on upgrade; new webhooks simply come out more secure by default.
 
-This is part of a broader hardening pass across releases: Netlify verification shipped in 2.20, and AWS SNS, Box, and Microsoft Teams followed in 2.22.
+This is part of a broader hardening pass across releases: Netlify verification shipped in n8n 2.20, and AWS SNS, Box, and Microsoft Teams followed in n8n 2.22.
 
 ### Jira: OAuth2 authentication
 
@@ -345,13 +345,13 @@ More providers followed in later releases:
 
 ### MiniMax
 
-_Released in 2.18 (2026-04-21)._
+_Released in n8n 2.18 (2026-04-21)._
 
 A [MiniMax chat-model sub-node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatminimax) (OpenAI-compatible API, default MiniMax-M2.7, with a Hide Thinking option that strips reasoning traces for clean responses) plus a [standalone MiniMax node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-langchain.minimax) covering chat, image generation, asynchronous video generation, and text-to-speech with voice, emotion, speed, and pitch controls.
 
 ### NVIDIA Nemotron embeddings
 
-_Released in 2.26 (2026-06-09)._
+_Released in n8n 2.26 (2026-06-09)._
 
 The NVIDIA Nemotron Embeddings node generates embeddings from NeMo Retriever models via build.nvidia.com or a self-hosted NIM, reusing the existing NVIDIA credential. The node automatically sets the right input type per call ("passage" when indexing, "query" when searching), preventing the silent retrieval-quality degradation that mismatched input types cause.
 
@@ -384,7 +384,7 @@ Redaction is configured per workflow under **Workflow settings**, and reveal acc
 ### Public API improvements
 
 * **Community packages.** Install, list, update, and uninstall community packages programmatically through new endpoints under `/api/v1/community-packages`. Each operation requires an API key with the matching `communityPackage:*` scope.
-* **Insights scope.** A new `insights:read` API key scope, setting up the insights summary endpoint that ships in v2.17.
+* **Insights scope.** A new `insights:read` API key scope, setting up the insights summary endpoint that ships in n8n 2.17.
 
 ***
 
@@ -405,7 +405,7 @@ N8N_OTEL_EXPORTER_OTLP_ENDPOINT=http://your-collector:4318
 
 Standard OTel variables (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`) are also respected.
 
-This is the foundational T1 feature. It was extended across later releases: node-level spans (v2.16), workflow version IDs in spans and distributed trace context propagation (v2.18 to v2.19), and AI Agent telemetry (v2.20).
+This is the foundational T1 feature. It was extended across later releases: node-level spans (n8n 2.16), workflow version IDs in spans and distributed trace context propagation (n8n 2.18 to n8n 2.19), and AI Agent telemetry (n8n 2.20).
 
 {% hint style="info" %}
 **Availability:** Self-hosted only.
@@ -534,7 +534,7 @@ Instance admins can now create vault connections scoped to a specific project. S
 
 ### Personal space policies
 
-_Released in 2.8.3 (2026-02-13)._
+_Released in n8n 2.8.3 (2026-02-13)._
 
 A new **Security & policies** settings section provides a central place for enforcing security requirements on your instance. In addition to the existing two-factor authentication enforcement, admins can now control what users can do in their personal spaces.
 
@@ -549,7 +549,7 @@ This release builds on recent updates to the permissions model, including [custo
 
 ### Custom roles: improved discoverability and permission visibility
 
-_Released in 2.8.3 (2026-02-13)._
+_Released in n8n 2.8.3 (2026-02-13)._
 
 The project role selector now separates built-in system roles and custom roles into distinct sections, making it easier to find and choose the right role. Hovering over a role shows a summary of its configured permissions, with an option to view the full permission details.
 
@@ -557,13 +557,13 @@ The project role selector now separates built-in system roles and custom roles i
 
 ### Stronger external secrets validation
 
-_Released in 2.8.0 (2026-02-09)._
+_Released in n8n 2.8.0 (2026-02-09)._
 
 n8n now verifies that the current user has access to the referenced vaults before allowing a credential that uses `$secrets...` expressions to be saved. If access is missing, the save operation fails. This prevents secret values from being exposed through guessed secret paths.
 
 ### Improved API auditability
 
-_Released in 2.8.0 (2026-02-09)._
+_Released in n8n 2.8.0 (2026-02-09)._
 
 API endpoints have been expanded to provide clearer visibility into project membership and credentials:
 
@@ -574,7 +574,7 @@ This makes it easier to audit who has access to which projects and credentials w
 
 ### More granular workflow permissions
 
-_Released in 2.8.0 (2026-02-09)._
+_Released in n8n 2.8.0 (2026-02-09)._
 
 Workflow publishing permissions for [custom roles](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-roles) have been split into two separate scopes: `workflow:publish` and `workflow:unpublish`. This enables more precise access control in governance scenarios where unpublishing needs to be managed independently.
 

--- a/docs/changelog/release-notes-0.x.md
+++ b/docs/changelog/release-notes-0.x.md
@@ -41,7 +41,7 @@ tags:
 
 These release notes are now archived and won't receive further updates. For the latest releases, including every patch version, see the [n8n releases on GitHub](https://github.com/n8n-io/n8n/releases).
 
-For a curated summary of the changes that matter most, see the [Changelog](./).
+For a curated summary of the changes that matter most, see the [Changelog](README.md).
 {% endhint %}
 
 Features and bug fixes for n8n before the release of 1.0.0.
@@ -122,7 +122,7 @@ For full release details, refer to [Releases](https://github.com/n8n-io/n8n/rele
 
 This release includes a [crowd.dev](https://www.crowd.dev/) node and crowd.dev Trigger node. crowd.dev is a tool to help you understand who is engaging with your open source project.
 
-[crowd.dev node documentation](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.crowddev).
+The crowd.dev node was later removed. See [Deprecated and versioned nodes](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/deprecated-nodes) for details.
 {% endhint %}
 
 ### Contributors <a href="#contributors" id="contributors"></a>

--- a/docs/changelog/release-notes-0.x.md
+++ b/docs/changelog/release-notes-0.x.md
@@ -420,7 +420,7 @@ This release deprecates the following:
 * The `EXECUTIONS_PROCESS` environment variable.
 * Running n8n in own mode. Main mode is now the default. Use [Queue mode](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/scaling/enable-queue-mode) if you need full execution isolation.
 * The `WEBHOOK_TUNNEL_URL` flag. Replaced by `WEBHOOK_URL`.
-* Support for MySQL and MariaDB as n8n backend databases. n8n will remove support completely in version 1.0. n8n recommends using PostgreSQL instead.
+* Support for MySQL and MariaDB as n8n backend databases. n8n will remove support completely in n8n 1.0. n8n recommends using PostgreSQL instead.
 
 ## n8n@0.226.2 <a href="#n8n02262" id="n8n02262"></a>
 

--- a/docs/changelog/release-notes-1.x.md
+++ b/docs/changelog/release-notes-1.x.md
@@ -1,5 +1,5 @@
 ---
-title: Release notes pre 2.0
+title: Release notes pre n8n 2.0
 hide:
   - tags
 contentType: reference
@@ -756,7 +756,7 @@ For full release details, refer to [Releases](https://github.com/n8n-io/n8n/rele
 View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.121.0...n8n@1.121.1) for this version.<br>
 
 * Prepared patch release 1.121.1 by updating version numbers across all packages.
-* Added a changelog entry for version 1.121.1 to document the release.
+* Added a changelog entry for n8n 1.121.1 to document the release.
 
 **Release date:** 2025-11-19
 
@@ -819,7 +819,7 @@ View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.120.3...n8n@1.120
 **Release date:** 2025-11-19
 
 * Prepared for release 1.120.4 by updating version numbers across all core, backend, AI/LLM, frontend, and tooling packages.
-* Added a changelog entry for version 1.120.4 to document the release.
+* Added a changelog entry for n8n 1.120.4 to document the release.
 
 For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
 
@@ -846,7 +846,7 @@ For full release details, refer to [Releases](https://github.com/n8n-io/n8n/rele
 View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.119.0...n8n@1.120.0) for this version.\
 **Release date:** 2025-11-10
 
-This release contains **security updates** and bug fixes. We recommend all users upgrade promptly to version 1.120 or higher.
+This release contains **security updates** and bug fixes. We recommend all users upgrade promptly to n8n 1.120 or higher.
 
 ### Contributors <a href="#contributors" id="contributors"></a>
 
@@ -988,8 +988,8 @@ AI Workflow Builder turns prompts into workflows. Describe what you want to buil
 **What’s new:**
 
 * Previously available to Starter and Pro users, AI Workflow Builder is now accessible to Enterprise Cloud users as well, with 1,000 monthly credits.
-* Supported on n8n version 1.115+. **If you don’t see the feature yet, open /settings/usage to trigger a license refresh.**
-* We’ve fixed a bug and now cloud users on v1.117.1 onwards will have access to a more reliable builder.
+* Supported on n8n 1.115+. **If you don’t see the feature yet, open /settings/usage to trigger a license refresh.**
+* We’ve fixed a bug and now cloud users on n8n 1.117.1 onwards will have access to a more reliable builder.
 * We’re currently working on bringing AI Workflow Builder to self-hosted users as well, including Community, Business, and Enterprise.
 {% endhint %}
 
@@ -1135,7 +1135,7 @@ Learn more about how we we’re building this feature in our [forum post](https:
 
 **Rollout timing:**
 
-* To ensure the smoothest experience for all users, this feature will be rolled out to users on version 1.115.0 over the course of a week so you may not have access to the feature immediately when you upgrade to 1.115.0.
+* To ensure the smoothest experience for all users, this feature will be rolled out to users on n8n 1.115.0 over the course of a week so you may not have access to the feature immediately when you upgrade to n8n 1.115.0.
 
 **Credit limits by plan:** This feature will have monthly credit limits [by plan](https://n8n.io/pricing/).
 
@@ -1312,8 +1312,8 @@ This release contains core updates, editor improvements, a new node, node update
 
 We’ve made updates to strengthen Single Sign-On (SSO) reliability and security, especially for enterprise and multi-instance setups.
 
-* OIDC and SAML sync in multi-main setups \[version: 1.113.0]: In multi-main deployments, updates to SSO settings are now synchronized across all instances, ensuring consistent login behavior everywhere.
-* Enhanced OIDC integration \[version 1.111.0]: n8n now supports OIDC providers that enforce state and nonce parameters. These are validated during login, providing smoother and more secure Single Sign-On.
+* OIDC and SAML sync in multi-main setups \[n8n 1.113.0]: In multi-main deployments, updates to SSO settings are now synchronized across all instances, ensuring consistent login behavior everywhere.
+* Enhanced OIDC integration \[n8n 1.111.0]: n8n now supports OIDC providers that enforce state and nonce parameters. These are validated during login, providing smoother and more secure Single Sign-On.
 
 ### Filter insights by project <a href="#filter-insights-by-project" id="filter-insights-by-project"></a>
 
@@ -2221,7 +2221,7 @@ View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.95.0...n8n@1.96.0
 {% hint style="warning" %}
 **Build failure**
 
-This release failed to build. Please use `1.97.0` instead.
+This release failed to build. Please use n8n `1.97.0` instead.
 {% endhint %}
 
 This release contains API updates, core changes, editor improvements, node updates, and bug fixes.
@@ -2393,7 +2393,7 @@ Learn more about this update and find out which nodes are already installable fr
 
 💻 **Use a verified node**
 
-Make sure you're on **n8n version 1.94.0** or later and the instance Owner has enabled verified community nodes. On Cloud, this can be done from the Admin Panel. For self-hosted instances, please refer to [documentation](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/basic-configuration/use-environment-variables/nodes). In both cases, verified nodes are enabled by default.
+Make sure you're on **n8n 1.94.0** or later and the instance Owner has enabled verified community nodes. On Cloud, this can be done from the Admin Panel. For self-hosted instances, please refer to [documentation](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/basic-configuration/use-environment-variables/nodes). In both cases, verified nodes are enabled by default.
 
 * Open the **Nodes panel** from the editor
 * Search for the Node. Verified nodes are indicated by a shield 🛡️
@@ -3143,7 +3143,7 @@ As of this release, **Tools Agent** is the only agent type available when adding
 * ReAct Agent
 * SQL Agent
 
-Existing workflows that use these agent types continue to run for now, but the underlying code will be removed in n8n v3. When that happens, workflows still using a deprecated agent type will fail. To prepare, replace affected AI Agent nodes with a new [AI Agent](https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/) node, which uses Tools Agent.
+Existing workflows that use these agent types continue to run for now, but the underlying code will be removed in n8n 3. When that happens, workflows still using a deprecated agent type will fail. To prepare, replace affected AI Agent nodes with a new [AI Agent](https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/) node, which uses Tools Agent.
 
 <br>
 
@@ -4152,7 +4152,7 @@ This release contains new features, node enhancements and bug fixes.
 {% hint style="info" %}
 **Skipped 1.62.0**
 
-We skipped 1.62.0 and went straight to 1.62.1 with an additional fix.
+We skipped n8n 1.62.0 and went straight to n8n 1.62.1 with an additional fix.
 {% endhint %}
 
 {% hint style="info" %}
@@ -5623,7 +5623,7 @@ This release removes `own` mode for self-hosted n8n. You must now use `EXECUTION
 {% hint style="info" %}
 **Skip this release**
 
-Please upgrade directly to 1.27.1.
+Please upgrade directly to n8n 1.27.1.
 {% endhint %}
 
 This release contains node enhancements and bug fixes.
@@ -5780,9 +5780,9 @@ View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.22.2...n8n@1.22.3
 **Release date:** 2023-12-27
 
 {% hint style="info" %}
-**Upgrade directly to 1.22.4**
+**Upgrade directly to n8n 1.22.4**
 
-Due to issues with this release, upgrade directly to 1.22.4.
+Due to issues with this release, upgrade directly to n8n 1.22.4.
 {% endhint %}
 
 This is a bug fix release.
@@ -5795,9 +5795,9 @@ View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.22.1...n8n@1.22.2
 **Release date:** 2023-12-27
 
 {% hint style="info" %}
-**Upgrade directly to 1.22.4**
+**Upgrade directly to n8n 1.22.4**
 
-Due to issues with this release, upgrade directly to 1.22.4.
+Due to issues with this release, upgrade directly to n8n 1.22.4.
 {% endhint %}
 
 This is a bug fix release.
@@ -5941,9 +5941,9 @@ View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.18.0...n8n@1.19.0
 **Release date:** 2023-11-29
 
 {% hint style="info" %}
-**Upgrade directly to 1.19.4**
+**Upgrade directly to n8n 1.19.4**
 
-Due to issues with this release, upgrade directly to 1.19.4.
+Due to issues with this release, upgrade directly to n8n 1.19.4.
 {% endhint %}
 
 This release contains new features, node enhancements, and bug fixes.
@@ -6130,9 +6130,9 @@ View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.12.2...n8n@1.13.0
 This release contains new features, feature enhancements, and bug fixes.
 
 {% hint style="info" %}
-**Upgrade directly to 1.14.0**
+**Upgrade directly to n8n 1.14.0**
 
-This release failed to publish to npm. Upgrade directly to 1.14.0.
+This release failed to publish to npm. Upgrade directly to n8n 1.14.0.
 {% endhint %}
 
 {% hint style="info" %}
@@ -6389,9 +6389,9 @@ View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.5.1...n8n@1.6.0) 
 This release contains bug fixes, new features, and node enhancements.
 
 {% hint style="info" %}
-**Upgrade directly to 1.6.1**
+**Upgrade directly to n8n 1.6.1**
 
-Skip this version and upgrade directly to 1.6.1, which contains essential bug fixes.
+Skip this version and upgrade directly to n8n 1.6.1, which contains essential bug fixes.
 {% endhint %}
 
 {% hint style="info" %}
@@ -6427,9 +6427,9 @@ View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.4.1...n8n@1.5.0) 
 This release contains new features, node enhancements, and bug fixes.
 
 {% hint style="info" %}
-**Upgrade directly to 1.5.1**
+**Upgrade directly to n8n 1.5.1**
 
-Skip this version and upgrade directly to 1.5.1, which contains essential bug fixes.
+Skip this version and upgrade directly to n8n 1.5.1, which contains essential bug fixes.
 {% endhint %}
 
 ### Highlights <a href="#highlights" id="highlights"></a>
@@ -6539,9 +6539,9 @@ View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.1.1...n8n@1.2.0) 
 This release contains new features, node enhancements, bug fixes, and performance improvements.
 
 {% hint style="info" %}
-**Upgrade directly to 1.2.1**
+**Upgrade directly to n8n 1.2.1**
 
-When upgrading, skip this release and go directly to 1.2.1.
+When upgrading, skip this release and go directly to n8n 1.2.1.
 {% endhint %}
 
 ### Highlights <a href="#highlights" id="highlights"></a>
@@ -6591,7 +6591,7 @@ This is a bug fix release.
 {% hint style="warning" %}
 **Breaking changes**
 
-Please note that this version contains breaking changes if upgrading from a `0.x.x` version. For full details, refer to the [n8n v1.0 migration guide](v10-migration-guide.md).
+Please note that this version contains breaking changes if upgrading from a `0.x.x` version. For full details, refer to the [n8n 1.0 migration guide](v10-migration-guide.md).
 {% endhint %}
 
 For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
@@ -6606,7 +6606,7 @@ This release contains new features, bug fixes, and node enhancements.
 {% hint style="warning" %}
 **Breaking changes**
 
-Please note that this version contains breaking changes if upgrading from a `0.x.x` version. For full details, refer to the [n8n v1.0 migration guide](v10-migration-guide.md).
+Please note that this version contains breaking changes if upgrading from a `0.x.x` version. For full details, refer to the [n8n 1.0 migration guide](v10-migration-guide.md).
 {% endhint %}
 
 ### Highlights <a href="#highlights" id="highlights"></a>
@@ -6642,7 +6642,7 @@ This is a bug fix release.
 {% hint style="warning" %}
 **Breaking changes**
 
-Please note that this version contains breaking changes if upgrading from a `0.x.x` version. For full details, refer to the [n8n v1.0 migration guide](v10-migration-guide.md).
+Please note that this version contains breaking changes if upgrading from a `0.x.x` version. For full details, refer to the [n8n 1.0 migration guide](v10-migration-guide.md).
 {% endhint %}
 
 For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
@@ -6657,7 +6657,7 @@ This is a bug fix release.
 {% hint style="warning" %}
 **Breaking changes**
 
-Please note that this version contains breaking changes if upgrading from a `0.x.x` version. For full details, refer to the [n8n v1.0 migration guide](v10-migration-guide.md).
+Please note that this version contains breaking changes if upgrading from a `0.x.x` version. For full details, refer to the [n8n 1.0 migration guide](v10-migration-guide.md).
 {% endhint %}
 
 For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
@@ -6677,7 +6677,7 @@ This release contains API enhancements and adds support for sending messages to 
 {% hint style="warning" %}
 **Breaking changes**
 
-Please note that this version contains breaking changes if upgrading from a `0.x.x` version. For full details, refer to the [n8n v1.0 migration guide](v10-migration-guide.md).
+Please note that this version contains breaking changes if upgrading from a `0.x.x` version. For full details, refer to the [n8n 1.0 migration guide](v10-migration-guide.md).
 {% endhint %}
 
 For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
@@ -6696,7 +6696,7 @@ This is a bug fix release.
 {% hint style="warning" %}
 **Breaking changes**
 
-Please note that this version contains breaking changes if upgrading from a `0.x.x` version. For full details, refer to the [n8n v1.0 migration guide](v10-migration-guide.md).
+Please note that this version contains breaking changes if upgrading from a `0.x.x` version. For full details, refer to the [n8n 1.0 migration guide](v10-migration-guide.md).
 {% endhint %}
 
 ### Contributors <a href="#contributors" id="contributors"></a>
@@ -6711,19 +6711,19 @@ View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.0.0...n8n@1.0.1) 
 {% hint style="warning" %}
 **Breaking changes**
 
-Please note that this version contains breaking changes. For full details, refer to the [n8n v1.0 migration guide](v10-migration-guide.md).
+Please note that this version contains breaking changes. For full details, refer to the [n8n 1.0 migration guide](v10-migration-guide.md).
 {% endhint %}
 
 This is n8n's version one release.
 
-For full details, refer to the [n8n v1.0 migration guide](v10-migration-guide.md).
+For full details, refer to the [n8n 1.0 migration guide](v10-migration-guide.md).
 
 ### Highlights <a href="#highlights" id="highlights"></a>
 
 {% hint style="info" %}
 #### Python support <a href="#python-support" id="python-support"></a>
 
-Although JavaScript remains the default language, you can now also select Python as an option in the [Code node](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/code-in-n8n/using-the-code-node) and even make use of [many Python modules](https://pyodide.org/en/stable/usage/packages-in-pyodide.html#packages-in-pyodide). Note that Python is unavailable in Code nodes added to a workflow before v1.0.
+Although JavaScript remains the default language, you can now also select Python as an option in the [Code node](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/code-in-n8n/using-the-code-node) and even make use of [many Python modules](https://pyodide.org/en/stable/usage/packages-in-pyodide.html#packages-in-pyodide). Note that Python is unavailable in Code nodes added to a workflow before n8n 1.0.
 {% endhint %}
 
 ### Contributors <a href="#contributors" id="contributors"></a>

--- a/docs/changelog/release-notes-1.x.md
+++ b/docs/changelog/release-notes-1.x.md
@@ -41,7 +41,7 @@ tags:
 
 These release notes are now archived and won't receive further updates. For the latest releases, including every patch version, see the [n8n releases on GitHub](https://github.com/n8n-io/n8n/releases).
 
-For a curated summary of the changes that matter most, see the [Changelog](./).
+For a curated summary of the changes that matter most, see the [Changelog](README.md).
 {% endhint %}
 
 New features and bug fixes for n8n.
@@ -5861,7 +5861,7 @@ This release contains new features and nodes, node enhancements, and bug fixes.
 
 This release introduces a third account type: admin. This role is available on pro and enterprise plans. Admins have similar permissions to instance owners.
 
-[Read more about user roles](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/manage-users-and-access/understand-account-types)
+[Read more about user roles](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/manage-users-and-access/understand-instance-roles)
 {% endhint %}
 
 {% hint style="info" %}

--- a/docs/changelog/release-notes-1.x.md
+++ b/docs/changelog/release-notes-1.x.md
@@ -2221,7 +2221,7 @@ View the [commits](https://github.com/n8n-io/n8n/compare/n8n@1.95.0...n8n@1.96.0
 {% hint style="warning" %}
 **Build failure**
 
-This release failed to build. Please use n8n `1.97.0` instead.
+This release failed to build. Please use n8n 1.97.0 instead.
 {% endhint %}
 
 This release contains API updates, core changes, editor improvements, node updates, and bug fixes.

--- a/docs/changelog/release-notes-2.x.md
+++ b/docs/changelog/release-notes-2.x.md
@@ -1054,7 +1054,7 @@ Redaction is configured per workflow under **Workflow settings**, and reveal acc
 ### Public API improvements <a href="#public-api-improvements" id="public-api-improvements"></a>
 
 * **Community packages.** Install, list, update, and uninstall community packages programmatically through new endpoints under `/api/v1/community-packages`. Each operation requires an API key with the matching `communityPackage:*` scope.
-* **Insights scope.** A new `insights:read` API key scope, setting up the insights summary endpoint that ships in v2.17.
+* **Insights scope.** A new `insights:read` API key scope, setting up the insights summary endpoint that ships in n8n 2.17.
 {% endhint %}
 
 For full release details, refer to [Releases](https://github.com/n8n-io/n8n/releases) on GitHub.
@@ -1082,7 +1082,7 @@ N8N_OTEL_EXPORTER_OTLP_ENDPOINT=http://your-collector:4318
 
 Standard OTel variables (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`) are also respected.
 
-This is the foundational T1 feature. It was extended across later releases: node-level spans (v2.16), workflow version IDs in spans and distributed trace context propagation (v2.18 to v2.19), and AI Agent telemetry (v2.20).
+This is the foundational T1 feature. It was extended across later releases: node-level spans (n8n 2.16), workflow version IDs in spans and distributed trace context propagation (n8n 2.18 to n8n 2.19), and AI Agent telemetry (n8n 2.20).
 
 **Availability.** Free, Pro, and Enterprise.
 {% endhint %}
@@ -2118,20 +2118,20 @@ For the full story behind 2.0, read our [announcement blog post](https://blog.n8
 
 ### Breaking changes <a href="#breaking-changes" id="breaking-changes"></a>
 
-Version 2.0 includes breaking changes across security defaults, data handling, and configuration. Key changes include:
+n8n 2.0 includes breaking changes across security defaults, data handling, and configuration. Key changes include:
 
 * Task runners enabled by default (Code node executions now run in isolated environments)
 * Environment variable access blocked from Code nodes by default
 * ExecuteCommand and LocalFileTrigger nodes disabled by default
 * In-memory binary data mode removed
 
-Review the complete list and migration guidance in the [v2.0 breaking changes docs.](https://docs.n8n.io/2-0-breaking-changes/)
+Review the complete list and migration guidance in the [n8n 2.0 breaking changes docs.](https://docs.n8n.io/2-0-breaking-changes/)
 
 ### Before you upgrade <a href="#before-you-upgrade" id="before-you-upgrade"></a>
 
 Use the **Migration Report** tool to identify workflow-level and instance-level issues that need attention before upgrading.
 
-See the [v2.0 migration tool docs](https://docs.n8n.io/migration-tool-v2/) for details.
+See the [n8n 2.0 migration tool docs](https://docs.n8n.io/migration-tool-v2/) for details.
 
 ### Product updates <a href="#product-updates" id="product-updates"></a>
 

--- a/docs/changelog/release-notes-2.x.md
+++ b/docs/changelog/release-notes-2.x.md
@@ -41,7 +41,7 @@ tags:
 
 These release notes are now archived and won't receive further updates. For the latest releases, including every patch version, see the [n8n releases on GitHub](https://github.com/n8n-io/n8n/releases).
 
-For a curated summary of the changes that matter most, see the [Changelog](./).
+For a curated summary of the changes that matter most, see the [Changelog](README.md).
 {% endhint %}
 
 New features and bug fixes for n8n.
@@ -521,7 +521,7 @@ This release contains bug fixes and features.
 {% hint style="info" %}
 ### Connect to MCP servers with less setup <a href="#connect-to-mcp-servers-with-less-setup" id="connect-to-mcp-servers-with-less-setup"></a>
 
-Connect your agent to select MCP servers without setting up an [MCP Client node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-langchain.mcpclient) and credential by hand. Pick a server from the nodes panel, sign in, and it's available to your agent.
+Connect your agent to select MCP servers without setting up an [MCP Client node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-langchain.mcpClient) and credential by hand. Pick a server from the nodes panel, sign in, and it's available to your agent.
 
 <br>
 
@@ -529,7 +529,7 @@ Initial coverage includes some of the most used services in the official MCP reg
 
 <br>
 
-If you need to connect to an MCP server that isn't in the list, you can still use the [MCP Client node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-langchain.mcpclient) with manual configuration.
+If you need to connect to an MCP server that isn't in the list, you can still use the [MCP Client node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-langchain.mcpClient) with manual configuration.
 {% endhint %}
 
 ### Contributors <a href="#contributors" id="contributors"></a>

--- a/docs/changelog/v10-migration-guide.md
+++ b/docs/changelog/v10-migration-guide.md
@@ -1,8 +1,8 @@
 ---
-title: n8n v1.0 migration guide
-description: What's new in version 1
+title: n8n 1.0 migration guide
+description: What's new in n8n 1.0
 contentType: reference
-nodeTitle: v1.0 migration guide
+nodeTitle: n8n 1.0 migration guide
 originalFilePath: 1-0-migration-checklist.md
 originalUrl: 'https://docs.n8n.io/1-0-migration-checklist'
 url: 'https://docs.n8n.io/release-notes/v10-migration-guide'
@@ -11,17 +11,17 @@ layout:
     visible: false
 ---
 
-# n8n v1.0 migration guide <a href="#n8n-v10-migration-guide" id="n8n-v10-migration-guide"></a>
+# n8n 1.0 migration guide <a href="#n8n-v10-migration-guide" id="n8n-v10-migration-guide"></a>
 
-This document provides a summary of what you should be aware of before updating to version 1.0 of n8n.
+This document provides a summary of what you should be aware of before updating to n8n 1.0.
 
-The release of n8n 1.0 marks a milestone in n8n's journey to make n8n available for demanding production environments. Version 1.0 represents the hard work invested over the last four years to make n8n the most accessible, powerful, and versatile automation tool. n8n 1.0 is now ready for use in production.
+The release of n8n 1.0 marks a milestone in n8n's journey to make n8n available for demanding production environments. n8n 1.0 represents the hard work invested over the last four years to make n8n the most accessible, powerful, and versatile automation tool. n8n 1.0 is now ready for use in production.
 
 ## New features <a href="#new-features" id="new-features"></a>
 
 ### Python support in the Code node <a href="#python-support-in-the-code-node" id="python-support-in-the-code-node"></a>
 
-Although JavaScript remains the default language, you can now also select Python as an option in the [Code node](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/code-in-n8n/using-the-code-node) and even make use of [many Python modules](https://pyodide.org/en/stable/usage/packages-in-pyodide.html#packages-in-pyodide). Note that Python is unavailable in Code nodes added to a workflow before v1.0.
+Although JavaScript remains the default language, you can now also select Python as an option in the [Code node](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/code-in-n8n/using-the-code-node) and even make use of [many Python modules](https://pyodide.org/en/stable/usage/packages-in-pyodide.html#packages-in-pyodide). Note that Python is unavailable in Code nodes added to a workflow before n8n 1.0.
 
 [PR #4295](https://github.com/n8n-io/n8n/pull/4295), [PR #6209](https://github.com/n8n-io/n8n/pull/6209)
 
@@ -33,7 +33,7 @@ In multi-branch workflows, n8n needs to determine the order in which to execute 
 
 n8n used to execute multi-input nodes as long as they received data on their first input. Nodes connected to the second input of multi-input nodes automatically executed regardless of whether they received data. The new execution order introduced in n8n 1.0 simplifies this behavior: Nodes are now executed only when they receive data, and multi-input nodes require data on at least one of their inputs to execute.
 
-Your existing workflows will use the legacy order, while new workflows will execute using the v1 order. You can configure the execution order for each workflow in [workflow settings](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/configure-workflow-settings).
+Your existing workflows will use the legacy order, while new workflows will execute using the n8n 1.0 order. You can configure the execution order for each workflow in [workflow settings](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/configure-workflow-settings).
 
 [PR #4238](https://github.com/n8n-io/n8n/pull/4238), [PR #6246](https://github.com/n8n-io/n8n/pull/6246), [PR #6507](https://github.com/n8n-io/n8n/pull/6507)
 
@@ -128,7 +128,7 @@ If you build custom nodes, refer to [HTTP request helpers](https://app.gitbook.c
 
 ### Removed WEBHOOK_TUNNEL_URL <a href="#removed-webhooktunnelurl" id="removed-webhooktunnelurl"></a>
 
-As of version 0.227.0, n8n has renamed the `WEBHOOK_TUNNEL_URL` configuration option to `WEBHOOK_URL`. In n8n 1.0, `WEBHOOK_TUNNEL_URL` has been removed. Update your setup to reflect the new name. For more information about this configuration option, refer to [the docs](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/basic-configuration/configuration-examples/configure-webhook-urls-with-reverse-proxy).
+As of n8n 0.227.0, n8n has renamed the `WEBHOOK_TUNNEL_URL` configuration option to `WEBHOOK_URL`. In n8n 1.0, `WEBHOOK_TUNNEL_URL` has been removed. Update your setup to reflect the new name. For more information about this configuration option, refer to [the docs](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/basic-configuration/configuration-examples/configure-webhook-urls-with-reverse-proxy).
 
 [PR #1408](https://github.com/n8n-io/n8n/pull/1408)
 
@@ -152,4 +152,4 @@ If you encounter any issues during the process of updating to n8n 1.0, please se
 
 ## Thank you <a href="#thank-you" id="thank-you"></a>
 
-We would like to take a moment to express our gratitude to all of our users for their continued support and feedback. Your contributions are invaluable in helping us make n8n the best possible automation tool. We're excited to continue working with you as we move forward with the release of version 1.0 and beyond. Thank you for being a part of our journey!
+We would like to take a moment to express our gratitude to all of our users for their continued support and feedback. Your contributions are invaluable in helping us make n8n the best possible automation tool. We're excited to continue working with you as we move forward with the release of n8n 1.0 and beyond. Thank you for being a part of our journey!

--- a/docs/changelog/v20-breaking-changes.md
+++ b/docs/changelog/v20-breaking-changes.md
@@ -1,8 +1,8 @@
 ---
-title: n8n v2.0 breaking changes
-description: Breaking changes coming in version 2.0
+title: n8n 2.0 breaking changes
+description: Breaking changes coming in n8n 2.0
 contentType: reference
-nodeTitle: v2.0 breaking changes
+nodeTitle: n8n 2.0 breaking changes
 originalFilePath: 2-0-breaking-changes.md
 originalUrl: 'https://docs.n8n.io/2-0-breaking-changes'
 url: 'https://docs.n8n.io/release-notes/v20-breaking-changes'
@@ -11,9 +11,9 @@ layout:
     visible: false
 ---
 
-# n8n v2.0 breaking changes <a href="#n8n-v20-breaking-changes" id="n8n-v20-breaking-changes"></a>
+# n8n 2.0 breaking changes <a href="#n8n-v20-breaking-changes" id="n8n-v20-breaking-changes"></a>
 
-n8n v2.0 has been released, and with it came some important changes. This document highlights breaking changes and actions you should take to prepare for the transition. These updates improve security, simplify configuration, and remove legacy features.
+n8n 2.0 has been released, and with it came some important changes. This document highlights breaking changes and actions you should take to prepare for the transition. These updates improve security, simplify configuration, and remove legacy features.
 
 The release of n8n 2.0 continues n8n's commitment to providing a secure, reliable, and production-ready automation platform. This major version includes important security enhancements and cleanup of deprecated features.
 
@@ -31,11 +31,11 @@ Parent-Workflow:
 Sub-Workflow:
 ![Sub-Workflow](.gitbook/assets/subworkflow.png)
 
-v1: The parent-execution reproduces the sub-execution's input as its output.:
-![v1: Parent execution won't receive the result of the child execution](.gitbook/assets/before1.png)
+n8n 1.0: The parent-execution reproduces the sub-execution's input as its output.:
+![n8n 1.0: Parent execution won't receive the result of the child execution](.gitbook/assets/before1.png)
 
-v2: The parent execution receives the result of the child execution:
-![v2: Parent execution will receive the result of the child execution](.gitbook/assets/after1.png)
+n8n 2.0: The parent execution receives the result of the child execution:
+![n8n 2.0: Parent execution will receive the result of the child execution](.gitbook/assets/after1.png)
 
 This allows using human-in-the-loop nodes in the sub-workflow and use the results (for example approving or declining an action) in the parent-workflow.
 
@@ -78,13 +78,13 @@ To improve security, n8n will block access to environment variables from the Cod
 
 n8n will require strict file permissions for configuration files to improve security. By default, configuration files must use `0600` permissions, which means only the file owner can read and write them. This approach is similar to how SSH protects private keys.
 
-**Migration path:** To test this behavior before v2.0, set `N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=true`. If your environment doesn't support file permissions (for example, on Windows), set `N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=false` to disable this requirement.
+**Migration path:** To test this behavior before n8n 2.0, set `N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=true`. If your environment doesn't support file permissions (for example, on Windows), set `N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=false` to disable this requirement.
 
 ### Enable task runners by default <a href="#enable-task-runners-by-default" id="enable-task-runners-by-default"></a>
 
 n8n will enable [task runners](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-task-runners) by default to improve security and isolation. All Code node executions will run on task runners.
 
-**Migration path:** Before upgrading to v2.0, set N8N_RUNNERS_ENABLED=true to test this behavior. Make sure your infrastructure meets the requirements for running task runners. For additional security, consider using [external mode](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-task-runners#external-mode).
+**Migration path:** Before upgrading to n8n 2.0, set N8N_RUNNERS_ENABLED=true to test this behavior. Make sure your infrastructure meets the requirements for running task runners. For additional security, consider using [external mode](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-task-runners#external-mode).
 
 ### `$evaluateExpression` no longer works in the Code node <a href="#dollarevaluateexpression-no-longer-works-in-the-code-node" id="dollarevaluateexpression-no-longer-works-in-the-code-node"></a>
 
@@ -100,13 +100,13 @@ Because Code node executions now run on task runners in secure mode by default, 
 
 ### Remove task runner from `n8nio/n8n` docker image <a href="#remove-task-runner-from-n8nion8n-docker-image" id="remove-task-runner-from-n8nion8n-docker-image"></a>
 
-Starting with v2.0, the main `n8nio/n8n` Docker image will no longer include the task runner for external mode. You must use the separate `n8nio/runners` Docker image to run task runners in external mode.
+Starting with n8n 2.0, the main `n8nio/n8n` Docker image will no longer include the task runner for external mode. You must use the separate `n8nio/runners` Docker image to run task runners in external mode.
 
 **Migration path:** If you run task runners in Docker with external mode, update your setup to use the `n8nio/runners` image instead of `n8nio/n8n`.
 
 ### Remove Pyodide-based Python Code node and tool <a href="#remove-pyodide-based-python-code-node-and-tool" id="remove-pyodide-based-python-code-node-and-tool"></a>
 
-n8n will remove the Pyodide-based Python Code node and tool and replace them with a [task runner-based](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-task-runners) implementation that uses native Python for better security and performance. Starting in v2.0, you can only use Python Code nodes with task runners in [external mode](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-task-runners#external-mode) and native Python tools.
+n8n will remove the Pyodide-based Python Code node and tool and replace them with a [task runner-based](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-task-runners) implementation that uses native Python for better security and performance. Starting in n8n 2.0, you can only use Python Code nodes with task runners in [external mode](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-task-runners#external-mode) and native Python tools.
 
 The native Python Code node doesn't support built-in variables like `_input` or dot access notation, which were available in the Pyodide-based version. For details, see the [Code node documentation](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.code#python-native).
 
@@ -124,7 +124,7 @@ n8n will disable the `ExecuteCommand` and `LocalFileTrigger` nodes by default be
 
 n8n will require authentication for OAuth callback endpoints by default. The default value for `N8N_SKIP_AUTH_ON_OAUTH_CALLBACK` will change from `true` (no authentication required) to `false` (authentication required).
 
-**Migration path:** Before upgrading to v2.0, set `N8N_SKIP_AUTH_ON_OAUTH_CALLBACK=false` and test your OAuth integrations to ensure they work with authentication enabled.
+**Migration path:** Before upgrading to n8n 2.0, set `N8N_SKIP_AUTH_ON_OAUTH_CALLBACK=false` and test your OAuth integrations to ensure they work with authentication enabled.
 
 ### Set default value for N8N_RESTRICT_FILE_ACCESS_TO <a href="#set-default-value-for-n8nrestrictfileaccessto" id="set-default-value-for-n8nrestrictfileaccessto"></a>
 
@@ -142,9 +142,9 @@ By default, the Git node will now block bare repositories for security reasons. 
 
 ### Drop MySQL/MariaDB support <a href="#drop-mysqlmariadb-support" id="drop-mysqlmariadb-support"></a>
 
-n8n will no longer support MySQL and MariaDB as storage backends. This support was deprecated in v1.0. For best compatibility and long-term support, use PostgreSQL. MySQL node will continue to be supported as before.
+n8n will no longer support MySQL and MariaDB as storage backends. This support was deprecated in n8n 1.0. For best compatibility and long-term support, use PostgreSQL. MySQL node will continue to be supported as before.
 
-**Migration path:** Before upgrading to v2.0, use the database migration tool to move your data from MySQL or MariaDB to PostgreSQL or SQLite.
+**Migration path:** Before upgrading to n8n 2.0, use the database migration tool to move your data from MySQL or MariaDB to PostgreSQL or SQLite.
 
 ### Remove SQLite legacy driver <a href="#remove-sqlite-legacy-driver" id="remove-sqlite-legacy-driver"></a>
 
@@ -154,7 +154,7 @@ n8n will remove the legacy SQLite driver due to reliability issues. The pooling 
 
 ### Remove in-memory binary data mode <a href="#remove-in-memory-binary-data-mode" id="remove-in-memory-binary-data-mode"></a>
 
-n8n will remove the `default` mode for `N8N_DEFAULT_BINARY_DATA_MODE`, which keeps execution binary data in memory during execution. For better performance and stability the following options will be available starting from v2:
+n8n will remove the `default` mode for `N8N_DEFAULT_BINARY_DATA_MODE`, which keeps execution binary data in memory during execution. For better performance and stability the following options will be available starting from n8n 2.0:
 
 - `filesystem`: Binary data is stored in the filesystem. Default option in regular mode.
 - `database`: Binary data is stored in the database. Default option in queue mode.
@@ -178,7 +178,7 @@ n8n loads environment configuration from a `.env` file using the `dotenv` librar
 
 ### Remove `n8n --tunnel` option <a href="#remove-n8n-tunnel-option" id="remove-n8n-tunnel-option"></a>
 
-The `n8n --tunnel` command-line option will be removed in v2.0.
+The `n8n --tunnel` command-line option will be removed in n8n 2.0.
 
 **Migration path:** If you currently use the `--tunnel` option for development or testing, switch to an alternative tunneling solution such as ngrok, localtunnel, or Cloudflare Tunnel. Update your workflow and documentation to reflect this change.
 

--- a/docs/changelog/v20-migration-tool.md
+++ b/docs/changelog/v20-migration-tool.md
@@ -1,8 +1,8 @@
 ---
-title: v2.0 Migration Tool
-description: Tool to help you migrate to v2.0
+title: n8n 2.0 Migration Tool
+description: Tool to help you migrate to n8n 2.0
 contentType: reference
-nodeTitle: v2.0 Migration tool
+nodeTitle: n8n 2.0 Migration tool
 originalFilePath: migration-tool-v2.md
 originalUrl: 'https://docs.n8n.io/migration-tool-v2'
 url: 'https://docs.n8n.io/release-notes/v20-migration-tool'
@@ -11,13 +11,13 @@ layout:
     visible: false
 ---
 
-# n8n v2.0 migration tool <a href="#n8n-v20-migration-tool" id="n8n-v20-migration-tool"></a>
+# n8n 2.0 migration tool <a href="#n8n-v20-migration-tool" id="n8n-v20-migration-tool"></a>
 
-The migration tool helps you prepare your n8n instance for upgrading to version 2.0 by identifying workflows and configurations that need attention before the upgrade.
+The migration tool helps you prepare your n8n instance for upgrading to n8n 2.0 by identifying workflows and configurations that need attention before the upgrade.
 
 ![Migration tool](.gitbook/assets/migration-tool.png)
 
-You can see all breaking changes for v2 [on this page](v20-breaking-changes.md).
+You can see all breaking changes for n8n 2.0 [on this page](v20-breaking-changes.md).
 
 ## Accessing the Tool <a href="#accessing-the-tool" id="accessing-the-tool"></a>
 Navigate to **Settings > Migration Report** to view your compatibility status.
@@ -73,19 +73,19 @@ What you'll see for each issue:
 * Same information as workflow issues (title, severity, description, docs)
 * **No workflow count:** These are global settings that apply instance-wide
 
-The v2.0 migration tool scans your n8n instance to identify potential compatibility issues and configuration changes required for upgrading to v2.0. This reference details each check the tool performs, explains the impact of detected issues, and provides recommendations to prepare your instance for migration.
+The n8n 2.0 migration tool scans your n8n instance to identify potential compatibility issues and configuration changes required for upgrading to n8n 2.0. This reference details each check the tool performs, explains the impact of detected issues, and provides recommendations to prepare your instance for migration.
 
 ## Understanding Empty States <a href="#understanding-empty-states" id="understanding-empty-states"></a>
 
 ### No Workflow Issues Found <a href="#no-workflow-issues-found" id="no-workflow-issues-found"></a>
-All your workflows are compatible with v2.0. Check the **Instance Issues** tab to ensure your server configuration is also ready.
+All your workflows are compatible with n8n 2.0. Check the **Instance Issues** tab to ensure your server configuration is also ready.
 
 ### No Instance Issues Found <a href="#no-instance-issues-found" id="no-instance-issues-found"></a>
 
-Your instance configuration is compatible with v2.0. Check the **Workflow Issues** tab to ensure all workflows are also ready.
+Your instance configuration is compatible with n8n 2.0. Check the **Workflow Issues** tab to ensure all workflows are also ready.
 
 ### Both Tabs Empty <a href="#both-tabs-empty" id="both-tabs-empty"></a>
-Your n8n instance is fully ready to upgrade to version 2.0.
+Your n8n instance is fully ready to upgrade to n8n 2.0.
 
 ## Recommended Workflow <a href="#recommended-workflow" id="recommended-workflow"></a>
 

--- a/docs/changelog/v30-breaking-changes.md
+++ b/docs/changelog/v30-breaking-changes.md
@@ -1,16 +1,16 @@
 ---
-title: n8n v3.0 breaking changes
-description: Breaking changes coming in version 3.0
+title: n8n 3.0 breaking changes
+description: Breaking changes coming in n8n 3.0
 contentType: reference
-nodeTitle: v3.0 breaking changes
+nodeTitle: n8n 3.0 breaking changes
 layout:
   description:
     visible: false
 ---
 
-# n8n v3.0 breaking changes <a href="#n8n-v30-breaking-changes" id="n8n-v30-breaking-changes"></a>
+# n8n 3.0 breaking changes <a href="#n8n-v30-breaking-changes" id="n8n-v30-breaking-changes"></a>
 
-This document highlights breaking changes and actions to prepare for the upcoming transition to n8n v3.0, scheduled for October 2026. These updates improve security, simplify configuration, and remove legacy features.
+This document highlights breaking changes and actions to prepare for the upcoming transition to n8n 3.0, scheduled for October 2026. These updates improve security, simplify configuration, and remove legacy features.
 
 The release of n8n 3.0 continues n8n's commitment to providing a secure, reliable, and production-ready automation platform. This major version includes important security enhancements and cleanup of deprecated features.
 
@@ -19,12 +19,12 @@ The release of n8n 3.0 continues n8n's commitment to providing a secure, reliabl
 ### Docker-based deployment required for self-hosted n8n <a href="#docker-based-deployment-required-for-self-hosted-n8n" id="docker-based-deployment-required-for-self-hosted-n8n"></a>
 
 - Self-hosted n8n will require a Docker-based deployment. Installations run via `npm` / `npx n8n` will no longer be supported.
-- **What to do:** If you currently run n8n with `npm` or `npx n8n`, plan a move to a Docker-based deployment before upgrading to v3. For local installations, Docker Compose is expected to be the easiest path.
+- **What to do:** If you currently run n8n with `npm` or `npx n8n`, plan a move to a Docker-based deployment before upgrading to n8n 3.0. For local installations, Docker Compose is expected to be the easiest path.
 - *Step-by-step migration guidance will be coming soon*
 
 ## Removed nodes and helpers <a href="#removed-nodes-and-helpers" id="removed-nodes-and-helpers"></a>
 
-Older nodes, modes, and helpers that have been replaced by newer patterns are being removed in v3.
+Older nodes, modes, and helpers that have been replaced by newer patterns are being removed in n8n 3.0.
 
 ### Removed nodes <a href="#removed-nodes" id="removed-nodes"></a>
 
@@ -54,7 +54,7 @@ Security defaults are getting stronger to make n8n safer by default. These chang
 
 ## Retired capabilities <a href="#retired-capabilities" id="retired-capabilities"></a>
 
-Some legacy or lower-usage product capabilities are being retired in v3. Guidance will be provided where a migration path or alternative exists.
+Some legacy or lower-usage product capabilities are being retired in n8n 3.0. Guidance will be provided where a migration path or alternative exists.
 
 - **Chat hub** — being retired.
 - **Workflow import from URL in the editor** — being removed. Other [import methods](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/export-and-import) remain supported: copy-paste, **Import from File** in the editor UI menu, the CLI, and the Public API.
@@ -62,6 +62,6 @@ Some legacy or lower-usage product capabilities are being retired in v3. Guidanc
 
 ---
 
-_This page will be updated with full details, migration guides, and links as v3 approaches its release._
+_This page will be updated with full details, migration guides, and links as n8n 3.0 approaches its release._
 
 

--- a/docs/contribute/style-guide-for-n8n-docs.md
+++ b/docs/contribute/style-guide-for-n8n-docs.md
@@ -350,6 +350,7 @@ Follow the [numbers guidance](#numbers-dates-and-times), plus these rules for n8
 * **Use the product name and numerals**: n8n 2.30.0.
 * **Don't add a `v` prefix**: write "n8n 2.30.0", not "n8n v2.30.0".
 * **Don't write the word "version" after "n8n"**: the number alone is clear. Write "n8n 2.30.0", not "n8n version 2.30.0".
+* **Don't put the version number in inline code formatting in running text**: write n8n 2.30.0, not n8n `2.30.0`. Only use code formatting when the version appears inside an actual code snippet, command, or file path, for example `n8n@2.30.0`, a Docker tag, or a `package.json` value.
 
 ### Preview status
 

--- a/docs/deploy/host-n8n/README.md
+++ b/docs/deploy/host-n8n/README.md
@@ -95,7 +95,7 @@ Select the installation method that best fits your technical requirements and in
 	
 	**Requirements:** Node.js installed on your system.
 	
-	**Note:** This installation method is being deprecated in n8n v3. Consider using Docker Compose or one-line setup instead.
+	**Note:** This installation method is being deprecated in n8n 3.0. Consider using Docker Compose or one-line setup instead.
 	
 	Installs n8n directly using Node Package Manager. Quick to set up but requires managing Node.js versions and dependencies yourself.
 

--- a/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/nodes.md
+++ b/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/nodes.md
@@ -54,7 +54,7 @@ This page lists the environment variables configuration options for managing nod
 ## Manage installed community packages <a href="#manage-installed-community-packages" id="manage-installed-community-packages"></a>
 
 {% hint style="info" %}
-**Available from n8n v2.21.0**
+**Available from n8n 2.21.0**
 
 
 {% endhint %}

--- a/docs/deploy/host-n8n/configure-n8n/manage-settings-using-environment-variables.md
+++ b/docs/deploy/host-n8n/configure-n8n/manage-settings-using-environment-variables.md
@@ -59,7 +59,7 @@ The other environment variables for an area have no effect unless `<AREA>_MANAGE
 ## Instance owner <a href="#instance-owner" id="instance-owner"></a>
 
 {% hint style="info" %}
-**Available from n8n v2.17.0**
+**Available from n8n 2.17.0**
 
 
 {% endhint %}
@@ -77,7 +77,7 @@ This variable expects a pre-hashed bcrypt value. Setting a plaintext password br
 ## SSO <a href="#sso" id="sso"></a>
 
 {% hint style="info" %}
-**Available from n8n v2.18.0**
+**Available from n8n 2.18.0**
 
 
 {% endhint %}
@@ -111,7 +111,7 @@ Set either `N8N_SSO_SAML_METADATA` (inline XML) or `N8N_SSO_SAML_METADATA_URL` (
 ## Security policy <a href="#security-policy" id="security-policy"></a>
 
 {% hint style="info" %}
-**Available from n8n v2.18.0**
+**Available from n8n 2.18.0**
 
 
 {% endhint %}
@@ -123,7 +123,7 @@ Manage the instance security policy from environment variables, including MFA en
 ## Log streaming <a href="#log-streaming" id="log-streaming"></a>
 
 {% hint style="info" %}
-**Available from n8n v2.19.0**
+**Available from n8n 2.19.0**
 
 
 {% endhint %}
@@ -135,7 +135,7 @@ Manage [log streaming](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/observe-an
 ## MCP <a href="#mcp" id="mcp"></a>
 
 {% hint style="info" %}
-**Available from n8n v2.20.0**
+**Available from n8n 2.20.0**
 
 
 {% endhint %}
@@ -147,7 +147,7 @@ Manage [instance-level MCP access](https://app.gitbook.com/s/r7wKI4I1BgdBCuq5Cvc
 ## Community packages <a href="#community-packages" id="community-packages"></a>
 
 {% hint style="info" %}
-**Available from n8n v2.21.0**
+**Available from n8n 2.21.0**
 
 
 {% endhint %}

--- a/docs/deploy/host-n8n/configure-n8n/scaling/use-external-storage.md
+++ b/docs/deploy/host-n8n/configure-n8n/scaling/use-external-storage.md
@@ -73,16 +73,16 @@ export N8N_EXTERNAL_STORAGE_S3_ACCESS_SECRET=...
 If your provider doesn't require a region, you can set `N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION` to `'auto'`.
 {% endhint %}
 
-## Validate and update your S3 bucket region format (v2.6.4 onward) <a href="#validate-and-update-your-s3-bucket-region-format-v264-onward" id="validate-and-update-your-s3-bucket-region-format-v264-onward"></a>
+## Validate and update your S3 bucket region format (n8n 2.6.4 onward) <a href="#validate-and-update-your-s3-bucket-region-format-v264-onward" id="validate-and-update-your-s3-bucket-region-format-v264-onward"></a>
 
-Starting from n8n v2.6.4, the value of the environment variable `N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION` must meet these conditions:
+Starting from n8n 2.6.4, the value of the environment variable `N8N_EXTERNAL_STORAGE_S3_BUCKET_REGION` must meet these conditions:
 
 - Only contain alphanumeric characters (`a-z`, `A-Z`, `0-9`) and hyphens (`-`).
 - Not contain underscores (`_`) or other special characters.
 
 If these conditions are not met, n8n will fail startup with connection errors even if the storage endpoint is reachable and was previously working in older versions.
 
-If S3 connection fails after upgrading n8n to v2.6.4, verify your region value matches these conditions and redeploy n8n.
+If S3 connection fails after upgrading n8n to 2.6.4, verify your region value matches these conditions and redeploy n8n.
 
 Tell n8n to store binary data in S3:
 

--- a/docs/deploy/host-n8n/configure-n8n/security/configure-sso.md
+++ b/docs/deploy/host-n8n/configure-n8n/security/configure-sso.md
@@ -27,4 +27,4 @@ n8n supports the SAML and OIDC authentication protocols for single sign-on (SSO)
 
 ## Configure SSO with environment variables <a href="#configure-sso-with-environment-variables" id="configure-sso-with-environment-variables"></a>
 
-You can also configure SSO from environment variables instead of through the UI. Available from n8n v2.18.0. See [SSO environment variables](../basic-configuration/use-environment-variables/sso.md) for the full list of variables, and [Manage instance settings using environment variables](../manage-settings-using-environment-variables.md) for how the activation pattern works.
+You can also configure SSO from environment variables instead of through the UI. Available from n8n 2.18.0. See [SSO environment variables](../basic-configuration/use-environment-variables/sso.md) for the full list of variables, and [Manage instance settings using environment variables](../manage-settings-using-environment-variables.md) for how the activation pattern works.

--- a/docs/deploy/host-n8n/configure-n8n/security/decrypt-oauth-20-tokens-with-jwe.md
+++ b/docs/deploy/host-n8n/configure-n8n/security/decrypt-oauth-20-tokens-with-jwe.md
@@ -19,7 +19,7 @@ layout:
 {% hint style="info" %}
 **Feature availability**
 
-* Available from n8n v2.21.0.
+* Available from n8n 2.21.0.
 * Available on any n8n instance with the `N8N_ENV_FEAT_OAUTH2_JWE` environment variable set to `true`. Self-hosted instances can set it directly. On Cloud, contact n8n support to request it.
 * Requires an identity provider (IdP) that can encrypt tokens as JWE.
 {% endhint %}

--- a/docs/deploy/host-n8n/configure-n8n/security/manage-security-policies.md
+++ b/docs/deploy/host-n8n/configure-n8n/security/manage-security-policies.md
@@ -92,7 +92,7 @@ You can enforce [execution data redaction](redact-execution-data.md) for all wor
 
 Data redaction enforcement is available on Enterprise Self-hosted and Enterprise Cloud plans.
 
-**Available from:** n8n version 2.26.0
+**Available from:** n8n 2.26.0
 {% endhint %}
 
 To enforce data redaction:
@@ -114,7 +114,7 @@ Redaction enforcement requires an Enterprise license with the data redaction fea
 
 ## Configure security policy with environment variables <a href="#configure-security-policy-with-environment-variables" id="configure-security-policy-with-environment-variables"></a>
 
-You can also manage security policy settings from environment variables instead of through the UI. Available from n8n v2.18.0. Set `N8N_SECURITY_POLICY_MANAGED_BY_ENV` to `true` and provide the variables below. See [Manage instance settings using environment variables](../manage-settings-using-environment-variables.md) for how the activation pattern works.
+You can also manage security policy settings from environment variables instead of through the UI. Available from n8n 2.18.0. Set `N8N_SECURITY_POLICY_MANAGED_BY_ENV` to `true` and provide the variables below. See [Manage instance settings using environment variables](../manage-settings-using-environment-variables.md) for how the activation pattern works.
 
 When `N8N_SECURITY_POLICY_MANAGED_BY_ENV` is `true`, the **Enforce two-factor authentication** and **Personal Space** toggles on this page become read-only.
 

--- a/docs/deploy/host-n8n/configure-n8n/security/redact-execution-data.md
+++ b/docs/deploy/host-n8n/configure-n8n/security/redact-execution-data.md
@@ -36,7 +36,7 @@ layout:
 
 Data redaction is available on Enterprise Self-hosted and Enterprise Cloud plans.
 
-**Available from:** n8n version 2.16.0 (per-workflow redaction), n8n version 2.26.0 (instance-level enforcement)
+**Available from:** n8n 2.16.0 (per-workflow redaction), n8n 2.26.0 (instance-level enforcement)
 {% endhint %}
 
 Execution data redaction lets you hide the input and output data of workflow executions. This helps protect sensitive information like personal data, authentication tokens, and financial records from users who can view the workflow but don't need to see the underlying data.

--- a/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
@@ -278,7 +278,7 @@ If an instance admin selects a Brave Search or SearXNG credential in the AI sett
 
 ## Enable agents
 
-Agents run on the same self-hosted stack as AI Assistant. Once AI Assistant works, add the `agents` module to [build and run agents on your instance](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/build-and-manage-agents). Agents need n8n `2.32.3` (Beta) or later.
+Agents run on the same self-hosted stack as AI Assistant. Once AI Assistant works, add the `agents` module to [build and run agents on your instance](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/build-and-manage-agents). Agents need n8n 2.32.3 (Beta) or later.
 
 {% hint style="warning" %}
 Agents aren't ready for self-hosted Enterprise yet.

--- a/docs/deploy/host-n8n/configure-n8n/set-up-task-runners.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-task-runners.md
@@ -127,7 +127,7 @@ From version 2.0 onwards, `N8N_RUNNERS_ENABLED` is deprecated and you no longer 
 
 | Environment variables                                  | Description                                                                                                                                                                   |
 | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `N8N_RUNNERS_ENABLED=true`                             | Enables task runners. Deprecated from version 2.0 onwards. Still supported in version 1.x.                                                                                    |
+| `N8N_RUNNERS_ENABLED=true`                             | Enables task runners. Deprecated from n8n 2.0 onwards. Still supported in n8n 1.x.                                                                                    |
 | `N8N_RUNNERS_MODE=external`                            | Use task runners in external mode.                                                                                                                                            |
 | `N8N_RUNNERS_AUTH_TOKEN=<random secure shared secret>` | A shared secret task runners use to connect to the broker.                                                                                                                    |
 | `N8N_RUNNERS_BROKER_LISTEN_ADDRESS=0.0.0.0`            | By default, the task broker only listens to localhost. When using multiple containers (for example, with Docker Compose), it needs to be able to accept external connections. |

--- a/docs/deploy/host-n8n/configure-n8n/use-the-command-line.md
+++ b/docs/deploy/host-n8n/configure-n8n/use-the-command-line.md
@@ -136,7 +136,7 @@ n8n unpublish:workflow --all
 {% hint style="warning" %}
 **Deprecated in n8n 2.0**
 
-The `update:workflow` command is deprecated and will be removed. Use [`publish:workflow`](use-the-command-line.md#publish-a-workflow) and [`unpublish:workflow`](use-the-command-line.md#unpublish-a-workflow) instead. See the [n8n v2.0 breaking changes](https://app.gitbook.com/s/hhM8Cox90Piiv0u0EgHM/v20-breaking-changes) for details.
+The `update:workflow` command is deprecated and will be removed. Use [`publish:workflow`](use-the-command-line.md#publish-a-workflow) and [`unpublish:workflow`](use-the-command-line.md#unpublish-a-workflow) instead. See the [n8n 2.0 breaking changes](https://app.gitbook.com/s/hhM8Cox90Piiv0u0EgHM/v20-breaking-changes) for details.
 {% endhint %}
 
 Set the active status of a workflow by its ID to false:

--- a/docs/deploy/host-n8n/configure-n8n/user-management.md
+++ b/docs/deploy/host-n8n/configure-n8n/user-management.md
@@ -98,7 +98,7 @@ If you're not familiar with SMTP, this [blog post by SendGrid](https://sendgrid.
 #### Pre-provision the instance owner from environment variables <a href="#pre-provision-the-instance-owner-from-environment-variables" id="pre-provision-the-instance-owner-from-environment-variables"></a>
 
 {% hint style="info" %}
-**Available from n8n v2.17.0**
+**Available from n8n 2.17.0**
 
 
 {% endhint %}

--- a/docs/deploy/host-n8n/keep-n8n-running/trace-executions-with-opentelemetry.md
+++ b/docs/deploy/host-n8n/keep-n8n-running/trace-executions-with-opentelemetry.md
@@ -187,7 +187,7 @@ n8n supports the following custom attribute levels:
 | Workflow | **Workflow settings** | `workflow.execute` | `n8n.workflow.custom.<key>` |
 | Node | Node **Settings** tab | `node.execute` | `n8n.node.custom.<key>` |
 
-Project and workflow custom span attributes are available from n8n `2.24.0`. Node custom span attributes are available from n8n `2.22.0`.
+Project and workflow custom span attributes are available from n8n 2.24.0. Node custom span attributes are available from n8n 2.22.0.
 
 ### Add project span attributes <a href="#add-project-span-attributes" id="add-project-span-attributes"></a>
 
@@ -289,7 +289,7 @@ Workflow and node spans include the following n8n-specific attributes.
 | `n8n.workflow.name` | Workflow name. |
 | `n8n.workflow.version_id` | Workflow version ID. |
 | `n8n.workflow.node_count` | Number of nodes in the workflow. |
-| `n8n.project.id` | Project ID. Available from n8n `2.23.0`. |
+| `n8n.project.id` | Project ID. Available from n8n 2.23.0. |
 | `n8n.execution.id` | Execution ID. |
 | `n8n.execution.mode` | Execution mode (for example, `manual`, `webhook`, `trigger`, `retry`). |
 | `n8n.execution.status` | Final execution status. |

--- a/docs/deploy/host-n8n/keep-n8n-running/trace-executions-with-opentelemetry.md
+++ b/docs/deploy/host-n8n/keep-n8n-running/trace-executions-with-opentelemetry.md
@@ -52,7 +52,7 @@ n8n also handles trace context propagation:
 ## Enable tracing in the UI <a href="#enable-tracing-in-the-ui" id="enable-tracing-in-the-ui"></a>
 
 {% hint style="info" %}
-**Available from n8n v2.27.0**
+**Available from n8n 2.27.0**
 
 You need to be an instance owner or admin to configure OpenTelemetry in the UI.
 {% endhint %}

--- a/docs/deploy/host-n8n/keep-n8n-running/visualize-metrics-with-grafana.md
+++ b/docs/deploy/host-n8n/keep-n8n-running/visualize-metrics-with-grafana.md
@@ -58,7 +58,7 @@ Grafana confirms the connection with a success message.
 
 ## Webhook observability <a href="#webhook-observability" id="webhook-observability"></a>
 
-Available from n8n version 2.28.0.
+Available from n8n 2.28.0.
 
 n8n exposes a `n8n_webhook_request_duration_seconds` histogram for every webhook call. Enable these environment variables to collect it:
 
@@ -100,7 +100,7 @@ Each series carries these labels:
 
 ## Form submission observability <a href="#form-submission-observability" id="form-submission-observability"></a>
 
-Available from n8n version 2.28.0.
+Available from n8n 2.28.0.
 
 n8n exposes a `n8n_form_submission_duration_seconds` histogram for every form submission. Enable these environment variables to collect it:
 
@@ -147,7 +147,7 @@ Form submissions don't include a `method` label because n8n only accepts form da
 
 ## Workflow name lookup <a href="#workflow-name-lookup" id="workflow-name-lookup"></a>
 
-Available from n8n version 2.28.0.
+Available from n8n 2.28.0.
 
 When you enable `N8N_METRICS_INCLUDE_WORKFLOW_INFO`, n8n exposes one gauge per workflow:
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.mondaycom.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.mondaycom.md
@@ -25,7 +25,7 @@ On this page, you'll find a list of operations the monday.com node supports and 
 {% hint style="warning" %}
 **Minimum required version**
 
-This node requires n8n version 1.22.6 or above.
+This node requires n8n 1.22.6 or above.
 {% endhint %}
 
 {% hint style="info" %}

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/README.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/README.md
@@ -28,7 +28,7 @@ On this page, you'll find a list of operations the OpenAI node supports and link
 **Previous node versions**
 
 The OpenAI node replaces the OpenAI assistant node from version 1.29.0 on.
-n8n version 1.117.0 introduces V2 of the OpenAI node that supports the OpenAI Responses API and removes support for the [to-be-deprecated Assistants API](https://platform.openai.com/docs/assistants/migration).
+n8n 1.117.0 introduces V2 of the OpenAI node that supports the OpenAI Responses API and removes support for the [to-be-deprecated Assistants API](https://platform.openai.com/docs/assistants/migration).
 {% endhint %}
 
 {% hint style="info" %}

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/assistant-operations.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/assistant-operations.md
@@ -27,7 +27,7 @@ Use this operation to create, delete, list, message, or update an assistant in O
 {% hint style="info" %}
 **Assistant operations deprecated in OpenAI node V2**
 
-n8n version 1.117.0 introduces V2 of the OpenAI node that supports the OpenAI Responses API and removes support for the [to-be-deprecated Assistants API](https://platform.openai.com/docs/assistants/migration).
+n8n 1.117.0 introduces V2 of the OpenAI node that supports the OpenAI Responses API and removes support for the [to-be-deprecated Assistants API](https://platform.openai.com/docs/assistants/migration).
 {% endhint %}
 
 ## Create an Assistant <a href="#create-an-assistant" id="create-an-assistant"></a>

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/text-operations.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-langchain.openai/text-operations.md
@@ -26,7 +26,7 @@ Use this operation to message a model or classify text for violations in OpenAI.
 {% hint style="info" %}
 **Previous node versions**
 
-n8n version 1.117.0 introduces the OpenAI node V2 that supports the OpenAI Responses API. It renames the 'Message a Model' operation to 'Generate a Chat Completion' to clarify its association with the Chat Completions API and introduces a separate 'Generate a Model Response' operation that uses the Responses API.
+n8n 1.117.0 introduces the OpenAI node V2 that supports the OpenAI Responses API. It renames the 'Message a Model' operation to 'Generate a Chat Completion' to clarify its association with the Chat Completions API and introduces a separate 'Generate a Model Response' operation that uses the Responses API.
 {% endhint %}
 
 ## Generate a Chat Completion <a href="#generate-a-chat-completion" id="generate-a-chat-completion"></a>

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.microsoftagent365trigger.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.microsoftagent365trigger.md
@@ -62,7 +62,7 @@ When enabled, select one of:
 
 ## Webhook authentication <a href="#webhook-authentication" id="webhook-authentication"></a>
 
-From n8n version 2.25.7 and 2.26.2, the Microsoft Agent 365 Trigger node validates every incoming request before it runs your workflow. The node checks the Bot Framework token that Microsoft sends with each request and confirms Microsoft issued it for your agent. The node rejects any request without a valid token, so others can't inject forged activities even if they know your webhook URL.
+From n8n 2.25.7 and 2.26.2, the Microsoft Agent 365 Trigger node validates every incoming request before it runs your workflow. The node checks the Bot Framework token that Microsoft sends with each request and confirms Microsoft issued it for your agent. The node rejects any request without a valid token, so others can't inject forged activities even if they know your webhook URL.
 
 This validation uses the **Client ID** from your [Microsoft Agent 365 credential](../../credentials/microsoftagent365.md). The Client ID must match the application (client) ID of your agent's app registration. If it doesn't, the node rejects legitimate requests from Microsoft.
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.html.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.html.md
@@ -23,7 +23,7 @@ The HTML node provides operations to help you work with HTML in n8n.
 {% hint style="info" %}
 **HTML Extract node**
 
-The HTML node replaces the HTML Extract node from version 0.213.0 on. If you're using an older version of n8n, you can still view the [HTML Extract node documentation](https://github.com/n8n-io/n8n-docs/blob/86fe33b681621e618e3adcab9a27e8605dbc23ad/docs/integrations/builtin/core-nodes/n8n-nodes-base.htmlextract.md).
+The HTML node replaces the HTML Extract node from n8n 0.213.0 on. If you're using an older version of n8n, you can still view the [HTML Extract node documentation](https://github.com/n8n-io/n8n-docs/blob/86fe33b681621e618e3adcab9a27e8605dbc23ad/docs/integrations/builtin/core-nodes/n8n-nodes-base.htmlextract.md).
 {% endhint %}
 {% hint style="warning" %}
 **Cross-site scripting**

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.merge.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.merge.md
@@ -29,9 +29,9 @@ The n8n team overhauled this node in n8n 0.194.0. This document reflects the lat
 {% hint style="info" %}
 **Minor changes in 1.49.0**
 
-n8n version 1.49.0 introduced the option to add more than two inputs. Older versions only support up to two inputs. If you're running an older version and want to combine multiple inputs in these versions, use the [Code node](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.code/).
+n8n 1.49.0 introduced the option to add more than two inputs. Older versions only support up to two inputs. If you're running an older version and want to combine multiple inputs in these versions, use the [Code node](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.code/).
 
-The **Mode > SQL Query** feature was also added in n8n version 1.49.0 and isn't available in older versions.
+The **Mode > SQL Query** feature was also added in n8n 1.49.0 and isn't available in older versions.
 {% endhint %}
 
 ## Node parameters <a href="#node-parameters" id="node-parameters"></a>

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.respondtowebhook.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.respondtowebhook.md
@@ -79,7 +79,7 @@ Select **Add Option** to view and set the options.
 
 ## How n8n secures HTML responses <a href="#how-n8n-secures-html-responses" id="how-n8n-secures-html-responses"></a>
 
-Starting with n8n version 1.103.0, n8n automatically wraps HTML responses to webhooks in `<iframe>` tags. This is a security mechanism to protect the instance users.
+Starting with n8n 1.103.0, n8n automatically wraps HTML responses to webhooks in `<iframe>` tags. This is a security mechanism to protect the instance users.
 
 This has the following implications:
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.webhook/README.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.webhook/README.md
@@ -155,7 +155,7 @@ Select **Add Option** to view more configuration options. The available options 
 
 ## How n8n secures HTML responses <a href="#how-n8n-secures-html-responses" id="how-n8n-secures-html-responses"></a>
 
-Starting with n8n version 1.103.0, n8n automatically wraps HTML responses to webhooks in `<iframe>` tags. This is a security mechanism to protect the instance users.
+Starting with n8n 1.103.0, n8n automatically wraps HTML responses to webhooks in `<iframe>` tags. This is a security mechanism to protect the instance users.
 
 This has the following implications:
 

--- a/docs/integrations/builtin/credentials/mondaycom.md
+++ b/docs/integrations/builtin/credentials/mondaycom.md
@@ -25,7 +25,7 @@ You can use these credentials to authenticate the following nodes:
 {% hint style="info" %}
 **Minimum required version**
 
-The monday.com node requires n8n version 1.22.6 or above.
+The monday.com node requires n8n 1.22.6 or above.
 {% endhint %}
 
 ## Supported authentication methods <a href="#supported-authentication-methods" id="supported-authentication-methods"></a>

--- a/docs/integrations/builtin/credentials/stripe.md
+++ b/docs/integrations/builtin/credentials/stripe.md
@@ -59,7 +59,7 @@ Refer to Stripe's [Create a secret API key](https://docs.stripe.com/keys#create-
 
 ## Verify incoming requests <a href="#verify-incoming-requests" id="verify-incoming-requests"></a>
 
-From n8n version 2.25.7 and 2.26.2, the [Stripe Trigger](../trigger-nodes/n8n-nodes-base.stripetrigger.md) node can verify that incoming webhook requests genuinely come from Stripe. n8n strongly recommends setting a **Signature Secret** so others can't send forged events to your workflow, even if they know your webhook URL.
+From n8n 2.25.7 and 2.26.2, the [Stripe Trigger](../trigger-nodes/n8n-nodes-base.stripetrigger.md) node can verify that incoming webhook requests genuinely come from Stripe. n8n strongly recommends setting a **Signature Secret** so others can't send forged events to your workflow, even if they know your webhook URL.
 
 n8n creates and manages the Stripe webhook endpoint for you when you publish a workflow, so you set the **Signature Secret** after the endpoint exists:
 

--- a/docs/integrations/builtin/credentials/twitter.md
+++ b/docs/integrations/builtin/credentials/twitter.md
@@ -34,7 +34,7 @@ You can use these credentials to authenticate the following nodes:
 {% hint style="info" %}
 **Deprecation warning**
 
-n8n used to support an **OAuth** authentication method, which used X's [OAuth 1.0a](https://developer.x.com/en/docs/authentication/oauth-1-0a) authentication method. n8n deprecated this method with the release of V2 of the X node in n8n version [0.236.0](https://app.gitbook.com/s/hhM8Cox90Piiv0u0EgHM/0.x#n8n02360).
+n8n used to support an **OAuth** authentication method, which used X's [OAuth 1.0a](https://developer.x.com/en/docs/authentication/oauth-1-0a) authentication method. n8n deprecated this method with the release of V2 of the X node in n8n [0.236.0](https://app.gitbook.com/s/hhM8Cox90Piiv0u0EgHM/0.x#n8n02360).
 {% endhint %}
 
 ## Related resources <a href="#related-resources" id="related-resources"></a>
@@ -45,7 +45,7 @@ Refer to [Application-only Authentication](https://developer.twitter.com/en/docs
 
 ## Using OAuth2 <a href="#using-oauth2" id="using-oauth2"></a>
 
-Use this method if you're using n8n version 0.236.0 or later.
+Use this method if you're using n8n 0.236.0 or later.
 
 To configure this credential, you'll need:
 

--- a/docs/integrations/builtin/credentials/twitter.md
+++ b/docs/integrations/builtin/credentials/twitter.md
@@ -34,7 +34,7 @@ You can use these credentials to authenticate the following nodes:
 {% hint style="info" %}
 **Deprecation warning**
 
-n8n used to support an **OAuth** authentication method, which used X's [OAuth 1.0a](https://developer.x.com/en/docs/authentication/oauth-1-0a) authentication method. n8n deprecated this method with the release of V2 of the X node in n8n [0.236.0](https://app.gitbook.com/s/hhM8Cox90Piiv0u0EgHM/0.x#n8n02360).
+n8n used to support an **OAuth** authentication method, which used X's [OAuth 1.0a](https://developer.x.com/en/docs/authentication/oauth-1-0a) authentication method. n8n deprecated this method with the release of V2 of the X node in n8n [0.236.0](https://app.gitbook.com/s/hhM8Cox90Piiv0u0EgHM/release-notes-0.x#n8n02360).
 {% endhint %}
 
 ## Related resources <a href="#related-resources" id="related-resources"></a>

--- a/docs/integrations/builtin/credentials/twitter.md
+++ b/docs/integrations/builtin/credentials/twitter.md
@@ -24,7 +24,7 @@ You can use these credentials to authenticate the following nodes:
 
 ## Prerequisites <a href="#prerequisites" id="prerequisites"></a>
 
-- Create an [X developer](https://developer.x.com/en) account.
+- Create an [X developer](https://developer.x.com) account.
 - Create a [Twitter app](https://developer.x.com/en/docs/apps) or use the default project and app created when you sign up for the developer portal. Refer to each supported authentication method below for more details on the app's configuration.
 
 ## Supported authentication methods <a href="#supported-authentication-methods" id="supported-authentication-methods"></a>

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.slacktrigger.md
@@ -87,7 +87,7 @@ The node requires scopes for the [conversations.list](https://api.slack.com/meth
 
 ## Verify the webhook <a href="#verify-the-webhook" id="verify-the-webhook"></a>
 
-From version `1.106.0`, you can set a [Slack Signing Secret](https://api.slack.com/authentication/verifying-requests-from-slack#signing_secrets_admin_page) when configuring your [Slack credentials](../credentials/slack.md#slack-trigger-configuration). When set, the Slack trigger node automatically verifies that requests are from Slack and include a trusted signature. n8n recommends setting this to ensure you only process requests sent from Slack.
+From n8n 1.106.0, you can set a [Slack Signing Secret](https://api.slack.com/authentication/verifying-requests-from-slack#signing_secrets_admin_page) when configuring your [Slack credentials](../credentials/slack.md#slack-trigger-configuration). When set, the Slack trigger node automatically verifies that requests are from Slack and include a trusted signature. n8n recommends setting this to ensure you only process requests sent from Slack.
 
 ## Common issues <a href="#common-issues" id="common-issues"></a>
 

--- a/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.stripetrigger.md
+++ b/docs/integrations/builtin/trigger-nodes/n8n-nodes-base.stripetrigger.md
@@ -30,7 +30,7 @@ You can find authentication information for this node [here](../credentials/stri
 
 ## Webhook authentication <a href="#webhook-authentication" id="webhook-authentication"></a>
 
-From n8n version 2.25.7 and 2.26.2, the Stripe Trigger node can verify that incoming requests genuinely come from Stripe. When you set a **Signature Secret** on your [Stripe credential](../credentials/stripe.md), the node checks the `Stripe-Signature` header on each request and rejects any request that's unsigned, forged, or more than five minutes old with a `401 Unauthorized` response. n8n doesn't run your workflow for rejected requests.
+From n8n 2.25.7 and 2.26.2, the Stripe Trigger node can verify that incoming requests genuinely come from Stripe. When you set a **Signature Secret** on your [Stripe credential](../credentials/stripe.md), the node checks the `Stripe-Signature` header on each request and rejects any request that's unsigned, forged, or more than five minutes old with a `401 Unauthorized` response. n8n doesn't run your workflow for rejected requests.
 
 Without a **Signature Secret**, the node doesn't verify incoming requests, so anyone who knows your webhook URL could send forged events. n8n strongly recommends setting one. For setup steps, refer to [Verify incoming requests](../credentials/stripe.md#verify-incoming-requests).
 

--- a/docs/integrations/community-nodes/installation-and-management/environment-variable-installation.md
+++ b/docs/integrations/community-nodes/installation-and-management/environment-variable-installation.md
@@ -13,7 +13,7 @@ layout:
 # Manage community packages from environment variables <a href="#manage-community-packages-from-environment-variables" id="manage-community-packages-from-environment-variables"></a>
 
 {% hint style="info" %}
-**Available from n8n v2.21.0**
+**Available from n8n 2.21.0**
 
 
 {% endhint %}

--- a/docs/privacy-and-security/privacy.md
+++ b/docs/privacy-and-security/privacy.md
@@ -145,7 +145,7 @@ To assist and improve user experience, n8n may send specific context data to LLM
 #### AI usage settings <a href="#ai-usage-settings" id="ai-usage-settings"></a>
 
 {% hint style="info" %}
-Available in n8n v2.7.0 and above.
+Available in n8n 2.7.0 and above.
 {% endhint %}
 
 You can manage your AI usage settings by navigating to **Settings** > **AI Usage** in your n8n instance.

--- a/docs/reusable-content/.gitbook/includes/integrations/builtin/core-nodes/code-node.md
+++ b/docs/reusable-content/.gitbook/includes/integrations/builtin/core-nodes/code-node.md
@@ -23,7 +23,7 @@ For usage examples and templates to help you get started, refer to n8n's [Code i
 {% hint style="info" %}
 **Function and Function Item nodes**
 
-The Code node replaces the Function and Function Item nodes from version 0.198.0. If you're using an older version of n8n, you can still view the [Function node documentation](https://github.com/n8n-io/n8n-docs/blob/67935ad2528e2e30d7984ea917e4af2910a096ec/docs/integrations/builtin/core-nodes/n8n-nodes-base.function.md) and [Function Item node documentation](https://github.com/n8n-io/n8n-docs/blob/67935ad2528e2e30d7984ea917e4af2910a096ec/docs/integrations/builtin/core-nodes/n8n-nodes-base.functionItem.md).
+The Code node replaces the Function and Function Item nodes from n8n 0.198.0. If you're using an older version of n8n, you can still view the [Function node documentation](https://github.com/n8n-io/n8n-docs/blob/67935ad2528e2e30d7984ea917e4af2910a096ec/docs/integrations/builtin/core-nodes/n8n-nodes-base.function.md) and [Function Item node documentation](https://github.com/n8n-io/n8n-docs/blob/67935ad2528e2e30d7984ea917e4af2910a096ec/docs/integrations/builtin/core-nodes/n8n-nodes-base.functionItem.md).
 {% endhint %}
 
 ## Usage <a href="#usage" id="usage"></a>
@@ -69,9 +69,9 @@ The Code node editing environment supports time-saving and useful keyboard short
 
 ## Python (Pyodide - legacy) <a href="#python-pyodide-legacy" id="python-pyodide-legacy"></a>
 
-Pyodide is a legacy feature. n8n v2 no longer supports this feature.
+Pyodide is a legacy feature. n8n 2 no longer supports this feature.
 
-n8n added Python support in version 1.0. It doesn't include a Python executable. Instead, n8n provides Python support using [Pyodide](https://pyodide.org/en/stable/), which is a port of CPython to WebAssembly. This limits the available Python packages to the [Packages included with Pyodide](https://pyodide.org/en/stable/usage/packages-in-pyodide.html#packages-in-pyodide). n8n downloads the package automatically the first time you use it.
+n8n added Python support in n8n 1.0. It doesn't include a Python executable. Instead, n8n provides Python support using [Pyodide](https://pyodide.org/en/stable/), which is a port of CPython to WebAssembly. This limits the available Python packages to the [Packages included with Pyodide](https://pyodide.org/en/stable/usage/packages-in-pyodide.html#packages-in-pyodide). n8n downloads the package automatically the first time you use it.
 
 {% hint style="info" %}
 **Slower than JavaScript**
@@ -98,7 +98,7 @@ You can't access the file system or make HTTP requests. Use the following nodes 
 
 ## Python (Native) <a href="#python-native" id="python-native"></a>
 
-n8n added native Python support using task runners in version 1.111.0. This feature is stable as of n8n v2.
+n8n added native Python support using task runners in n8n 1.111.0. This feature is stable as of n8n 2.
 
 Main differences from Pyodide:
 

--- a/docs/reusable-content/.gitbook/includes/integrations/builtin/core-nodes/merge/if-merge-branch-execution.md
+++ b/docs/reusable-content/.gitbook/includes/integrations/builtin/core-nodes/merge/if-merge-branch-execution.md
@@ -4,7 +4,7 @@ title: if-merge-branch-execution
 {% hint style="info" %}
 **0.236.0 and below**
 
-n8n removed this execution behavior in version 1.0. This section applies to workflows using the **v0 (legacy)** workflow execution order. By default, this is all workflows built before version 1.0. You can change the execution order in your [workflow settings](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/configure-workflow-settings).
+n8n removed this execution behavior in n8n 1.0. This section applies to workflows using the **v0 (legacy)** workflow execution order. By default, this is all workflows built before n8n 1.0. You can change the execution order in your [workflow settings](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/configure-workflow-settings).
 {% endhint %}
 If you add a Merge node to a workflow containing an If node, it can result in both output data streams of the If node executing.
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -131,7 +131,7 @@ exclude = [
   '^https://business\.adobe\.com/products/commerce\.html',  # Times out on automated checks
   '^https://developer\.paddle\.com/',  # Times out on automated checks
   '^https://console\.cloud\.google\.com/apis/library',  # Redirect loop on automated checks (works in a browser)
-  '^https://github\.com/(CxGarcia|miguel-mconf|yoky-devsavant|kirill-chertkov|bramknuever|bugagashenkj|FFTDB)$',  # Deleted contributor accounts credited in historical release notes
+  '^https://github\.com/(CxGarcia|miguel-mconf|yoky-devsavant|kirill-chertkov|bramknuever|bugagashenkj|FFTDB|jamesliupenn|nikozila|torbhai|manusjs)$',  # Deleted contributor accounts credited in historical release notes
   '^https://developers\.facebook\.com/docs/(certificate-transparency-api|graph-api/webhooks/getting-started/webhooks-for-certificate-transparency|graph-api/webhooks/reference/certificate-transparency)',  # Meta removed/moved these docs (404); needs content review
   '^https://docs\.openwebui\.com/getting-started/api-endpoints',  # OpenWebUI moved these docs (404); needs content review
   ]

--- a/skills/n8n-docs-author/SKILL.md
+++ b/skills/n8n-docs-author/SKILL.md
@@ -156,7 +156,10 @@ See [reference.md](reference.md) for full examples and rules.
   never just "version 2".
 - **Format:** product name plus numerals: `n8n 2.30.0`. No `v` prefix, don't
   write "version" after "n8n", and don't add "or later"; "available from"
-  already means "and onward".
+  already means "and onward". Don't wrap the version in inline code formatting
+  in running text (write "n8n 2.30.0", not "n8n `2.30.0`") — only use code
+  formatting when the version is part of an actual code snippet, command, or
+  file path (`n8n@2.30.0`, a Docker tag, a `package.json` value).
 - **Placement:** match the scope. Whole page or section → an `info` hint titled
   `**Feature availability**` under the page title or heading. Mentioned in
   passing with no heading of its own → fold it into the sentence ("The Data

--- a/skills/n8n-docs-author/SKILL.md
+++ b/skills/n8n-docs-author/SKILL.md
@@ -157,7 +157,7 @@ See [reference.md](reference.md) for full examples and rules.
 - **Format:** product name plus numerals: `n8n 2.30.0`. No `v` prefix, don't
   write "version" after "n8n", and don't add "or later"; "available from"
   already means "and onward". Don't wrap the version in inline code formatting
-  in running text (write "n8n 2.30.0", not "n8n `2.30.0`") — only use code
+  in running text (write "n8n 2.30.0", not "n8n `2.30.0`"). Only use code
   formatting when the version is part of an actual code snippet, command, or
   file path (`n8n@2.30.0`, a Docker tag, a `package.json` value).
 - **Placement:** match the scope. Whole page or section → an `info` hint titled

--- a/skills/n8n-docs-author/reference.md
+++ b/skills/n8n-docs-author/reference.md
@@ -384,7 +384,11 @@ In prose, qualify a bare number: "n8n 2.30.0" or "node version 4.7", not "versio
 
 **Writing the number.** Product name plus numerals: `n8n 2.30.0`. No `v` prefix
 (`n8n 2.30.0`, not `n8n v2.30.0`), don't write "version" after "n8n", and don't
-add "or later"; "available from" already means "and onward".
+add "or later"; "available from" already means "and onward". Don't wrap the
+version in inline code formatting in running text ("n8n 2.30.0", not
+"n8n `2.30.0`") — reserve code formatting for when the version is part of an
+actual code snippet, command, or file path (`n8n@2.30.0`, a Docker tag, a
+`package.json` value).
 
 ### Plan, platform, and version limits
 


### PR DESCRIPTION
Applied style guide rules on referring to n8n versions to all doc:

#### Writing version numbers

> Follow the [numbers guidance](#numbers-dates-and-times), plus these rules for n8n instance versions:
> 
> * **Use the product name and numerals**: n8n 2.30.0.
> * **Don't add a `v` prefix**: write "n8n 2.30.0", not "n8n v2.30.0".
> * **Don't write the word "version" after "n8n"**: the number alone is clear. Write "n8n 2.30.0", not "n8n version 2.30.0".
> * **Don't put the version number in inline code formatting in running text**: write n8n 2.30.0, not n8n `2.30.0`. Only use code formatting when the version appears inside an actual code snippet, command, or file path, for example `n8n@2.30.0`, a Docker tag, or a `package.json` value.