### PR TITLE
docs: add n8n User Auth option to Form Trigger node documentation

### DIFF
--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
@@ -146,7 +146,7 @@ Choose when n8n sends a response to the form submission. You can respond when:
 
 Select **Add Option** to view more configuration options: 
 
-* **Append n8n Attribution**: Turn off to hide the **Form automated with n8n** attribute at the bottom of the form.
+- **Append n8n Attribution**: Turn off to hide the **Form automated with n8n** attribute at the bottom of the form.
 * **Button Label**: The label to use for your form's submit button. n8n displays the **Button Label** as the name of the submit button.
 * **Form Path**: The final segment of the form's URL, for both testing and production. Replaces the automatically generated UUID as the final component.
 * **Ignore Bots**: Turn on to ignore requests from bots like link previewers and web crawlers.

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
@@ -151,7 +151,7 @@ Select **Add Option** to view more configuration options:
 * **Form Path**: The final segment of the form's URL, for both testing and production. Replaces the automatically generated UUID as the final component.
 * **Ignore Bots**: Turn on to ignore requests from bots like link previewers and web crawlers.
 * **Include User in Output**: Only relevant when **Authentication** is set to **n8n User Auth**. Turn off to exclude the submitting user's ID, email, first name, and last name from the node's output (turned on by default).
-* **Use Workflow Timezone**: Turn on to use the timezone in the [Workflow settings](/build/manage-workflows/configure-workflow-settings.md) instead of UTC (default). This affects the value of the `submittedAt` timestamp in the node output.
+* **Use Workflow Timezone**: Turn on to use the timezone in the [Workflow settings](../../../build/manage-workflows/configure-workflow-settings.md) instead of UTC (default). This affects the value of the `submittedAt` timestamp in the node output.
 * **Custom Form Styling**: Override the default styling of the public form interface with CSS. The field pre-populates with the default styling so you can change only what you need to.
 
 ## Customizing Form Trigger node behavior <a href="#customizing-form-trigger-node-behavior" id="customizing-form-trigger-node-behavior"></a>

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
@@ -151,7 +151,7 @@ Select **Add Option** to view more configuration options:
 * **Form Path**: The final segment of the form's URL, for both testing and production. Replaces the automatically generated UUID as the final component.
 * **Ignore Bots**: Turn on to ignore requests from bots like link previewers and web crawlers.
 * **Include User in Output**: Only relevant when **Authentication** is set to **n8n User Auth**. Turn off to exclude the submitting user's ID, email, first name, and last name from the node's output (turned on by default).
-* **Use Workflow Timezone**: Turn on to use the timezone in the [Workflow settings](../../../build/manage-workflows/configure-workflow-settings.md) instead of UTC (default). This affects the value of the `submittedAt` timestamp in the node output.
+* **Use Workflow Timezone**: Turn on to use the timezone in the [Workflow settings](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/configure-workflow-settings) instead of UTC (default). This affects the value of the `submittedAt` timestamp in the node output.
 * **Custom Form Styling**: Override the default styling of the public form interface with CSS. The field pre-populates with the default styling so you can change only what you need to.
 
 ## Customizing Form Trigger node behavior <a href="#customizing-form-trigger-node-behavior" id="customizing-form-trigger-node-behavior"></a>

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
@@ -73,6 +73,7 @@ These are the main node configuration fields:
 ### Authentication <a href="#authentication" id="authentication"></a>
 
 - **Basic Auth**
+- **n8n User Auth**
 - **None**
 
 #### Using basic auth <a href="#using-basic-auth" id="using-basic-auth"></a>
@@ -81,6 +82,14 @@ To configure this credential, you'll need:
 
 - The **Username** you use to access the app or service your HTTP Request is targeting.
 - The **Password** that goes with that username.
+
+#### Using n8n User Auth <a href="#using-n8n-user-auth" id="using-n8n-user-auth"></a>
+
+Only users logged in to this n8n instance can view or submit the form.
+
+* Unauthenticated visitors loading the form are redirected to the n8n sign-in page.
+* Unauthenticated form submissions receive a 401 response.
+* By default, n8n adds the submitting user's ID, email, first name, and last name to the output data. Turn off **Include User in Output** in [Node options](#node-options) to exclude this.
 
 ### Form URLs <a href="#form-urls" id="form-urls"></a>
 
@@ -137,12 +146,13 @@ Choose when n8n sends a response to the form submission. You can respond when:
 
 Select **Add Option** to view more configuration options: 
 
-- **Append n8n Attribution**: Turn off to hide the **Form automated with n8n** attribute at the bottom of the form.
-- **Button Label**: The label to use for your form's submit button. n8n displays the **Button Label** as the name of the submit button.
-- **Form Path**: The final segment of the form's URL, for both testing and production. Replaces the automatically generated UUID as the final component.
-- **Ignore Bots**: Turn on to ignore requests from bots like link previewers and web crawlers. 
-- **Use Workflow Timezone**: Turn on to use the timezone in the [Workflow settings](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/configure-workflow-settings) instead of UTC (default). This affects the value of the `submittedAt` timestamp in the node output. 
-- **Custom Form Styling**: Override the default styling of the public form interface with CSS. The field pre-populates with the default styling so you can change only what you need to.
+* **Append n8n Attribution**: Turn off to hide the **Form automated with n8n** attribute at the bottom of the form.
+* **Button Label**: The label to use for your form's submit button. n8n displays the **Button Label** as the name of the submit button.
+* **Form Path**: The final segment of the form's URL, for both testing and production. Replaces the automatically generated UUID as the final component.
+* **Ignore Bots**: Turn on to ignore requests from bots like link previewers and web crawlers.
+* **Include User in Output**: Only relevant when **Authentication** is set to **n8n User Auth**. Turn off to exclude the submitting user's ID, email, first name, and last name from the node's output (turned on by default).
+* **Use Workflow Timezone**: Turn on to use the timezone in the [Workflow settings](/build/manage-workflows/configure-workflow-settings.md) instead of UTC (default). This affects the value of the `submittedAt` timestamp in the node output.
+* **Custom Form Styling**: Override the default styling of the public form interface with CSS. The field pre-populates with the default styling so you can change only what you need to.
 
 ## Customizing Form Trigger node behavior <a href="#customizing-form-trigger-node-behavior" id="customizing-form-trigger-node-behavior"></a>
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Documents the Form Trigger’s n8n User Auth option and adds an Include User in Output toggle to clarify access control and user data handling. Addresses Linear DOC-2090.

- Adds “n8n User Auth”: redirects unauthenticated visitors to sign-in, returns 401 on unauthenticated submits, and includes user ID, email, first name, and last name by default; toggle via “Include User in Output.”
- Adds “Include User in Output” node option (only for “n8n User Auth”) under Node options.
- Removes the outdated “Append n8n Attribution” option from Node options.
- Fixes the Workflow settings link to the correct cross-space path.

<sup>Written for commit f2be3039a441cd3a8579af002f2847dc770d9cce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

