### PR TITLE
docs: add Google Chat and YouTube links to managed Google OAuth documentation

### DIFF
--- a/docs/reusable-content/.gitbook/includes/integrations/managed-google-oauth.md
+++ b/docs/reusable-content/.gitbook/includes/integrations/managed-google-oauth.md
@@ -3,7 +3,7 @@ title: managed-google-oauth
 ---
 * [Google Calendar](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.googlecalendar)
 * [Google Calendar Trigger](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/trigger-nodes/n8n-nodes-base.googlecalendartrigger)
-* [Google Chat](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.googlechat.md)
+* [Google Chat](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.googlechat)
 * [Google Contacts](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.googlecontacts)
 * [Google Docs](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.googledocs)
 * [Google Drive](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.googledrive)

--- a/docs/reusable-content/.gitbook/includes/integrations/managed-google-oauth.md
+++ b/docs/reusable-content/.gitbook/includes/integrations/managed-google-oauth.md
@@ -14,4 +14,4 @@ title: managed-google-oauth
 * [Google Sheets Trigger](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/trigger-nodes/n8n-nodes-base.googlesheetstrigger)
 * [Google Slides](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.googleslides)
 * [Google Tasks](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.googletasks)
-* [YouTube](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.youtube.md)
+* [YouTube](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.youtube)

--- a/docs/reusable-content/.gitbook/includes/integrations/managed-google-oauth.md
+++ b/docs/reusable-content/.gitbook/includes/integrations/managed-google-oauth.md
@@ -3,6 +3,7 @@ title: managed-google-oauth
 ---
 * [Google Calendar](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.googlecalendar)
 * [Google Calendar Trigger](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/trigger-nodes/n8n-nodes-base.googlecalendartrigger)
+* [Google Chat](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.googlechat.md)
 * [Google Contacts](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.googlecontacts)
 * [Google Docs](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.googledocs)
 * [Google Drive](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.googledrive)
@@ -13,3 +14,4 @@ title: managed-google-oauth
 * [Google Sheets Trigger](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/trigger-nodes/n8n-nodes-base.googlesheetstrigger)
 * [Google Slides](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.googleslides)
 * [Google Tasks](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.googletasks)
+* [YouTube](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.youtube.md)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Google Chat and YouTube to the managed Google OAuth include so Cloud credential overwrites are documented and align with DOC-2099. Previously these nodes were missing; now both appear with links to their node docs.

- Confirm the Google Chat and YouTube links resolve to the correct node pages.
- Check list formatting and alphabetical ordering match existing entries across pages that include this file.

<sup>Written for commit a7988152dc95e9802344f270ad43d6b48b2637c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

