### PR TITLE
docs: update self-hosting Postgres to 18

### DIFF
--- a/docs/deploy/host-n8n/configure-n8n/choose-n8ns-database.md
+++ b/docs/deploy/host-n8n/configure-n8n/choose-n8ns-database.md
@@ -44,7 +44,9 @@ n8n supports:
 
 Run the latest minor release within your major version.
 
-n8n doesn't officially support PostgreSQL-compatible derivatives, such as Amazon Aurora, AlloyDB, CockroachDB, or YugabyteDB.
+Amazon Aurora PostgreSQL is **experimental**. n8n's hosting templates offer it for high-availability setups, where Aurora recovers faster when the primary database goes down. n8n doesn't test or certify Aurora, and n8n's PostgreSQL version support doesn't extend to it. Use upstream PostgreSQL unless you specifically need what Aurora offers.
+
+n8n doesn't support other PostgreSQL-compatible derivatives, such as AlloyDB, CockroachDB, or YugabyteDB.
 
 The PostgreSQL project retires its oldest maintained major version and releases a new one every November, so n8n's supported version range shifts each year. Check this page for the current supported versions, rather than relying on a specific version number you've seen elsewhere.
 

--- a/docs/deploy/host-n8n/install-options/install-using-docker-compose.md
+++ b/docs/deploy/host-n8n/install-options/install-using-docker-compose.md
@@ -259,6 +259,9 @@ SQLite is fine for trying things out, but for a production instance that must ha
    {% hint style="warning" %} Postgres 18 changed where it stores data by default. Setting `PGDATA` keeps it in the same folder as earlier versions, so the volume mount stays the same. Don't remove that line: without it, Postgres 18 writes somewhere the volume doesn't cover and your database starts empty.
    {% endhint %}
 
+   {% hint style="warning" %} Already running an older Postgres? Moving straight to 18 is a major version upgrade, and Postgres can't open a data directory written by an older major. Bumping the image tag on an existing setup fails with `database files are incompatible with server`, but your data stays intact, so back up first with `pg_dumpall`, then follow the official [PostgreSQL upgrade guide](https://www.postgresql.org/docs/18/upgrading.html).
+   {% endhint %}
+
 3. Point n8n at it by adding these to the n8n service's environment block, and making it wait on Postgres too:
 
    ``` yaml

--- a/docs/deploy/host-n8n/install-options/install-using-docker-compose.md
+++ b/docs/deploy/host-n8n/install-options/install-using-docker-compose.md
@@ -259,7 +259,7 @@ SQLite is fine for trying things out, but for a production instance that must ha
    {% hint style="warning" %} Postgres 18 changed where it stores data by default. Setting `PGDATA` keeps it in the same folder as earlier versions, so the volume mount stays the same. Don't remove that line: without it, Postgres 18 writes somewhere the volume doesn't cover and your database starts empty.
    {% endhint %}
 
-   {% hint style="warning" %} Already running an older Postgres? Moving straight to 18 is a major version upgrade, and Postgres can't open a data directory written by an older major. Bumping the image tag on an existing setup fails with `database files are incompatible with server`, but your data stays intact, so back up first with `pg_dumpall`, then follow the official [PostgreSQL upgrade guide](https://www.postgresql.org/docs/18/upgrading.html).
+   {% hint style="warning" %} Already running an older Postgres? Moving straight to 18 is a major version upgrade, and Postgres can't open a data directory written by an older major. Bumping the image tag on an existing setup fails with `database files are incompatible with server`. Your data stays intact. Back up first with `pg_dumpall`, then follow the official [PostgreSQL upgrade guide](https://www.postgresql.org/docs/18/upgrading.html).
    {% endhint %}
 
 3. Point n8n at it by adding these to the n8n service's environment block, and making it wait on Postgres too:

--- a/docs/deploy/host-n8n/install-options/install-using-docker-compose.md
+++ b/docs/deploy/host-n8n/install-options/install-using-docker-compose.md
@@ -240,12 +240,13 @@ SQLite is fine for trying things out, but for a production instance that must ha
 
    services:
      postgres:
-       image: postgres:16
+       image: postgres:18
        restart: always
        environment:
          POSTGRES_USER: ${POSTGRES_USER}
          POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
          POSTGRES_DB: ${POSTGRES_DB}
+         PGDATA: /var/lib/postgresql/data
        volumes:
          - db-storage:/var/lib/postgresql/data
        healthcheck:
@@ -254,6 +255,9 @@ SQLite is fine for trying things out, but for a production instance that must ha
          timeout: 5s
          retries: 10
    ```
+
+   {% hint style="warning" %} Postgres 18 changed where it stores data by default. Setting `PGDATA` keeps it in the same folder as earlier versions, so the volume mount stays the same. Don't remove that line: without it, Postgres 18 writes somewhere the volume doesn't cover and your database starts empty.
+   {% endhint %}
 
 3. Point n8n at it by adding these to the n8n service's environment block, and making it wait on Postgres too:
 

