### PR TITLE
docs: document the MCP log streaming events

### DIFF
--- a/docs/administer/observe-and-log/stream-logs-to-external-systems.md
+++ b/docs/administer/observe-and-log/stream-logs-to-external-systems.md
@@ -143,6 +143,9 @@ The following events are available. You can choose which events to stream in **S
 	* Role mapping rule updated
 	* Role mapping rule deleted
 	* Role mapping rules bulk deleted
+	* MCP OAuth completed
+	* MCP tool called
+	* MCP access updated
 * Worker
 	* Started
 	* Stopped
@@ -172,6 +175,36 @@ The following events are available. You can choose which events to stream in **S
 	* Job stalled
 
 Two sets of audit events mention packages, and they're unrelated. **Package installed**, **Package updated**, and **Package deleted** cover [community nodes](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/community-nodes/installation-and-management) installed on the instance. The **n8n package** events cover [n8n packages](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/manage-workflows/n8n-packages), the portable archives you use to move workflows between instances.
+
+### MCP events
+
+The three **MCP** audit events cover the instance MCP server, which you turn on in **Settings** > **MCP**. They don't cover workflows that use the **MCP Server Trigger** node. These events are available from n8n 2.34.0.
+
+| Event name | Sent when |
+| --- | --- |
+| `n8n.audit.mcp.oauth.completed` | A user finishes authorizing an MCP client through OAuth. Carries `userId`, `clientId`, and `clientName`. |
+| `n8n.audit.mcp.tool.called` | An MCP client calls a tool. See the fields below. |
+| `n8n.audit.mcp.access.updated` | Someone turns instance MCP access on or off. Carries the acting user and the new `enabled` value. |
+
+To stream all three, subscribe your destination to `n8n.audit.mcp`. In **Settings** > **Log Streaming** > **Events**, they appear in the **Audit** group.
+
+`n8n.audit.mcp.tool.called` carries these fields:
+
+| Field | Description |
+| --- | --- |
+| `userId` | The user whose credentials the client authenticated with. |
+| `_email`, `_firstName`, `_lastName`, `globalRole` | That user's details. |
+| `toolName` | The tool that was called, for example `execute_workflow`. |
+| `workflowId` | The workflow the tool acted on, when it acts on one. |
+| `status` | `success` or `error`. |
+| `errorMessage` | Why the call failed. Only present when `status` is `error`. |
+| `authType` | `oauth` or `api_key`. `api_key` covers every bearer token that isn't an OAuth access token. |
+| `clientId` | The OAuth client the call authenticated as, as registered with your instance. Present when `authType` is `oauth`. |
+| `clientName` | The name the client reports for itself. |
+
+To measure usage per client, group by `clientId`. It identifies one client registration, so it stays the same across every call that client makes, including after its token refreshes. Two installations of the same product register separately and get different values, so `clientId` counts registrations rather than products. `clientName` isn't verified and isn't unique, so don't use it as a key.
+
+Setting `anonymizeAuditMessages` on a destination masks the user's email and name. It doesn't mask `userId`, `authType`, or `clientId`, so you can still group and count by them.
 
 ## Destinations <a href="#destinations" id="destinations"></a>
 


### PR DESCRIPTION
## Summary

The `n8n.audit.mcp.*` events shipped in n8n 2.34.0 (n8n-io/n8n#33300) but never reached this page, so there's no way to discover them from the docs or to know what they carry. This lists them and documents the tool-call payload.

Three changes to **Stream logs to external systems**:

- Lists **MCP OAuth completed**, **MCP tool called** and **MCP access updated** in the Audit group, matching the labels in **Settings** > **Log Streaming** > **Events**.
- Adds an **MCP events** section: what each event means, the subscription prefix (`n8n.audit.mcp`), and a field table for `n8n.audit.mcp.tool.called`.
- Explains how to attribute usage per client, since that's the question this raises in practice. Group by `clientId`, which identifies one client registration and stays stable across that client's calls and token refreshes. Don't group by `clientName`, which the client reports for itself and which is neither verified nor unique.

It also records that `anonymizeAuditMessages` masks the user's email and name but leaves `userId`, `authType` and `clientId` intact, so an anonymizing destination can still count usage.

## Scope note

These events cover the instance MCP server only. Tool calls against **MCP Server Trigger** workflows don't emit them, and the page now says so.

## Hold until the code ships

The `authType` and `clientId` rows document n8n-io/n8n#36630, which isn't released yet. The `2.34.0` note in this section refers to the three events, not to those two fields. Please hold this PR until #36630 lands, then add a version note for them if the docs convention calls for one.

## Related

- n8n-io/n8n#36630 (adds `clientId` and `authType`)
- n8n-io/n8n#33300 (added the events)
- https://linear.app/n8n/issue/ADO-5276/feature-log-mcp-events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the `n8n.audit.mcp.*` log streaming events and their payloads so operators can discover and use them. These events shipped in 2.34.0 but were missing from this page, fulfilling Linear ADO-5276.

**Review and rollout**
- Lists the three MCP audit events under Audit and shows the subscription prefix `n8n.audit.mcp`, matching Settings > Log Streaming > Events.
- Adds a field reference for `n8n.audit.mcp.tool.called`, including `authType` and `clientId`; records `anonymizeAuditMessages` masking (names/email) while leaving `userId`, `authType`, and `clientId`; advises attributing usage by `clientId`, not `clientName`.
- Clarifies scope: these events cover the instance MCP server only, not workflows using the `MCP Server Trigger` node.
- Hold merge until the release that adds `authType` and `clientId` to the event payload (n8n-io/n8n#36630). After release, add a version note for those fields if required.

<sup>Written for commit faa1d365f491ee5d29a93fc1f1511d268415bfdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

