### PR TITLE
docs: update Execute Command node documentation to reflect removal of apk from n8n Docker image

### DIFF
--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.executecommand/README.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.executecommand/README.md
@@ -89,26 +89,38 @@ Use one of two methods to run multiple commands in one Execute Command node:
 
 #### Run cURL command <a href="#run-curl-command" id="run-curl-command"></a>
 
-You can also use the [HTTP Request](../n8n-nodes-base.httprequest/README.md) node to make a cURL request.
+You can also use the [HTTP Request](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest.md) node to make a cURL request.
 
-If you want to run the curl command in the Execute Command node, you will have to build a Docker image based on the existing n8n image. The default n8n Docker image uses Alpine Linux. You will have to install the curl package.
+If you want to run the curl command in the Execute Command node, you will have to build a Docker image based on the existing n8n image. The default n8n Docker image uses Alpine Linux.
+
+{% hint style="info" %}
+**`apk` isn't included in the n8n image**
+
+The `apk` package manager was removed from the official n8n Docker image. To install a package like `curl`, you need to restore `apk` from a fresh Alpine base image first, as shown below.
+{% endhint %}
 
 1. Create a file named `Dockerfile`.
-2.  Add the below code snippet to the Dockerfile.
+2. Add the below code snippet to the Dockerfile.
 
-    ```shell
-    FROM docker.n8n.io/n8nio/n8n
-    USER root
-    RUN apk --update add curl
-    USER node
-    ```
-3.  In the same folder, execute the command below to build the Docker image.
+```shell
+   FROM docker.n8n.io/n8nio/n8n
+   USER root
 
-    ```shell
-    docker build -t n8n-curl
-    ```
+   # Restore the apk package manager (removed from the base image)
+   COPY --from=alpine:3.22 /sbin/apk /sbin/apk
+   COPY --from=alpine:3.22 /lib/apk /lib/apk
+   COPY --from=alpine:3.22 /usr/lib/libapk* /usr/lib/
+
+   RUN apk add --no-cache curl
+   USER node
+```
+3. In the same folder, execute the command below to build the Docker image.
+
+```shell
+   docker build -t n8n-curl .
+```
 4. Replace the Docker image you used before. For example, replace `docker.n8n.io/n8nio/n8n` with `n8n-curl`.
-5. Run the newly created Docker image. You'll now be able to execute ssh using the Execute Command Node.
+5. Run the newly created Docker image. You'll now be able to execute curl using the Execute Command Node.
 
 ## Templates and examples <a href="#templates-and-examples" id="templates-and-examples"></a>
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.executecommand/README.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.executecommand/README.md
@@ -89,7 +89,7 @@ Use one of two methods to run multiple commands in one Execute Command node:
 
 #### Run cURL command <a href="#run-curl-command" id="run-curl-command"></a>
 
-You can also use the [HTTP Request](/integrations/builtin/core-nodes/n8n-nodes-base.httprequest.md) node to make a cURL request.
+You can also use the [HTTP Request](../n8n-nodes-base.httprequest/README.md) node to make a cURL request.
 
 If you want to run the curl command in the Execute Command node, you will have to build a Docker image based on the existing n8n image. The default n8n Docker image uses Alpine Linux.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies that `apk` is no longer present in the official n8n Docker image and adds a working path to run `curl` via a custom image. Addresses Linear DOC-2180.

- Adds an info hint; updates the Dockerfile to restore `apk` from `alpine:3.22`, install `curl`, and switch back to `node`.
- Fixes the internal HTTP Request node link and the build command (`docker build -t n8n-curl .`); replaces “ssh” with `curl`.
- Required action for users who need `curl` in Execute Command: build and run the custom image and replace `docker.n8n.io/n8nio/n8n` with `n8n-curl`.

<sup>Written for commit 2a25298c2fe350232a3abb05404f5dde6c77ad7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