--- a/docs/deploy/host-n8n/install-options/use-a-cloud-provider/deploy-to-aws.md
+++ b/docs/deploy/host-n8n/install-options/use-a-cloud-provider/deploy-to-aws.md
@@ -132,6 +132,14 @@ Create an `n8n-secret.yaml` file. Refer to [Environment variables](../../configu
 
 The two deployment manifests (`n8n-deployment.yaml` and `postgres-deployment.yaml`) define the n8n and Postgres applications to Kubernetes.
 
+{% hint style="warning" %}
+The manifests run PostgreSQL 18. Setting up for the first time needs nothing extra.
+
+If you already have a database running an older PostgreSQL major version, don't apply this to it. PostgreSQL 18 can't open a data directory written by an older major version, and moving the folder doesn't help. The pod stays in `CrashLoopBackOff` with `database files are incompatible with server`. PostgreSQL leaves your data alone, and you can pin the image back to the version you were on.
+
+To move an existing database across, follow the official [PostgreSQL upgrade guide](https://www.postgresql.org/docs/18/upgrading.html) first.
+{% endhint %}
+
 The manifests define the following:
 
 - Send the environment variables defined to each application pod

--- a/docs/deploy/host-n8n/install-options/use-a-cloud-provider/deploy-to-azure.md
+++ b/docs/deploy/host-n8n/install-options/use-a-cloud-provider/deploy-to-azure.md
@@ -129,6 +129,14 @@ Create an `n8n-secret.yaml` file. Refer to [Environment variables](../../configu
 
 The two deployment manifests (`n8n-deployment.yaml` and `postgres-deployment.yaml`) define the n8n and Postgres applications to Kubernetes.
 
+{% hint style="warning" %}
+The manifests run PostgreSQL 18. Setting up for the first time needs nothing extra.
+
+If you already have a database running an older PostgreSQL major version, don't apply this to it. PostgreSQL 18 can't open a data directory written by an older major version, and moving the folder doesn't help. The pod stays in `CrashLoopBackOff` with `database files are incompatible with server`. PostgreSQL leaves your data alone, and you can pin the image back to the version you were on.
+
+To move an existing database across, follow the official [PostgreSQL upgrade guide](https://www.postgresql.org/docs/18/upgrading.html) first.
+{% endhint %}
+
 The manifests define the following:
 
 - Send the environment variables defined to each application pod

--- a/docs/deploy/host-n8n/install-options/use-a-cloud-provider/deploy-to-google-kubernetes.md
+++ b/docs/deploy/host-n8n/install-options/use-a-cloud-provider/deploy-to-google-kubernetes.md
@@ -136,6 +136,14 @@ Create an `n8n-secret.yaml` file. Refer to [Environment variables](../../configu
 
 The two deployment manifests (`n8n-deployment.yaml` and `postgres-deployment.yaml`) define the n8n and Postgres applications to Kubernetes.
 
+{% hint style="warning" %}
+The manifests run PostgreSQL 18. Setting up for the first time needs nothing extra.
+
+If you already have a database running an older PostgreSQL major version, don't apply this to it. PostgreSQL 18 can't open a data directory written by an older major version, and moving the folder doesn't help. The pod stays in `CrashLoopBackOff` with `database files are incompatible with server`. PostgreSQL leaves your data alone, and you can pin the image back to the version you were on.
+
+To move an existing database across, follow the official [PostgreSQL upgrade guide](https://www.postgresql.org/docs/18/upgrading.html) first.
+{% endhint %}
+
 The manifests define the following:
 
 - Send the environment variables defined to each application pod


### PR DESCRIPTION
Matches the docs to the hosting templates, which moved to Postgres 18 in [n8n-hosting#181](https://github.com/n8n-io/n8n-hosting/pull/181).

Relates to https://linear.app/n8n/issue/DOC-2233

## Docker Compose page

This page keeps its own compose snippet, so it needed a real edit. Two lines change **together**:

| | Before | Now |
|---|---|---|
| image | `postgres:16` | `postgres:18` |
| volume | `- db-storage:/var/lib/postgresql/data` | `- db-storage:/var/lib/postgresql` |

Postgres 18 stores its data in a new folder, so changing one without the other breaks:

- image alone, and it won't start
- mount alone, and it starts with an **empty database**, so the user's data looks gone

A warning below the snippet says this, and gives the `postgres:16` pairing for anyone staying put. That was the main risk here: bumping the tag alone is the obvious edit and it is the broken one.

## Kubernetes tutorial pages

AWS, Azure and GKE. These tell people to `git clone` the hosting repo, so they pick up Postgres 18 automatically once that PR merges. **No step changes.**

They gain a warning: a fresh setup needs nothing extra, but an existing database on an older major won't open under 18, and moving the data folder doesn't help either. It points at the official [PostgreSQL upgrade guide](https://www.postgresql.org/docs/18/upgrading.html) rather than describing a procedure here.

## Checks

- Booted the exact compose snippet from this page: comes up healthy on 18.6, `data_directory` at `/var/lib/postgresql/18/docker`
- `CrashLoopBackOff` with `database files are incompatible with server` is the real message, reproduced on a minikube cluster with an existing 16 volume
- Vale: no new errors versus `main` on all four pages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates self-hosting docs to PostgreSQL 18 to match `n8n-hosting`. Prevents empty-database starts in Docker and failed major upgrades for existing installs.

- Docker Compose: set `image: postgres:18`, add `PGDATA: /var/lib/postgresql/data`, keep `- db-storage:/var/lib/postgresql/data`. Do not remove `PGDATA`—PostgreSQL 18 otherwise writes outside the mount and the database starts empty.
- Kubernetes tutorials (AWS/Azure/GKE): warn that manifests run PostgreSQL 18. Data directories from older majors won’t open; pods show `CrashLoopBackOff` with “database files are incompatible with server.” Pin the image to your current major until you upgrade.
- Migration: To stay on your current major, pin `postgres:<major>`. To upgrade, back up with `pg_dumpall` and follow the official PostgreSQL upgrade guide before switching to 18; bumping the image alone fails with “database files are incompatible with server.”
- Database compatibility: Amazon Aurora PostgreSQL is experimental for HA; other PostgreSQL‑compatible derivatives remain unsupported.

Addresses DOC‑2233.

<sup>Written for commit c16cdccfdea77df467c583b49305f571ebe45bf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

