### PR TITLE
[TEST - do not merge] docs: update n8n MCP server docs for n8n#31446

### DIFF
--- a/docs/connect/connect-to-n8n-mcp-server/mcp-server-tools-reference.md
+++ b/docs/connect/connect-to-n8n-mcp-server/mcp-server-tools-reference.md
@@ -946,6 +946,8 @@ Update an existing workflow in n8n by applying an ordered batch of targeted part
 | `setNodeDisabled` | `nodeName`, `disabled` |  | Enables or disables a node. |
 | `setNodeSettings` | `nodeName`, `settings` |  | Updates node-level execution settings. `settings` must include at least one supported setting. |
 | `setWorkflowMetadata` |  | `name`, `description` | Updates workflow metadata. `name` has a maximum length of 128 characters; `description` has a maximum length of 255 characters. |
+| `addTags` | `names` |  | Attaches tag names to the workflow. Unknown tag names are created automatically. Idempotent. `names` must contain 1-50 names, each 1-24 characters. |
+| `removeTags` | `names` |  | Detaches tag names from the workflow. Unknown names are ignored. `names` must contain 1-50 names, each 1-24 characters. |
 
 #### `setNodeSettings` fields <a href="#setnodesettings-fields" id="setnodesettings-fields"></a>
 
@@ -985,7 +987,10 @@ Update an existing workflow in n8n by applying an ordered batch of targeted part
 - Credential auto-assignment runs only for nodes added in the current call.
 - HTTP Request nodes are skipped during credential auto-assignment and must be configured manually.
 - The resulting workflow is validated before saving. Validation warnings are returned in `validationWarnings`.
-- Marks the workflow with `aiBuilderAssisted` metadata and `builderVariant: mcp`.
+- Marks the workflow with `aiBuilderAssisted` metadata and `builderVariant: mcp`, unless the batch only contains `addTags` and `removeTags` operations.
+- `addTags` and `removeTags` fail if workflow tags are disabled on the instance.
+- Creating tags that don't exist yet with `addTags` requires the `tag:create` global permission. Without it, the update fails and lists the tag names that don't exist.
+- Use `list_workflow_tags` to discover existing tag names before applying tag operations.
 
 ---
 


### PR DESCRIPTION
> [!WARNING]
> **This is a test run of the MCP Docs Automation v2 n8n workflow. Do not merge. Close it once reviewed.**

Automated draft. The n8n MCP docs need an update because n8n-io/n8n PR #31446 was approved and is about to ship.

**Source PR:** https://github.com/n8n-io/n8n/pull/31446 - (test-mode override)
**Source PR author:** test-mode
**Pages updated:** Tools reference

**MCP files changed in the source PR:**
- `packages/cli/src/modules/mcp/mcp.service.ts` (modified)
- `packages/cli/src/modules/mcp/mcp.types.ts` (modified)
- `packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts` (modified)
- `packages/cli/src/modules/mcp/tools/list-tags.tool.ts` (added)
- `packages/cli/src/modules/mcp/tools/schemas.ts` (modified)
- `packages/cli/src/modules/mcp/tools/search-workflows.tool.ts` (modified)
- `packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts` (modified)
- `packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts` (modified)
- `packages/cli/src/modules/mcp/tools/workflow-validation.utils.ts` (modified)

> Drafted automatically by the *MCP Docs Automation v2* n8n workflow. The source PR is approved but **not merged yet** - confirm it landed unchanged before merging this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents workflow tag support in the n8n MCP server Tools reference. Previously `update_workflow` could not manage tags and always set `aiBuilderAssisted`/`builderVariant: mcp`; it now supports `addTags`/`removeTags`, and batches with only tag ops do not set those metadata fields.

- Adds `addTags`/`removeTags` operations with limits: `names` must include 1–50 names, each 1–24 characters. `addTags` is idempotent and creates unknown names; `removeTags` ignores unknown names.
- Notes failure conditions: tag ops fail when workflow tags are disabled; creating new tags via `addTags` requires the `tag:create` permission and reports missing names on failure.
- Points to `list_workflow_tags` for discovering existing tag names before applying tag operations.

<sup>Written for commit d2e080960c63aa515fc1dd6aafd34efff9c329af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

