### PR TITLE
docs: Add project-role self-escalation bullet to privilege escalation risk warning

### DIFF
--- a/docs/administer/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-instance-roles.md
+++ b/docs/administer/manage-users-and-access/set-permissions-and-roles-rbac/create-custom-instance-roles.md
@@ -134,6 +134,7 @@ Certain permission combinations create a privilege escalation risk:
 
 * A user with **Roles: Manage all roles** can edit their own custom role to add permissions they weren't originally granted.
 * A user with **Members: Manage** can invite a user they control, then grant that user Admin-level access.
+* A user with **Roles: Manage project roles** can edit a custom project role they hold themselves to grant themselves permissions they weren't originally granted in that project.
 
 Only assign these permissions to fully trusted users, and avoid combining them unless necessary.
 {% endhint %}


### PR DESCRIPTION
## Summary

Adds a third bullet to the "Privilege escalation risk" callout on the Create custom instance roles page. **Manage project roles** (`role:manageProject`) lets a holder edit the scopes of any project-type custom role, including one they hold themselves in a project — this documents that alongside the existing **Manage all roles** and **Members: Manage** cases.

No behavior change, docs-only. Companion PR on the in-app warning: n8n-io/n8n#36458

## Related

https://linear.app/n8n/issue/IAM-1237

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds "Roles: Manage project roles" (`role:manageProject`) to the "Privilege escalation risk" callout on Create custom instance roles to document that holders can edit a project role they hold to grant themselves permissions in that project. Previously the callout listed only `role:manage` and Members: Manage.

Docs-only; no behavior change. Addresses Linear IAM-1237.

<sup>Written for commit 6f76fa59bfef6f38e1c4e9964b3b84e601943cd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

