### PR TITLE
docs: remove version specification from one-line setup command

### DIFF
--- a/docs/deploy/host-n8n/install-options/one-line-setup.md
+++ b/docs/deploy/host-n8n/install-options/one-line-setup.md
@@ -33,10 +33,8 @@ The one-line setup command requires the `docker compose` v2 plugin specifically 
 Open a terminal and run:
 
 ```bash
-curl -fsSL https://get.n8n.io | sh -s -- --version 2.35.0
+curl -fsSL https://get.n8n.io | sh
 ```
-
-The version specification is necessary until n8n 2.35.0 (currently a beta release) is a stable release.
 
 This does everything for you:
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removes the version pin from the one-line setup command now that 2.35 is stable. Previously the docs used `curl -fsSL https://get.n8n.io | sh -s -- --version 2.35.0` with a caveat; now they use `curl -fsSL https://get.n8n.io | sh` to install the latest stable by default. This completes Linear DOC-2212.

**Review notes**
- Verify `get.n8n.io` defaults to 2.35+ without `--version`.
- Scan for any remaining references to the temporary version pin or caveat.

<sup>Written for commit 16b9ba379a01db26ea6b30f94cee528581f4cde1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

