### PR TITLE
docs: add missing MCP OAuth2 API credentials page (DOC-2012)

### DIFF
--- a/docs/integrations/SUMMARY.md
+++ b/docs/integrations/SUMMARY.md
@@ -764,6 +764,7 @@
     * [Matrix credentials](builtin/credentials/matrix.md)
     * [Mattermost credentials](builtin/credentials/mattermost.md)
     * [Mautic credentials](builtin/credentials/mautic.md)
+    * [MCP credentials](builtin/credentials/mcp.md)
     * [Medium credentials](builtin/credentials/medium.md)
     * [MessageBird credentials](builtin/credentials/messagebird.md)
     * [Metabase credentials](builtin/credentials/metabase.md)

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md
@@ -24,15 +24,16 @@ The MCP Client Tool node is a [Model Context Protocol (MCP)](https://modelcontex
 {% hint style="info" %}
 **Credentials**
 
-The MCP Client Tool node supports [Bearer](../../credentials/httprequest.md#using-bearer-auth), generic [header](../../credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](../../credentials/httprequest.md#using-oauth2) authentication methods.
+The MCP Client Tool node supports [Bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](/integrations/builtin/credentials/mcp.md#using-oauth2) authentication methods.
 {% endhint %}
+
 
 ## Node parameters <a href="#node-parameters" id="node-parameters"></a>
 
 Configure the node with the following parameters.
 
 * **SSE Endpoint**: The SSE endpoint for the MCP server you want to connect to.
-* **Authentication**: The authentication method for authentication to your MCP server. The MCP tool supports [bearer](../../credentials/httprequest.md#using-bearer-auth), generic [header](../../credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](../../credentials/httprequest.md#using-oauth2) authentication. Select **None** to attempt to connect without authentication.
+* **Authentication**: The authentication method for authentication to your MCP server. The MCP tool supports [bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](/integrations/builtin/credentials/mcp.md#using-oauth2) authentication. Select **None** to attempt to connect without authentication.
 	* **Multiple Headers Auth**: Use this when your MCP server requires more than one header, for example an API key and a username. Add each header as a **Name** and **Value** pair in the credential. You can add as many headers as you need.
 * **Tools to Include**: Choose which tools you want to expose to the AI Agent:
 	* **All**: Expose all the tools given by the MCP server.

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md
@@ -33,7 +33,7 @@ The MCP Client Tool node supports [Bearer](../../credentials/httprequest.md#usin
 Configure the node with the following parameters.
 
 * **SSE Endpoint**: The SSE endpoint for the MCP server you want to connect to.
-* **Authentication**: The authentication method for authentication to your MCP server. The MCP tool supports [bearer](../../credentials/httprequest.md#using-bearer-auth), generic [header](../../credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](/../../credentials/mcp.md#using-oauth2) authentication. Select **None** to attempt to connect without authentication.
+* **Authentication**: The authentication method for authentication to your MCP server. The MCP tool supports [bearer](../../credentials/httprequest.md#using-bearer-auth), generic [header](../../credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](../../credentials/mcp.md#using-oauth2) authentication. Select **None** to attempt to connect without authentication.
 	* **Multiple Headers Auth**: Use this when your MCP server requires more than one header, for example an API key and a username. Add each header as a **Name** and **Value** pair in the credential. You can add as many headers as you need.
 * **Tools to Include**: Choose which tools you want to expose to the AI Agent:
 	* **All**: Expose all the tools given by the MCP server.

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md
@@ -24,7 +24,7 @@ The MCP Client Tool node is a [Model Context Protocol (MCP)](https://modelcontex
 {% hint style="info" %}
 **Credentials**
 
-The MCP Client Tool node supports [Bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](/integrations/builtin/credentials/mcp.md#using-oauth2) authentication methods.
+The MCP Client Tool node supports [Bearer](../../credentials/httprequest.md#using-bearer-auth), generic [header](../../credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](../../credentials/mcp.md#using-oauth2) authentication methods.
 {% endhint %}
 
 
@@ -33,7 +33,7 @@ The MCP Client Tool node supports [Bearer](/integrations/builtin/credentials/htt
 Configure the node with the following parameters.
 
 * **SSE Endpoint**: The SSE endpoint for the MCP server you want to connect to.
-* **Authentication**: The authentication method for authentication to your MCP server. The MCP tool supports [bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](/integrations/builtin/credentials/mcp.md#using-oauth2) authentication. Select **None** to attempt to connect without authentication.
+* **Authentication**: The authentication method for authentication to your MCP server. The MCP tool supports [bearer](../../credentials/httprequest.md#using-bearer-auth), generic [header](../../credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](/../../credentials/mcp.md#using-oauth2) authentication. Select **None** to attempt to connect without authentication.
 	* **Multiple Headers Auth**: Use this when your MCP server requires more than one header, for example an API key and a username. Add each header as a **Name** and **Value** pair in the credential. You can add as many headers as you need.
 * **Tools to Include**: Choose which tools you want to expose to the AI Agent:
 	* **All**: Expose all the tools given by the MCP server.

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcpClient.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcpClient.md
@@ -38,7 +38,7 @@ Configure the node with the following parameters.
 
 * **Server Transport**: The transport protocol used by the MCP Server endpoint you want to connect to.
 * **MCP Endpoint URL**: The URL of the external MCP Server. For example, `https://mcp.notion.com/mcp`.
-* **Authentication**: The authentication method for authentication to your MCP server. The MCP Client node supports [bearer](../credentials/httprequest.md#using-bearer-auth), generic [header](../credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](../credentials/httprequest.md#using-oauth2) authentication. Select **None** to attempt to connect without authentication.
+* **Authentication**: The authentication method for authentication to your MCP server. The MCP Client node supports [bearer](../credentials/httprequest.md#using-bearer-auth), generic [header](../credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](../credentials/mcp.md#using-oauth2) authentication. Select **None** to attempt to connect without authentication.
 	* **Multiple Headers Auth**: Use this when your MCP server requires more than one header, for example an API key and a username. Add each header as a **Name** and **Value** pair in the credential. You can add as many headers as you need.
 * **Tool**: Select the tool to use in the node. The list of tools is automatically fetched from the external MCP server.
 * **Input Mode**: 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcpClient.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcpClient.md
@@ -28,7 +28,7 @@ If you want to use MCP tools as tools for an AI Agent, use the [MCP Client Tool 
 {% hint style="info" %}
 **Credentials**
 
-The MCP Client node supports [Bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](/integrations/builtin/credentials/mcp.md#using-oauth2) authentication methods.
+The MCP Client node supports [Bearer](../credentials/httprequest.md#using-bearer-auth), generic [header](../credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](../credentials/mcp.md#using-oauth2) authentication methods.
 {% endhint %}
 
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcpClient.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.mcpClient.md
@@ -28,8 +28,9 @@ If you want to use MCP tools as tools for an AI Agent, use the [MCP Client Tool 
 {% hint style="info" %}
 **Credentials**
 
-The MCP Client node supports [Bearer](../credentials/httprequest.md#using-bearer-auth), generic [header](../credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](../credentials/httprequest.md#using-oauth2) authentication methods.
+The MCP Client node supports [Bearer](/integrations/builtin/credentials/httprequest.md#using-bearer-auth), generic [header](/integrations/builtin/credentials/httprequest.md#using-header-auth), multiple headers, and [OAuth2](/integrations/builtin/credentials/mcp.md#using-oauth2) authentication methods.
 {% endhint %}
+
 
 ## Node parameters <a href="#node-parameters" id="node-parameters"></a>
 

--- a/docs/integrations/builtin/credentials/mcp.md
+++ b/docs/integrations/builtin/credentials/mcp.md
@@ -1,0 +1,37 @@
+---
+title: MCP credentials
+description: Documentation for MCP credentials. Use these credentials to authenticate MCP servers in n8n, a workflow automation platform.
+contentType: [integration, reference]
+priority: medium
+---
+
+# MCP OAuth2 API credentials
+
+You can use these credentials to authenticate the following nodes:
+
+* [MCP Client Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md)
+
+## Prerequisites
+
+You need an MCP server that supports OAuth2 authentication. Refer to the [MCP specification's authorization guide](https://modelcontextprotocol.io/specification/basic/authorization) for details on how MCP servers implement OAuth2.
+
+## Supported authentication methods
+
+* OAuth2
+
+## Using OAuth2
+
+This credential extends n8n's generic [OAuth2 API credential](./httprequest.md#using-oauth2), with two additional fields for MCP's authorization flow:
+
+* **Use Dynamic Client Registration**: Turned on by default. When on, n8n automatically registers itself as an OAuth2 client with the MCP server ([RFC 7591](https://www.rfc-editor.org/rfc/rfc7591)), so you don't need to manually create an app or paste in a Client ID and Client Secret. Turn this off if your MCP server doesn't support Dynamic Client Registration, or if you already have a Client ID and Client Secret from the server's own developer settings. In that case, fill in the standard OAuth2 fields (**Authorization URL**, **Access Token URL**, **Client ID**, **Client Secret**) as you would for any generic OAuth2 credential.
+* **Resource URL**: Optional. The exact protected resource URL required by the MCP server. Leave this empty to let n8n discover it automatically from the server.
+
+{% hint style="info" %}
+**Having trouble with Dynamic Client Registration?**
+
+If you see errors related to a mismatched or invalid redirect URI during the OAuth2 flow, double-check that your MCP server's Dynamic Client Registration endpoint is configured to accept n8n's OAuth Redirect URL exactly as shown in the credential.
+{% endhint %}
+
+## Related resources
+
+Refer to the [MCP specification](https://modelcontextprotocol.io/specification/) and its [authorization guide](https://modelcontextprotocol.io/specification/basic/authorization) for more information about how MCP servers implement OAuth2 and Dynamic Client Registration.

--- a/docs/integrations/builtin/credentials/mcp.md
+++ b/docs/integrations/builtin/credentials/mcp.md
@@ -33,7 +33,3 @@ This credential extends n8n's generic [OAuth2 API credential](./httprequest.md#u
 
 If you see errors related to a mismatched or invalid redirect URI during the OAuth2 flow, double-check that your MCP server's Dynamic Client Registration endpoint is configured to accept n8n's OAuth Redirect URL exactly as shown in the credential.
 {% endhint %}
-
-## Related resources
-
-Refer to the [MCP specification](https://modelcontextprotocol.io/specification/) and its [authorization guide](https://modelcontextprotocol.io/specification/basic/authorization) for more information about how MCP servers implement OAuth2 and Dynamic Client Registration.

--- a/docs/integrations/builtin/credentials/mcp.md
+++ b/docs/integrations/builtin/credentials/mcp.md
@@ -1,12 +1,13 @@
 ---
 title: MCP credentials
 description: Documentation for MCP credentials. Use these credentials to authenticate MCP servers in n8n, a workflow automation platform.
-description: Documentation for MCP credentials. Use these credentials to authenticate MCP servers in n8n, a workflow automation platform.
 layout:
   description:
     visible: false
 contentType: [integration, reference]
-# MCP OAuth2 API credentials
+---
+
+# MCP credentials
 
 You can use these credentials to authenticate the following nodes:
 

--- a/docs/integrations/builtin/credentials/mcp.md
+++ b/docs/integrations/builtin/credentials/mcp.md
@@ -9,7 +9,7 @@ priority: medium
 
 You can use these credentials to authenticate the following nodes:
 
-* [MCP Client Tool](/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md)
+* [MCP Client Tool](../cluster-nodes/sub-nodes/n8n-nodes-langchain.toolmcp.md)
 
 ## Prerequisites
 

--- a/docs/integrations/builtin/credentials/mcp.md
+++ b/docs/integrations/builtin/credentials/mcp.md
@@ -1,10 +1,11 @@
 ---
 title: MCP credentials
 description: Documentation for MCP credentials. Use these credentials to authenticate MCP servers in n8n, a workflow automation platform.
+description: Documentation for MCP credentials. Use these credentials to authenticate MCP servers in n8n, a workflow automation platform.
+layout:
+  description:
+    visible: false
 contentType: [integration, reference]
-priority: medium
----
-
 # MCP OAuth2 API credentials
 
 You can use these credentials to authenticate the following nodes:

--- a/docs/integrations/builtin/credentials/mcp.md
+++ b/docs/integrations/builtin/credentials/mcp.md
@@ -15,7 +15,7 @@ You can use these credentials to authenticate the following nodes:
 
 ## Prerequisites
 
-You need an MCP server that supports OAuth2 authentication. Refer to the [MCP specification's authorization guide](https://modelcontextprotocol.io/specification/basic/authorization) for details on how MCP servers implement OAuth2.
+You need an MCP server that supports OAuth2 authentication.
 
 ## Supported authentication methods
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the missing MCP OAuth2 credentials page at /integrations/builtin/credentials/mcp/, fixing the Help link 404 in the MCP OAuth credentials modal and centralizing OAuth2 guidance for MCP Client and MCP Client Tool. Documents Dynamic Client Registration and Resource URL, and adds a “MCP credentials” nav entry. Addresses DOC-2012.

- In the MCP OAuth2 credential modal, confirm Help opens /integrations/builtin/credentials/mcp/#using-oauth2.
- Verify the “MCP credentials” nav entry and page title.
- In MCP Client and MCP Client Tool docs, confirm OAuth2 links point to the new page; bearer/header links still target the `httprequest` credential doc.

<sup>Written for commit 35d56f9a34c1018e56e493bd63e3a1e7b7195b0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

