### PR TITLE
docs(changelog): one entry per thing, restructure 2.19 and below

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -612,7 +612,7 @@ Workflow settings updates are also logged with the specific parameters that chan
 
 ## Time Saved node
 
-**Released:** 2025-12-16 in [n8n 2.1](release-notes.md#n8n21)
+**Released:** 2025-12-15 in [n8n 2.1](release-notes.md#n8n21)
 
 Previously, teams could only track a single fixed time saved value for each workflow regardless of which path an execution takes. The new Time Saved node enables more precise time savings calculations where different execution paths save different amounts of time.
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -581,6 +581,20 @@ This release builds on recent updates to the permissions model, including [custo
 
 ***
 
+## Inspect a role's permissions before assigning it
+
+**Released:** 2026-02-13 in [n8n 2.8.3](release-notes.md#n8n28)
+
+The project role selector now splits built-in system roles and [custom roles](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-roles) into separate sections, so a long list of custom roles no longer buries the defaults. Hovering over any role shows a summary of its configured permissions, with an option to open the full permission details. Previously you had to leave the assignment flow and open the role itself to check what you were about to grant.
+
+<figure><img src=".gitbook/assets/custom_roles_selector.png" alt="System roles and custom roles are now displayed in separate sections"><figcaption><p>System roles and custom roles are now displayed in separate sections</p></figcaption></figure>
+
+{% hint style="info" %}
+**Availability:** Enterprise.
+{% endhint %}
+
+***
+
 ## Human-in-the-loop for AI tool calls
 
 **Released:** 2026-01-26 in [n8n 2.6](release-notes.md#n8n26)
@@ -640,7 +654,11 @@ Human in the loop for the Chat node
 
 **Released:** 2026-01-12 in [n8n 2.4](release-notes.md#n8n24)
 
-The Syslog log streaming destination now supports TLS over TCP. Previously it sent log events unencrypted, which ruled it out for SIEM and observability platforms that require encrypted transport. Enable TLS on the destination and point it at your platform's TLS port, and n8n streams audit and execution events over an encrypted connection.
+The Syslog [log streaming](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/observe-and-log/stream-logs-to-external-systems) destination now supports TLS over TCP. Previously it sent log events over plain UDP or TCP, which ruled it out for SIEM and observability platforms that require encrypted transport. Set the destination's transport protocol to TLS instead of the default UDP, and supply the PEM-formatted CA certificate for the connection.
+
+{% hint style="info" %}
+**Availability:** Enterprise.
+{% endhint %}
 
 ***
 
@@ -679,6 +697,10 @@ Log streaming now includes additional audit events to improve visibility into op
 This update adds events for manual workflow cancellations and workflow activation/deactivation (publish/unpublish), variable lifecycle events (create/update/delete), and user management actions (including enabling/disabling 2FA).
 
 Workflow settings updates are also logged with the specific parameters that changed (for example, selecting a new error workflow), instead of a generic "updated" event.
+
+{% hint style="info" %}
+**Availability:** Enterprise.
+{% endhint %}
 
 ***
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -355,11 +355,9 @@ Self-hosted instances can now retain insights data for up to 365 days by default
 
 ***
 
-## IdP role mapping and instance bootstrapping
+## IdP role mapping inside n8n
 
 **Released:** 2026-04-28 in [n8n 2.19](release-notes.md#n8n219)
-
-### IdP role mapping inside n8n
 
 Instance admins can now define group-to-role mappings inside n8n instead of encoding n8n-specific role logic in the IdP. With JIT provisioning enabled, admins write expressions against SAML attributes or OIDC claims to assign instance and project roles automatically at login. The IdP only needs to send standard group membership data: n8n handles the mapping, and role assignments are re-evaluated on every login, so access stays in sync without IdP changes.
 
@@ -369,7 +367,11 @@ Open **Settings → SSO**, pick **Instance roles via SSO** or **Instance and pro
 **Availability:** Business and Enterprise.
 {% endhint %}
 
-### Instance bootstrapping
+***
+
+## Instance bootstrapping
+
+**Released:** 2026-04-28 in [n8n 2.19](release-notes.md#n8n219)
 
 n8n can now be fully configured at startup through environment variables. Owner accounts, SSO (OIDC and SAML), security policies, and log streaming destinations are all applied on first boot, with no manual UI interaction required. Fields managed this way are locked in the UI and re-applied on every restart.
 
@@ -411,11 +413,9 @@ The NVIDIA Nemotron Embeddings node generates embeddings from NeMo Retriever mod
 
 ***
 
-## Embedded access and execution data redaction
+## Token exchange authentication for embedded access
 
 **Released:** 2026-04-07 in [n8n 2.16](release-notes.md#n8n216)
-
-### Token exchange authentication for embedded access
 
 n8n now supports OAuth 2.0 Token Exchange (RFC 8693) as a second authentication mechanism alongside API keys. Two scenarios are covered: seamless iframe embedding, where users see n8n inside another product without a separate login screen, and delegated API access, where a system acts on behalf of a user with full audit attribution.
 
@@ -425,7 +425,11 @@ The embedding system holds an asymmetric private key and signs short-lived JWTs 
 **Availability:** Enterprise. Requires an asymmetric key pair configured via `N8N_TOKEN_EXCHANGE_TRUSTED_KEYS`. Uses role-based scoping.
 {% endhint %}
 
-### Execution data redaction
+***
+
+## Execution data redaction
+
+**Released:** 2026-04-07 in [n8n 2.16](release-notes.md#n8n216)
 
 Instance and project admins can now redact execution data. When enabled, sensitive data from production runs is never displayed in the UI, and isn't fetched from the database until a user with the reveal permission explicitly requests it. Manual executions can be left fully visible so developers can keep building and debugging without interruption. Every reveal is logged as an audit event.
 
@@ -434,11 +438,6 @@ Redaction is configured per workflow under **Workflow settings**, and reveal acc
 {% hint style="info" %}
 **Availability:** Enterprise.
 {% endhint %}
-
-### Public API improvements
-
-* **Community packages.** Install, list, update, and uninstall community packages programmatically through new endpoints under `/api/v1/community-packages`. Each operation requires an API key with the matching `communityPackage:*` scope.
-* **Insights scope.** A new `insights:read` API key scope, setting up the insights summary endpoint that ships in n8n 2.17.
 
 ***
 
@@ -473,13 +472,21 @@ This is the foundational T1 feature. It was extended across later releases: node
 
 n8n now connects natively to Databricks. The new node runs SQL with asynchronous polling and chunked results (each row arrives as its own item), manages Unity Catalog objects (catalogs, schemas, tables, volumes, and functions), calls Model Serving endpoints with automatic input detection and validation, interacts with Genie AI, handles file operations up to 5 GiB, and manages Vector Search indexes. Lakehouse data can flow through the same workflows as the rest of your stack, without custom HTTP wiring. Learn more in the [Databricks node documentation](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.databricks).
 
-### Perplexity node v2
+***
 
-The [Perplexity node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-langchain.perplexity) moves to v2 with full API coverage while keeping v1 workflows compatible: agent responses with third-party models, tools, and JSON-schema structured outputs; raw search with advanced filters; and embeddings, including contextualized embeddings.
+## Perplexity node v2
 
-### See what depends on what
+**Released:** 2026-03-24 in [n8n 2.14](release-notes.md#n8n214)
 
-Workflow, credential, and data table cards, as well as the data table detail view, now show dependency information, so you can check what relies on a resource before you delete or change it.
+The [Perplexity node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-langchain.perplexity) moves to v2 with full API coverage, and existing v1 workflows keep working. Agent responses now handle third-party models, tool calls, and JSON-schema structured output, so results come back in a shape the next node can parse. Raw search gains advanced filters, and the node adds embeddings, including contextualized embeddings.
+
+***
+
+## See what depends on what
+
+**Released:** 2026-03-24 in [n8n 2.14](release-notes.md#n8n214)
+
+Before you delete or change a resource, you can now see what relies on it. Workflow, credential, and data table cards show dependency information, as does the data table detail view. Previously you had to open everything that might reference a credential or table and check by hand, or find out after the change broke something.
 
 ***
 
@@ -493,31 +500,22 @@ Open version history, click **Compare changes**, pick any two versions, and the 
 **Availability:** Pro, Business, and Enterprise.
 {% endhint %}
 
-### Project-scoped external secrets: full team access
+***
 
-What's new:
+## Project-scoped external secrets
 
-* Project admins manage their own vault connections from project settings.
-* Project editors can use project-scoped secrets in credentials once the instance admin enables access.
-* [Custom roles](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-roles) now include five secrets scopes: list, read, create, update, and delete.
-* Instance admins/owners no longer need to be project members for secrets to resolve.
+**Released:** 2026-03-16 in [n8n 2.13](release-notes.md#n8n213)
 
-**For instance admins:** go to **Settings > External Secrets** and enable the **System Roles** toggle, or use custom roles for more granular control.
+Vault connections can now be scoped to a single project. Secrets from that connection appear only in that project's credentials, not across the instance, and instance-level connections are unaffected. This shipped in two halves: instance admins could create project-scoped connections first, and project teams got self-service access in the following release.
 
-**For project admins:** go to **Project Settings > External Secrets** to create and manage project-level connections. Instance-level connections shared with you appear as read-only.
+_Instance admin setup released in n8n 2.11 (2026-03-02)._ Instance admins create a project-scoped connection from **Settings > External Secrets**.
+
+_Full team access released in n8n 2.13 (2026-03-16)._ Project admins now manage their own vault connections from **Project Settings > External Secrets**. Instance-level connections shared with them appear as read-only. Project editors can use project-scoped secrets in credentials once an instance admin enables access with the **System Roles** toggle under **Settings > External Secrets**, or through custom roles for finer control. [Custom roles](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-roles) gained five secrets scopes: list, read, create, update, and delete. Instance admins and owners no longer need to be project members for secrets to resolve.
 
 Refer to [External secrets](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/manage-credentials/use-external-secret-stores) for more information.
 
 {% hint style="info" %}
 **Availability:** Enterprise.
-{% endhint %}
-
-### Folder-based filtering in the push and pull dialog
-
-The push and pull dialogs now include a **Folder** filter alongside Status and Owner. Selecting a folder scopes the list to workflows in that folder and its subfolders, shown as a hierarchical tree with folder-level checkboxes. Text search also matches folder names.
-
-{% hint style="info" %}
-**Availability:** Enterprise. Requires [Environments](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/use-source-control-and-environments/set-up-source-control) configured.
 {% endhint %}
 
 ***
@@ -560,31 +558,11 @@ Things to keep in mind:
 **Availability:** Cloud only.
 {% endhint %}
 
-### Custom roles: Assignments tab
-
-Instance admins now have a dedicated **Assignments** tab on each [custom role](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-roles) showing every user assigned to that role, which project they're in, and a direct link to manage them, with no more navigating project by project.
-
-### Project-scoped external secrets: instance admin setup
-
-Instance admins can now create vault connections scoped to a specific project. Secrets from that connection appear only within that project's credentials, not across the instance. Instance-level connections are unaffected. Refer to [External secrets](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/manage-credentials/use-external-secret-stores) for more information.
-
-### Workflow execute as a separate permission scope
-
-`workflow:execute` is now a distinct scope in [custom project roles](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-roles), separate from editing and publishing. Users can be granted run access without being able to modify the workflow, which is a common compliance requirement for sensitive workflows.
-
-{% hint style="info" %}
-**Availability:** Custom roles and project-scoped external secrets are available on Enterprise.
-{% endhint %}
-
 ***
 
-## Personal space policies and finer-grained governance
+## Personal space policies
 
-**Released:** 2026-02-09 – 2026-02-13 in [n8n 2.8.0–2.8.3](release-notes.md#n8n28)
-
-### Personal space policies
-
-_Released in n8n 2.8.3 (2026-02-13)._
+**Released:** 2026-02-13 in [n8n 2.8.3](release-notes.md#n8n28)
 
 A new **Security & policies** settings section provides a central place for enforcing security requirements on your instance. In addition to the existing two-factor authentication enforcement, admins can now control what users can do in their personal spaces.
 
@@ -597,39 +575,8 @@ This release builds on recent updates to the permissions model, including [custo
 
 <figure><img src=".gitbook/assets/personal_space_policies.png" alt="The new Security &#x26; policies settings section"><figcaption><p>The new Security &#x26; policies settings section</p></figcaption></figure>
 
-### Custom roles: improved discoverability and permission visibility
-
-_Released in n8n 2.8.3 (2026-02-13)._
-
-The project role selector now separates built-in system roles and custom roles into distinct sections, making it easier to find and choose the right role. Hovering over a role shows a summary of its configured permissions, with an option to view the full permission details.
-
-<figure><img src=".gitbook/assets/custom_roles_selector.png" alt="System roles and custom roles are now displayed in separate sections"><figcaption><p>System roles and custom roles are now displayed in separate sections</p></figcaption></figure>
-
-### Stronger external secrets validation
-
-_Released in n8n 2.8.0 (2026-02-09)._
-
-n8n now verifies that the current user has access to the referenced vaults before allowing a credential that uses `$secrets...` expressions to be saved. If access is missing, the save operation fails. This prevents secret values from being exposed through guessed secret paths.
-
-### Improved API auditability
-
-_Released in n8n 2.8.0 (2026-02-09)._
-
-API endpoints have been expanded to provide clearer visibility into project membership and credentials:
-
-* `GET /projects/{projectId}/users` returns all members of a project including their assigned role.
-* `GET /credentials` returns a paginated list of all credentials across the instance, including the project they belong to.
-
-This makes it easier to audit who has access to which projects and credentials without manually reviewing each one in the UI.
-
-### More granular workflow permissions
-
-_Released in n8n 2.8.0 (2026-02-09)._
-
-Workflow publishing permissions for [custom roles](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-roles) have been split into two separate scopes: `workflow:publish` and `workflow:unpublish`. This enables more precise access control in governance scenarios where unpublishing needs to be managed independently.
-
 {% hint style="info" %}
-**Availability:** Personal space policies, custom roles, stronger external secrets validation, and improved API auditability are available on Enterprise.
+**Availability:** Enterprise.
 {% endhint %}
 
 ***
@@ -689,15 +636,17 @@ Human in the loop for the Chat node
 
 ***
 
-## TLS for Syslog log streaming and credential updates via API
+## TLS support for Syslog log streaming
 
 **Released:** 2026-01-12 in [n8n 2.4](release-notes.md#n8n24)
 
-### TLS support for Syslog log streaming
+The Syslog log streaming destination now supports TLS over TCP. Previously it sent log events unencrypted, which ruled it out for SIEM and observability platforms that require encrypted transport. Enable TLS on the destination and point it at your platform's TLS port, and n8n streams audit and execution events over an encrypted connection.
 
-The Syslog log streaming destination now supports TLS over TCP for encrypted connections. This enables secure log streaming to enterprise SIEM and observability platforms that require encrypted transport. With this release, log streaming is now compatible with a broader range of enterprise SIEM platforms.
+***
 
-### Update credentials via API
+## Update credentials via API
+
+**Released:** 2026-01-12 in [n8n 2.4](release-notes.md#n8n24)
 
 n8n's public API now supports updating existing credentials by ID via a new `PATCH /credentials/:id` endpoint. Previously, credentials could only be created through the API, so any changes required deleting and recreating the credential.
 
@@ -705,11 +654,9 @@ When updating, you can either replace all credential data at once (useful for bu
 
 ***
 
-## Finer-grained workflow permissions and richer audit events
+## More granular workflow permissions in custom project roles
 
 **Released:** 2025-12-22 in [n8n 2.2](release-notes.md#n8n22)
-
-### More granular workflow permissions within Custom Project Roles
 
 Custom Project Roles allow you to define fine-grained permissions at the project level. With this release, workflow permissions have been further refined by separating workflow editing from workflow publishing.
 
@@ -721,7 +668,11 @@ This change makes it easier to align access controls with internal processes whe
 **Availability:** Enterprise.
 {% endhint %}
 
-### Log streaming: more audit events for improved observability
+***
+
+## Log streaming: more audit events for improved observability
+
+**Released:** 2025-12-22 in [n8n 2.2](release-notes.md#n8n22)
 
 Log streaming now includes additional audit events to improve visibility into operational and security-relevant changes.
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -42,7 +42,7 @@ Learn more in the [Microsoft Excel (SharePoint) node documentation](https://app.
 
 You can now get a full audit trail for every human-in-the-loop step in your workflows. Every Send and Wait node across Slack, Telegram, Discord, WhatsApp, Google Chat, Gmail, Outlook, Email/SMTP, Microsoft Teams, and the Chat Trigger node now includes a `respondedAt` ISO-8601 timestamp in its output the moment n8n receives a response. No configuration is required: the field appears automatically alongside the existing `approved`, `text`, or `form` fields and does not change the output shape for existing workflows.
 
-For Slack and Telegram, you can go further with the new **Advanced Interactivity** options on the Send and Wait for Response operation. Approvers respond with a single tap or click inside the app itself, and the node output records who responded: their ID, name, username, and (for Slack, when scopes allow) email, plus the channel and message ID. You can restrict which users are allowed to approve by listing their IDs in **Restrict Who Can Approve**. Anyone not on the list gets a private notice you can word yourself, and the workflow keeps waiting. You can also control what happens to the message after a decision with the **After Decision** setting: show the outcome and remove the buttons (the default), remove the buttons only, or leave the message unchanged.
+For Slack and Telegram, you can go further with the new Advanced Interactivity options on the Send and Wait for Response operation. Approvers respond with a single tap or click inside the app itself, and the node output records who responded: their ID, name, username, and (for Slack, when scopes allow) email, plus the channel and message ID. You can restrict which users are allowed to approve by listing their IDs in Restrict Who Can Approve. Anyone not on the list gets a private notice you can word yourself, and the workflow keeps waiting. You can also control what happens to the message after a decision with the After Decision setting: show the outcome and remove the buttons (the default), remove the buttons only, or leave the message unchanged.
 
 To enable approvals in Slack, your n8n instance must be reachable from Slack over public HTTPS. You will need to turn on Interactivity in your Slack app, set the **Request URL** to `https://<your-n8n-instance>/webhook-waiting-slack`, and paste your app's signing secret into the **Signature Secret** field of your Slack credential. Then, in the Slack node, set **Response Type** to **Approval** and turn on **Capture Who Responded** under the **Advanced Interactivity** section. For Telegram, your instance must be reachable over public HTTPS on a port Telegram supports for webhooks (443, 80, 88, or 8443). Enable **Approve Within Chat** in the same section: n8n registers the webhook for you using your existing Telegram credential, with no additional setup on Telegram's side.
 
@@ -155,11 +155,11 @@ Learn more in the [Canvas Groups documentation](https://app.gitbook.com/s/rPN1zU
 
 **Released:** 2026-06-23 in [n8n 2.28](release-notes.md#n8n228)
 
-The [GitHub node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.github) now has a dedicated **Pull Request** resource. The whole life of a pull request is available as node operations, instead of hand-rolled HTTP Request calls against the GitHub API.
+The [GitHub node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.github) now has a dedicated Pull Request resource. The whole life of a pull request is available as node operations, instead of hand-rolled HTTP Request calls against the GitHub API.
 
 Create a pull request from one branch into another, including drafts and PRs from a fork. Update its title, body, state, or base branch as it moves along, and close or reopen it. Fetch a single PR to read its current state, and create or edit comments on it. Merge with the method your repository is configured for: merge commit, squash, or rebase, with merge queues handled for you.
 
-Two operations return the change itself rather than its metadata. **Get Diff** and **Get Patch** fetch the raw diff and patch, which is what makes a pull request usable as workflow input. Hand the diff to an AI agent for a first-pass review, scan it for files that need sign-off, or post a summary to the repository's channel.
+Two operations return the change itself rather than its metadata. Get Diff and Get Patch fetch the raw diff and patch, which is what makes a pull request usable as workflow input. Hand the diff to an AI agent for a first-pass review, scan it for files that need sign-off, or post a summary to the repository's channel.
 
 All of this was possible with the HTTP Request node, but you had to know the REST paths, assemble the payload for each call, and interpret GitHub's responses yourself. The native operations take a repository and the fields each operation needs. Errors surface exactly as GitHub returns them, so a refused merge tells you why.
 
@@ -169,7 +169,7 @@ Refer to the [GitHub node documentation](https://app.gitbook.com/s/BKcbOzIWja8Nf
 
 **Released:** 2026-06-23 in [n8n 2.28](release-notes.md#n8n228)
 
-The [Webhook node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.webhook) gains an expression-based **Only run if** option that rejects requests that don't match a condition before an execution starts. Filter out health checks, retries, or irrelevant events at the door instead of starting a run that immediately exits: fewer no-op executions, less noise in your execution list, and saved execution quota.
+The [Webhook node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.webhook) gains an expression-based Only run if option that rejects requests that don't match a condition before an execution starts. Filter out health checks, retries, or irrelevant events at the door instead of starting a run that immediately exits: fewer no-op executions, less noise in your execution list, and saved execution quota.
 
 ## One credential for multiple Microsoft nodes
 
@@ -227,7 +227,7 @@ Your AI agents can now search the web out of the box. Enable web search from the
 
 **Released:** 2026-06-02 in [n8n 2.25](release-notes.md#n8n2251)
 
-The [Form Trigger](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.formtrigger) (node version 2.6 and later) adds an **n8n User Auth** authentication option. It limits a form to people signed in to your n8n instance. Select it from the node's **Authentication** dropdown and the form stops being public. Visitors who aren't signed in are redirected to the n8n login page, and a submission without a valid session is rejected with a 401.
+The [Form Trigger](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.formtrigger) (node version 2.6 and later) adds an n8n User Auth authentication option. It limits a form to people signed in to your n8n instance. Select it from the node's **Authentication** dropdown and the form stops being public. Visitors who aren't signed in are redirected to the n8n login page, and a submission without a valid session is rejected with a 401.
 
 This is about attribution as much as access. Every submission carries the authenticated user's ID, email, and first and last name alongside the form fields, taken from their n8n account rather than from anything they typed. Nobody can file a request under a colleague's name, and you don't need to ask for an email address at all. Downstream nodes can act on the submitter: open the ticket under their name, send the confirmation to their real address, or check them against an approver list. To keep those details out of your execution data, turn off **Include User in Output**.
 
@@ -283,7 +283,7 @@ This is part of a broader hardening pass across releases: the Linear Trigger gai
 
 **Released:** 2026-05-12 in [n8n 2.21](release-notes.md#n8n221)
 
-The [Jira node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.jira) and [Jira Trigger](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/trigger-nodes/n8n-nodes-base.jiratrigger) add a **Cloud (OAuth2)** authentication option using Atlassian's OAuth 2.0 authorization code flow (3LO). Connect through auth.atlassian.com with your Atlassian cloud ID resolved and cached automatically. No more creating and rotating API tokens by hand for Jira Cloud.
+The [Jira node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.jira) and [Jira Trigger](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/trigger-nodes/n8n-nodes-base.jiratrigger) add a Cloud (OAuth2) authentication option using Atlassian's OAuth 2.0 authorization code flow (3LO). Connect through auth.atlassian.com with your Atlassian cloud ID resolved and cached automatically. No more creating and rotating API tokens by hand for Jira Cloud.
 
 ## Microsoft Agent 365 Trigger node
 
@@ -311,7 +311,7 @@ Self-hosted instances can now retain insights data for up to 365 days by default
 
 Instance admins can now define group-to-role mappings inside n8n instead of encoding n8n-specific role logic in the IdP. With JIT provisioning enabled, admins write expressions against SAML attributes or OIDC claims to assign instance and project roles automatically at login. The IdP only needs to send standard group membership data: n8n handles the mapping, and role assignments are re-evaluated on every login, so access stays in sync without IdP changes.
 
-Open **Settings → SSO**, pick **Instance roles via SSO** or **Instance and project roles via SSO** under User role provisioning, switch the mapping card from "Map rules on your IdP" to "Map rules inside n8n", and add expressions using the `$claims` object to match users for each role. Expression-based matching handles non-standard group structures that plain string matching can't reach.
+Open **Settings > SSO**, pick **Instance roles via SSO** or **Instance and project roles via SSO** under User role provisioning, switch the mapping card from "Map rules on your IdP" to "Map rules inside n8n", and add expressions using the `$claims` object to match users for each role. Expression-based matching handles non-standard group structures that plain string matching can't reach.
 
 {% hint style="info" %}
 **Availability:** Business and Enterprise.
@@ -373,7 +373,7 @@ The embedding system holds an asymmetric private key and signs short-lived JWTs 
 
 Instance and project admins can now redact execution data. When enabled, sensitive data from production runs is never displayed in the UI, and isn't fetched from the database until a user with the reveal permission explicitly requests it. Manual executions can be left fully visible so developers can keep building and debugging without interruption. Every reveal is logged as an audit event.
 
-Redaction is configured per workflow under **Workflow settings**, and reveal access is granted via project or instance settings to specific users only. See the [execution data redaction docs](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/security/redact-execution-data).
+Redaction is configured per workflow under Workflow settings, and reveal access is granted via project or instance settings to specific users only. See the [execution data redaction docs](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/security/redact-execution-data).
 
 {% hint style="info" %}
 **Availability:** Enterprise.
@@ -486,7 +486,7 @@ Things to keep in mind:
 
 **Released:** 2026-02-13 in [n8n 2.8.3](release-notes.md#n8n28)
 
-A new **Security & policies** settings section provides a central place for enforcing security requirements on your instance. In addition to the existing two-factor authentication enforcement, admins can now control what users can do in their personal spaces.
+A new Security & policies settings section provides a central place for enforcing security requirements on your instance. In addition to the existing two-factor authentication enforcement, admins can now control what users can do in their personal spaces.
 
 Available policies include:
 
@@ -542,12 +542,12 @@ Human in the loop for AI tool calls
 
 **Released:** 2026-01-20 in [n8n 2.5](release-notes.md#n8n25)
 
-The **Chat** node now includes two new actions for human-in-the-loop interactions in agentic workflows:
+The Chat node now includes two new actions for human-in-the-loop interactions in agentic workflows:
 
 * **Send a message**: send a message to the user and continue the workflow.
 * **Send a message and wait for response**: send a message and pause execution until the user replies. Users can respond with free text in the Chat or by clicking inline approval buttons, as defined in the node's configuration.
 
-These actions can be used as deterministic workflow steps or as tools for an **AI Agent**, enabling multi-turn human interaction within a single execution when using the **Chat Trigger**.
+These actions can be used as deterministic workflow steps or as tools for an AI Agent, enabling multi-turn human interaction within a single execution when using the Chat Trigger.
 
 When used as an agent tool, the agent can ask for clarification before proceeding, helping it better interpret user intent and follow instructions. Agents can also send updates during long-running workflows using these actions.
 
@@ -556,7 +556,7 @@ To set this up:
 1. Trigger your workflow with the **Chat Trigger** node. In the node parameters, add the **Response Mode** option and set it to **Using Response Nodes**.
 2. Add a **Chat** node later in the workflow, or add it as a tool for an **AI Agent**. Select one of the operations: **Send a message** or **Send a message and wait for response**.
 
-Keep in mind: if you want an AI Agent to choose between sending a message or waiting for input, add two **Chat** tool nodes, one for each action. For AI Agents triggered by the **Chat Trigger** node, adding **Send a message and wait for response** is recommended so the agent can request clarification when needed.
+Keep in mind: if you want an AI Agent to choose between sending a message or waiting for input, add two Chat tool nodes, one for each action. For AI Agents triggered by the Chat Trigger node, adding Send a message and wait for response is recommended so the agent can request clarification when needed.
 
 Learn more in the [Chat node documentation](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-langchain.chat#operation).
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -508,7 +508,7 @@ Open version history, click **Compare changes**, pick any two versions, and the 
 
 Vault connections can now be scoped to a single project. Secrets from that connection appear only in that project's credentials, not across the instance, and instance-level connections are unaffected. This shipped in two halves: instance admins could create project-scoped connections first, and project teams got self-service access in the following release.
 
-_Instance admin setup released in n8n 2.11 (2026-03-02)._ Instance admins create a project-scoped connection from **Settings > External Secrets**.
+_Instance admin setup released in n8n 2.11 (2026-03-03)._ Instance admins create a project-scoped connection from **Settings > External Secrets**.
 
 _Full team access released in n8n 2.13 (2026-03-16)._ Project admins now manage their own vault connections from **Project Settings > External Secrets**. Instance-level connections shared with them appear as read-only. Project editors can use project-scoped secrets in credentials once an instance admin enables access with the **System Roles** toggle under **Settings > External Secrets**, or through custom roles for finer control. [Custom roles](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-roles) gained five secrets scopes: list, read, create, update, and delete. Instance admins and owners no longer need to be project members for secrets to resolve.
 
@@ -543,7 +543,7 @@ Requires a self-hosted 1Password Connect Server with read-only access.
 
 ## Easier credential setup on Cloud
 
-**Released:** 2026-03-02 in [n8n 2.11](release-notes.md#n8n211)
+**Released:** 2026-03-03 in [n8n 2.11](release-notes.md#n8n211)
 
 Setting up credentials on n8n Cloud is now much simpler. For supported services, just click the **Connect** button, authenticate with the service, and you're ready to go. Skip the manual setup for Slack, Firecrawl, HubSpot, GitHub, Google Calendar, PagerDuty, Apify, and more.
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -14,8 +14,6 @@ Old-style release notes pages for [2.x](release-notes-2.x.md), [1.x](release-not
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/iFLUKG9zJaouigaM7IOo/" %}
 
-***
-
 ## Return webhook responses of any size from your workers
 
 **Released:** 2026-08-04 in [n8n 2.34](release-notes.md#n8n234)
@@ -28,8 +26,6 @@ Offloading needs a `N8N_DEFAULT_BINARY_DATA_MODE` that stores data (any mode exc
 
 Refer to [Large webhook responses](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/scaling/enable-queue-mode#large-webhook-responses) for the full configuration, upgrade order, and troubleshooting.
 
-***
-
 ## Read and write SharePoint Excel workbooks directly in n8n
 
 **Released:** 2026-07-28 in [n8n 2.33](release-notes.md#n8n233)
@@ -39,8 +35,6 @@ You can now read and write Excel workbooks stored in SharePoint document librari
 The node supports two authentication methods: sign in as a person using a Microsoft OAuth2 credential with the `Sites.ReadWrite.All` (or `Sites.Read.All`) scope, or sign in as an app using a Microsoft Entra Service Principal credential for unattended workflows that require no user interaction.
 
 Learn more in the [Microsoft Excel (SharePoint) node documentation](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.microsoftexcelsharepoint).
-
-***
 
 ## Capture who approved and when in human-in-the-loop steps
 
@@ -54,8 +48,6 @@ To enable approvals in Slack, your n8n instance must be reachable from Slack ove
 
 Learn more in the [Approvals in Slack documentation](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.slack/approvals).
 
-***
-
 ## App-only authentication for Microsoft nodes
 
 **Released:** 2026-07-07 in [n8n 2.30](release-notes.md#n8n230)
@@ -66,15 +58,11 @@ Until now, Microsoft automations were tied to a person's OAuth session: when tha
 
 _OneDrive and Outlook support released in n8n 2.29 (2026-06-30)._
 
-***
-
 ## mTLS authentication for Kafka
 
 **Released:** 2026-07-07 in [n8n 2.30](release-notes.md#n8n230)
 
 The [Kafka credential](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/credentials/kafka) now supports mutual TLS: provide a CA certificate, client certificate, and private key (PEM) to connect to brokers that require client-certificate authentication. mTLS applies to the Kafka node, the Kafka Trigger, and the credential test, and n8n validates that certificate and key match before you save.
-
-***
 
 ## AI Assistant: describe a goal, get a working automation
 
@@ -98,8 +86,6 @@ Learn more in the [AI Assistant documentation](https://app.gitbook.com/s/rPN1zU5
 **Availability:** n8n Cloud only. Self-hosted support is coming.
 {% endhint %}
 
-***
-
 ## MCP server updates
 
 **Released:** 2026-06-30 in [n8n 2.29](release-notes.md#n8n229)
@@ -117,8 +103,6 @@ We've shipped a number of updates to the n8n MCP server over the past few weeks.
 
 Learn more in the [n8n MCP server documentation](https://app.gitbook.com/s/r7wKI4I1BgdBCuq5Cvcx/connect-to-n8n-mcp-server).
 
-***
-
 ## GitHub App authentication
 
 **Released:** 2026-06-30 in [n8n 2.29](release-notes.md#n8n229)
@@ -132,8 +116,6 @@ A GitHub App belongs to the organization. You register it once and install it on
 To set it up, create the App in your organization settings, install it, and generate a private key. In n8n, create a GitHub App credential and enter the App ID, the Installation ID, and that private key. n8n signs the JWT, exchanges it for an installation access token, and refreshes the token as it expires, so there is nothing to rotate on a schedule.
 
 Existing credentials are untouched. Personal access token and OAuth2 stay available and stay selected on saved nodes, so this is an option to move to rather than a migration.
-
-***
 
 ## Insights alerts you when date ranges exceed available data
 
@@ -155,8 +137,6 @@ Learn more in the [insights retention documentation](https://app.gitbook.com/s/w
 **Availability:** Pro, Business, and Enterprise.
 {% endhint %}
 
-***
-
 ## Organize large workflows with Canvas Groups
 
 **Released:** 2026-06-23 in [n8n 2.28](release-notes.md#n8n228)
@@ -170,8 +150,6 @@ To create a group, select a connected run of nodes by dragging a box around them
 A Canvas Group is saved with the workflow, so anyone who opens it sees the same structure. Whether a group is collapsed or expanded is a personal preference stored in your browser, so your view stays put when you come back without changing what teammates see. A few rules decide which nodes you can combine into one group: triggers stay outside them, the nodes have to form one connected chain, and an AI node keeps its sub-nodes (chat model, memory, and tools) inside the same group.
 
 Learn more in the [Canvas Groups documentation](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/understand-workflows/workflow-components/canvas-groups).
-
-***
 
 ## GitHub node: manage the full pull request lifecycle
 
@@ -187,15 +165,11 @@ All of this was possible with the HTTP Request node, but you had to know the RES
 
 Refer to the [GitHub node documentation](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.github#operations) for the full list of operations.
 
-***
-
 ## Webhook node: Only Run If
 
 **Released:** 2026-06-23 in [n8n 2.28](release-notes.md#n8n228)
 
 The [Webhook node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.webhook) gains an expression-based **Only run if** option that rejects requests that don't match a condition before an execution starts. Filter out health checks, retries, or irrelevant events at the door instead of starting a run that immediately exits: fewer no-op executions, less noise in your execution list, and saved execution quota.
-
-***
 
 ## One credential for multiple Microsoft nodes
 
@@ -210,8 +184,6 @@ Nothing changes for existing workflows. On saved nodes the **Authentication** dr
 _Microsoft OneDrive support released in n8n 2.27 (2026-06-16)._
 
 Learn more in the [Microsoft credentials documentation](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/credentials/microsoft).
-
-***
 
 ## Move workflows between instances as packages
 
@@ -229,8 +201,6 @@ This feature is in **preview**. The package format and APIs are still under deve
 
 Learn more in the [n8n Packages documentation](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/n8n-packages).
 
-***
-
 ## Configure OpenTelemetry tracing from the UI
 
 **Released:** 2026-06-16 in [n8n 2.27](release-notes.md#n8n227)
@@ -247,15 +217,11 @@ On self-hosted instances, environment variables keep working and take precedence
 
 Learn more in the [OpenTelemetry tracing documentation](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/keep-n8n-running/trace-executions-with-opentelemetry).
 
-***
-
 ## Web search for AI agents
 
 **Released:** 2026-06-02 in [n8n 2.25](release-notes.md#n8n2251)
 
 Your AI agents can now search the web out of the box. Enable web search from the agent's Advanced panel: where the model provider offers a native search tool, the agent uses it directly, and for providers without one, n8n falls back to Brave Search or a self-hosted SearXNG instance. Until now, giving an agent live web access meant wiring up a community node or an external API by hand; now it's built in, so agents can ground their answers in current information like prices, docs, and news, without extra setup.
-
-***
 
 ## Form Trigger: restrict forms to logged-in users
 
@@ -267,8 +233,6 @@ This is about attribution as much as access. Every submission carries the authen
 
 That makes the Form Trigger a practical front door for internal requests: access requests, expense claims, IT tickets, anything where the submitter's identity matters. It works with every n8n login method, including SSO, so the form inherits the authentication your instance already enforces. It applies across every page of a multi-page form, not just the first.
 
-***
-
 ## Rebuilt Odoo node and Oracle vector search
 
 **Released:** 2026-05-27 in [n8n 2.23](release-notes.md#n8n223)
@@ -278,8 +242,6 @@ The [Odoo node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes
 ### Oracle Database as a vector store
 
 New [Oracle DB Vector Store](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstoreoracledb) and [Oracle ONNX Embedding](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsoracledb) nodes bring retrieval-augmented generation to data that lives in Oracle. Insert, load, and retrieve documents (including retrieve-as-tool for AI agents) with configurable distance strategies and metadata filtering that supports nested AND/OR conditions. Embeddings are generated by an ONNX model loaded in the database itself, so vectors and source data stay in one place. Requires an ONNX model in the database.
-
-***
 
 ## Connect to MCP servers with less setup
 
@@ -295,8 +257,6 @@ If you need to connect to an MCP server that isn't in the list, you can still us
 Connect to MCP servers with less setup
 {% endembed %}
 
-***
-
 ## OpenTelemetry custom telemetry tags
 
 **Released:** 2026-05-19 in [n8n 2.22](release-notes.md#n8n222)
@@ -309,8 +269,6 @@ Learn more in the [custom span attributes documentation](https://app.gitbook.com
 **Availability:** Enterprise.
 {% endhint %}
 
-***
-
 ## Verified webhooks across fourteen trigger nodes
 
 **Released:** 2026-05-12 in [n8n 2.21](release-notes.md#n8n221)
@@ -321,15 +279,11 @@ Verification uses each service's own signing mechanism, typically an HMAC signat
 
 This is part of a broader hardening pass across releases: the Linear Trigger gained an optional signing secret in n8n 2.18, Netlify verification shipped in n8n 2.20, and AWS SNS, Box, and Microsoft Teams followed in n8n 2.22.
 
-***
-
 ## Jira: OAuth2 authentication
 
 **Released:** 2026-05-12 in [n8n 2.21](release-notes.md#n8n221)
 
 The [Jira node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.jira) and [Jira Trigger](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/trigger-nodes/n8n-nodes-base.jiratrigger) add a **Cloud (OAuth2)** authentication option using Atlassian's OAuth 2.0 authorization code flow (3LO). Connect through auth.atlassian.com with your Atlassian cloud ID resolved and cached automatically. No more creating and rotating API tokens by hand for Jira Cloud.
-
-***
 
 ## Microsoft Agent 365 Trigger node
 
@@ -345,15 +299,11 @@ If you already use n8n with Microsoft services through individual nodes (Outlook
 
 For the full launch story, see the [n8n blog post](https://blog.n8n.io/deploy-n8n-agents-that-show-up-as-members-of-the-team-inside-microsoft-apps/).
 
-***
-
 ## Insights data duration
 
 **Released:** 2026-05-05 in [n8n 2.20](release-notes.md#n8n220)
 
 Self-hosted instances can now retain insights data for up to 365 days by default, with a configurable maximum of 730 days. Retention is controlled by the new `N8N_INSIGHTS_MAX_AGE_DAYS` environment variable and is no longer tied to license logic. See the [insights docs](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/observe-and-log/track-usage-with-insights).
-
-***
 
 ## IdP role mapping inside n8n
 
@@ -367,8 +317,6 @@ Open **Settings → SSO**, pick **Instance roles via SSO** or **Instance and pro
 **Availability:** Business and Enterprise.
 {% endhint %}
 
-***
-
 ## Instance bootstrapping
 
 **Released:** 2026-04-28 in [n8n 2.19](release-notes.md#n8n219)
@@ -381,15 +329,11 @@ This makes deployment configuration the single source of truth, so you can stand
 **Availability:** Enterprise.
 {% endhint %}
 
-***
-
 ## Favorites
 
 **Released:** 2026-04-21 in [n8n 2.18](release-notes.md#n8n218)
 
 You can now mark projects, folders, workflows, and data tables as [favorites](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/favorite-items), so the resources you work with every day are one click away instead of a search away.
-
-***
 
 ## New model providers: Moonshot Kimi and Alibaba Cloud Model Studio
 
@@ -411,8 +355,6 @@ _Released in n8n 2.26 (2026-06-09)._
 
 The NVIDIA Nemotron Embeddings node generates embeddings from NeMo Retriever models via build.nvidia.com or a self-hosted NIM, reusing the existing NVIDIA credential. The node automatically sets the right input type per call ("passage" when indexing, "query" when searching), preventing the silent retrieval-quality degradation that mismatched input types cause.
 
-***
-
 ## Token exchange authentication for embedded access
 
 **Released:** 2026-04-07 in [n8n 2.16](release-notes.md#n8n216)
@@ -425,8 +367,6 @@ The embedding system holds an asymmetric private key and signs short-lived JWTs 
 **Availability:** Enterprise. Requires an asymmetric key pair configured via `N8N_TOKEN_EXCHANGE_TRUSTED_KEYS`. Uses role-based scoping.
 {% endhint %}
 
-***
-
 ## Execution data redaction
 
 **Released:** 2026-04-07 in [n8n 2.16](release-notes.md#n8n216)
@@ -438,8 +378,6 @@ Redaction is configured per workflow under **Workflow settings**, and reveal acc
 {% hint style="info" %}
 **Availability:** Enterprise.
 {% endhint %}
-
-***
 
 ## OpenTelemetry support for workflows
 
@@ -464,15 +402,11 @@ This is the foundational T1 feature. It was extended across later releases: node
 **Availability:** Self-hosted only.
 {% endhint %}
 
-***
-
 ## Databricks node
 
 **Released:** 2026-03-24 in [n8n 2.14](release-notes.md#n8n214)
 
 n8n now connects natively to Databricks. The new node runs SQL with asynchronous polling and chunked results (each row arrives as its own item), manages Unity Catalog objects (catalogs, schemas, tables, volumes, and functions), calls Model Serving endpoints with automatic input detection and validation, interacts with Genie AI, handles file operations up to 5 GiB, and manages Vector Search indexes. Lakehouse data can flow through the same workflows as the rest of your stack, without custom HTTP wiring. Learn more in the [Databricks node documentation](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-base.databricks).
-
-***
 
 ## Perplexity node v2
 
@@ -480,15 +414,11 @@ n8n now connects natively to Databricks. The new node runs SQL with asynchronous
 
 The [Perplexity node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-langchain.perplexity) moves to v2 with full API coverage, and existing v1 workflows keep working. Agent responses now handle third-party models, tool calls, and JSON-schema structured output, so results come back in a shape the next node can parse. Raw search gains advanced filters, and the node adds embeddings, including contextualized embeddings.
 
-***
-
 ## See what depends on what
 
 **Released:** 2026-03-24 in [n8n 2.14](release-notes.md#n8n214)
 
 Before you delete or change a resource, you can now see what relies on it. Workflow, credential, and data table cards show dependency information, as does the data table detail view. Previously you had to open everything that might reference a credential or table and check by hand, or find out after the change broke something.
-
-***
 
 ## Visual diff in version history
 
@@ -499,8 +429,6 @@ Open version history, click **Compare changes**, pick any two versions, and the 
 {% hint style="info" %}
 **Availability:** Pro, Business, and Enterprise.
 {% endhint %}
-
-***
 
 ## Project-scoped external secrets
 
@@ -517,8 +445,6 @@ Refer to [External secrets](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/manag
 {% hint style="info" %}
 **Availability:** Enterprise.
 {% endhint %}
-
-***
 
 ## 1Password as an external secrets provider
 
@@ -539,8 +465,6 @@ Requires a self-hosted 1Password Connect Server with read-only access.
 **Availability:** Enterprise.
 {% endhint %}
 
-***
-
 ## Easier credential setup on Cloud
 
 **Released:** 2026-03-03 in [n8n 2.11](release-notes.md#n8n211)
@@ -557,8 +481,6 @@ Things to keep in mind:
 {% hint style="info" %}
 **Availability:** Cloud only.
 {% endhint %}
-
-***
 
 ## Personal space policies
 
@@ -579,8 +501,6 @@ This release builds on recent updates to the permissions model, including [custo
 **Availability:** Enterprise.
 {% endhint %}
 
-***
-
 ## Inspect a role's permissions before assigning it
 
 **Released:** 2026-02-13 in [n8n 2.8.3](release-notes.md#n8n28)
@@ -592,8 +512,6 @@ The project role selector now splits built-in system roles and [custom roles](ht
 {% hint style="info" %}
 **Availability:** Enterprise.
 {% endhint %}
-
-***
 
 ## Human-in-the-loop for AI tool calls
 
@@ -619,8 +537,6 @@ Get precise control over where human judgment is required, without limiting what
 {% embed url="https://youtu.be/B-_nIFI27VY" %}
 Human in the loop for AI tool calls
 {% endembed %}
-
-***
 
 ## Chat node: human-in-the-loop actions
 
@@ -648,8 +564,6 @@ Learn more in the [Chat node documentation](https://app.gitbook.com/s/BKcbOzIWja
 Human in the loop for the Chat node
 {% endembed %}
 
-***
-
 ## TLS support for Syslog log streaming
 
 **Released:** 2026-01-12 in [n8n 2.4](release-notes.md#n8n24)
@@ -660,8 +574,6 @@ The Syslog [log streaming](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/observ
 **Availability:** Enterprise.
 {% endhint %}
 
-***
-
 ## Update credentials via API
 
 **Released:** 2026-01-12 in [n8n 2.4](release-notes.md#n8n24)
@@ -669,8 +581,6 @@ The Syslog [log streaming](https://app.gitbook.com/s/wMJrGrimpx3PxCJpUswm/observ
 n8n's public API now supports updating existing credentials by ID via a new `PATCH /credentials/:id` endpoint. Previously, credentials could only be created through the API, so any changes required deleting and recreating the credential.
 
 When updating, you can either replace all credential data at once (useful for bulk updates) or set `isPartialData: true` to merge changes with existing data. Ideal for automated secret rotation or fixing individual values without losing your configuration.
-
-***
 
 ## More granular workflow permissions in custom project roles
 
@@ -686,8 +596,6 @@ This change makes it easier to align access controls with internal processes whe
 **Availability:** Enterprise.
 {% endhint %}
 
-***
-
 ## Log streaming: more audit events for improved observability
 
 **Released:** 2025-12-22 in [n8n 2.2](release-notes.md#n8n22)
@@ -701,8 +609,6 @@ Workflow settings updates are also logged with the specific parameters that chan
 {% hint style="info" %}
 **Availability:** Enterprise.
 {% endhint %}
-
-***
 
 ## Time Saved node
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -219,13 +219,13 @@ Learn more in the [OpenTelemetry tracing documentation](https://app.gitbook.com/
 
 ## Web search for AI agents
 
-**Released:** 2026-06-02 in [n8n 2.25](release-notes.md#n8n2251)
+**Released:** 2026-06-02 in [n8n 2.25.1](release-notes.md#n8n2251)
 
 Your AI agents can now search the web out of the box. Enable web search from the agent's Advanced panel: where the model provider offers a native search tool, the agent uses it directly, and for providers without one, n8n falls back to Brave Search or a self-hosted SearXNG instance. Until now, giving an agent live web access meant wiring up a community node or an external API by hand; now it's built in, so agents can ground their answers in current information like prices, docs, and news, without extra setup.
 
 ## Form Trigger: restrict forms to logged-in users
 
-**Released:** 2026-06-02 in [n8n 2.25](release-notes.md#n8n2251)
+**Released:** 2026-06-02 in [n8n 2.25.1](release-notes.md#n8n2251)
 
 The [Form Trigger](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.formtrigger) (node version 2.6 and later) adds an n8n User Auth authentication option. It limits a form to people signed in to your n8n instance. Select it from the node's **Authentication** dropdown and the form stops being public. Visitors who aren't signed in are redirected to the n8n login page, and a submission without a valid session is rejected with a 401.
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -77,7 +77,7 @@ AI Assistant supersedes the AI Workflow Builder, and the difference is autonomy.
 Every workflow it builds is a normal n8n workflow: a visible canvas you can open, inspect, edit, and publish, with step-by-step execution logs to audit, built on the 400+ integrations n8n already ships instead of rebuilt API connections. You stay in control throughout: high-impact actions such as publishing wait for your approval. This is an early first step, and we want your feedback on where to take it next.
 
 {% hint style="warning" %}
-This feature is in **preview**. It can make mistakes, and its behavior may change while it's in development. Always review generated workflows before using them in production.
+This feature is in preview. It can make mistakes, and its behavior may change while it's in development. Always review generated workflows before using them in production.
 {% endhint %}
 
 Learn more in the [AI Assistant documentation](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/ways-of-building-workflows/ai-assistant).
@@ -175,11 +175,11 @@ The [Webhook node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-n
 
 **Released:** 2026-06-23 in [n8n 2.28](release-notes.md#n8n228)
 
-The generic **Microsoft OAuth2 API** credential now works with Microsoft Excel 365, Outlook, Teams, To Do, and Graph Security, alongside OneDrive. Instead of registering a separate Microsoft Entra app for every Microsoft service you automate, you register one and grant it the delegated permissions your workflows need. To use it, open any supported node, set **Authentication** to **Microsoft OAuth2 (Graph)**, and select the credential. Your IT team approves and maintains a single app registration instead of one per service.
+The generic Microsoft OAuth2 API credential now works with Microsoft Excel 365, Outlook, Teams, To Do, and Graph Security, alongside OneDrive. Instead of registering a separate Microsoft Entra app for every Microsoft service you automate, you register one and grant it the delegated permissions your workflows need. To use it, open any supported node, set **Authentication** to **Microsoft OAuth2 (Graph)**, and select the credential. Your IT team approves and maintains a single app registration instead of one per service.
 
 Set the credential's **Scope** field to the space-separated permissions the nodes you use require, for example `Files.ReadWrite.All` for OneDrive and Excel, or `Mail.ReadWrite` and `Mail.Send` for Outlook, always including `openid` and `offline_access`. Some permissions, such as `SecurityEvents.ReadWrite.All` for Graph Security, need admin consent. If your organization runs on a sovereign cloud (US Government, US Government DOD, or China), set the **Microsoft Graph API Base URL** on the credential and every node using it picks it up.
 
-Nothing changes for existing workflows. On saved nodes the **Authentication** dropdown stays on the node-specific credential, so credentials like Microsoft Excel OAuth2 API keep working untouched. The generic credential is an additive option, not a replacement.
+Nothing changes for existing workflows. On saved nodes the Authentication dropdown stays on the node-specific credential, so credentials like Microsoft Excel OAuth2 API keep working untouched. The generic credential is an additive option, not a replacement.
 
 _Microsoft OneDrive support released in n8n 2.27 (2026-06-16)._
 
@@ -196,7 +196,7 @@ Imports are checked up front. If a conflict or an unresolved credential would bl
 This makes it easy to promote workflows from development to production, back up and restore an instance, hand a workflow to a teammate without sharing secrets, or migrate between instances.
 
 {% hint style="warning" %}
-This feature is in **preview**. The package format and APIs are still under development, and breaking changes may occur without a major version bump.
+This feature is in preview. The package format and APIs are still under development, and breaking changes may occur without a major version bump.
 {% endhint %}
 
 Learn more in the [n8n Packages documentation](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/n8n-packages).
@@ -339,7 +339,7 @@ You can now mark projects, folders, workflows, and data tables as [favorites](ht
 
 **Released:** 2026-04-13 in [n8n 2.17](release-notes.md#n8n217)
 
-Two model providers join n8n's AI lineup natively. **Moonshot Kimi** arrives as both a [chat-model sub-node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatmoonshot) for AI Agents (with a dynamic model list, defaulting to kimi-k2.5) and a [standalone node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-langchain.moonshot) with multi-turn chat, tool calling, built-in web search, thinking mode, JSON responses, and image analysis. [**Alibaba Cloud Model Studio**](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-langchain.alibabacloud) brings the Qwen family: chat with web search and agent-tool support, vision-language image analysis, text-to-image, and text- and image-to-video generation with automatic download of results.
+Two model providers join n8n's AI lineup natively. Moonshot Kimi arrives as both a [chat-model sub-node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.lmchatmoonshot) for AI Agents (with a dynamic model list, defaulting to kimi-k2.5) and a [standalone node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-langchain.moonshot) with multi-turn chat, tool calling, built-in web search, thinking mode, JSON responses, and image analysis. [Alibaba Cloud Model Studio](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/app-nodes/n8n-nodes-langchain.alibabacloud) brings the Qwen family: chat with web search and agent-tool support, vision-language image analysis, text-to-image, and text- and image-to-video generation with automatic download of results.
 
 More providers followed in later releases:
 
@@ -454,7 +454,7 @@ n8n now supports 1Password Connect Server as an [external secrets](https://app.g
 
 Secrets are fetched at runtime and never stored in n8n: 1Password stays the single source of truth. Multi-field items are available as structured sub-paths: `$secrets.<vault>.<item>.<field>`.
 
-**How to connect:**
+To connect:
 
 1. Deploy a 1Password Connect Server and create an access token scoped to the vaults n8n should read.
 2. In n8n, go to **Settings > External Secrets**, select **1Password**, and enter your Connect Server URL and token.
@@ -523,14 +523,14 @@ Human-in-the-loop (HITL) for AI tool calls enforces review directly at the tool 
 
 Because the review step is implemented using standard n8n integrations, approvals are not limited to a single user or interface. Decisions can be routed across people and systems, enforcing approval from the right person using the channels they already work in.
 
-**What you can do:**
+What you can do:
 
 * Require explicit human approval for any tool the agent can call, including the MCP Client tool or sub-workflows exposed as tools.
 * Apply approval selectively, so some tools execute autonomously while others require review.
 * Route approvals across users and channels (for example, send a Slack-initiated action for approval by another user via email).
 * Add safety checks for high-impact or potentially destructive operations without complex workflow patterns or brittle prompt logic.
 
-**How to use it:** on the connection from the AI Agent to the tool you want to gate, click the **+** icon and choose **Add human review step**. The Tools panel opens with nodes you can use to handle the review; select one and configure the approver, the message, and the available actions.
+To gate a tool, click the **+** icon on its connection from the AI Agent and choose **Add human review step**. The Tools panel opens with nodes you can use to handle the review; select one and configure the approver, the message, and the available actions.
 
 Get precise control over where human judgment is required, without limiting what your agent can do. Learn more in the [human-in-the-loop tools docs](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/integrate-ai/ai-examples/human-in-the-loop-for-tools).
 
@@ -551,10 +551,10 @@ These actions can be used as deterministic workflow steps or as tools for an **A
 
 When used as an agent tool, the agent can ask for clarification before proceeding, helping it better interpret user intent and follow instructions. Agents can also send updates during long-running workflows using these actions.
 
-**How to:**
+To set this up:
 
-1. Trigger your workflow with the **Chat Trigger** node. In the node parameters, add the _Response Mode_ option and set it to _Using Response Nodes_.
-2. Add a **Chat** node later in the workflow, or add it as a tool for an **AI Agent**. Select one of the operations: _Send a message_ or _Send a message and wait for response_.
+1. Trigger your workflow with the **Chat Trigger** node. In the node parameters, add the **Response Mode** option and set it to **Using Response Nodes**.
+2. Add a **Chat** node later in the workflow, or add it as a tool for an **AI Agent**. Select one of the operations: **Send a message** or **Send a message and wait for response**.
 
 Keep in mind: if you want an AI Agent to choose between sending a message or waiting for input, add two **Chat** tool nodes, one for each action. For AI Agents triggered by the **Chat Trigger** node, adding **Send a message and wait for response** is recommended so the agent can request clarification when needed.
 


### PR DESCRIPTION
Phase 2 of the changelog cleanup started in #5198, covering 2.19 and below, plus two page-wide formatting passes.

## Part 1: one entry per thing, 2.19 and below

Same three rules as #5198: one entry per thing, `###` only for items that make no sense outside their parent, and qualification decided separately from length.

**Five invented umbrellas split.** Their H2 was a name that existed only to hold two or more equal-weight features, with no lead prose because there was nothing to lead. No leads were written for them; they were split into their real constituent entries.

| Umbrella | Became |
| --- | --- |
| 2.19 IdP role mapping and instance bootstrapping | IdP role mapping inside n8n + Instance bootstrapping |
| 2.16 Embedded access and execution data redaction | Token exchange authentication for embedded access + Execution data redaction |
| 2.8 Personal space policies and finer-grained governance | Personal space policies + Inspect a role's permissions before assigning it |
| 2.4 TLS for Syslog log streaming and credential updates via API | TLS support for Syslog log streaming + Update credentials via API |
| 2.2 Finer-grained workflow permissions and richer audit events | More granular workflow permissions in custom project roles + Log streaming: more audit events |

**One roundup merged.** Project-scoped external secrets shipped in halves: instance-admin setup in 2.11, full team access in 2.13. The later completes the earlier, so it is one entry with per-version attribution inside it, dated to the newer half.

**Six items dropped** to Release notes, which already lists every one of them: Public API improvements (2.16), Folder-based filtering in the push and pull dialog (2.13), Custom roles Assignments tab and Workflow execute as a separate permission scope (2.11), and stronger external secrets validation, improved API auditability, and more granular workflow permissions (2.8).

Entries at 2.19 and below go from 15 to 23, and the 21 orphan H3s become 13 entries. The count rises rather than falls because the five umbrellas were concealing ten separately-shareable features behind names nobody shipped. The volume of *things documented* does fall: 33 items become 25.

Every dropped item was re-tested from scratch against "would we have written this up if it were the only thing in the release?", including at short-entry length, which did not exist when an earlier pass looked at this material. What went is an API mirror of an existing UI action, a filter added to a dialog, a tab inside an already-documented feature, security hardening rather than a capability, and the thinnest of three scope splits.

### Availability, verified against the docs

Three entries needed hints the old umbrella structure had lost or never carried:

- Both log streaming entries (2.4 Syslog TLS, 2.2 audit events) now carry `**Availability:** Enterprise.`, per [Log streaming](https://github.com/n8n-io/n8n-docs/blob/main/docs/administer/observe-and-log/stream-logs-to-external-systems.md): "Log Streaming is available on all Enterprise plans."
- The restored custom roles entry carries the same, per [Create custom roles](https://github.com/n8n-io/n8n-docs/blob/main/docs/administer/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-roles.md).

The 2.8 and 2.11 shared hints, which enumerated features that no longer live together, were rewritten to match what remains. The Syslog TLS entry also gained the real setup step from the destination reference: set the transport protocol to TLS rather than the default UDP, and supply the PEM CA certificate.

### One date fix

`release-notes.md` gives 2026-03-03 for n8n 2.11. The new roundup inherited 2026-03-02 from the pre-existing "Easier credential setup on Cloud" entry, which had the same wrong date. Both now match. A full audit of every date on the page against Release notes found one more, untouched here and left alone as out of scope: **Time Saved node** says 2025-12-16 where Release notes gives 2025-12-15.

## Part 2: drop the `***` dividers

All 47 removed. The H2 headline plus the bold `**Released:**` line under it already marks an entry boundary; the horizontal rules added weight without adding separation.

## Part 3: bold only where it earns its place

The repo style guide says "UI elements: bold" (`docs/contribute/style-guide-for-n8n-docs.md`, Text formatting). The page was both over- and under-applying it, and using italics as a competing convention for the same job. Bold now marks four things only:

1. The structural `**Released:**` and `**Availability:**` labels.
2. A UI control in an imperative step: "set **Authentication** to **Microsoft OAuth2 (Graph)**", "click **Compare changes**".
3. A settings navigation path: `**Settings > External Secrets**`.
4. The lead-in term of a bullet in a list of parallel items.

Everything else is plain, including node, resource, credential, and option names in a sentence that merely reports what shipped. What went: bold as emphasis ("in **preview**"), bold on brand names (Moonshot Kimi, Alibaba Cloud Model Studio), bold as a fake sub-heading ("What you can do:", "How to use it:", "How to:", "How to connect:"), and 15 descriptive UI mentions. Italic UI labels in the 2.5 Chat node entry became bold, so UI labels are formatted one way on the page rather than two. Also normalized `Settings → SSO` to the `>` separator used everywhere else.

Bold spans went from 172 to 122: 64 structural, 18 bullet labels, 40 UI controls in instructions.

## Verified

- 47 entries, each with a well-formed `**Released:**` line and exactly one blank line as separation.
- Every `#n8nXYZ` anchor resolves against `docs/changelog/release-notes.md`. `#n8n283` does not exist, so the two 2.8.3 entries point at `#n8n28`, the closest valid anchor.
- Page stays version-sorted newest first, not date-sorted.
- Only 3 `###` subsections left, all legitimate: MiniMax and NVIDIA Nemotron under New model providers, Oracle vector store under the Oracle entry.
- Every referenced `.gitbook/assets/` image exists, including `custom_roles_selector.png`, in use again.
- No em dashes, no absolute `docs.n8n.io` links, no "beta", no duplicate headlines. New prose measures median 16 words per sentence, max 26.
- All checks green, including `runner / vale`, which I expected to fail structurally on a multi-entry changelog PR and did not.

The `changelog-entry` skill has been updated for the divider removal and the bold rule. Note that Fabian's pipeline carries its own standalone prompt outside this repo, so its PRs will keep arriving with dividers and over-applied bold until that prompt is edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
