### PR TITLE
[TEST - do not merge] docs: update n8n MCP server docs for n8n#31446

### DIFF
--- a/docs/connect/connect-to-n8n-mcp-server/mcp-server-tools-reference.md
+++ b/docs/connect/connect-to-n8n-mcp-server/mcp-server-tools-reference.md
@@ -946,6 +946,8 @@ Update an existing workflow in n8n by applying an ordered batch of targeted part
 | `setNodeDisabled` | `nodeName`, `disabled` |  | Enables or disables a node. |
 | `setNodeSettings` | `nodeName`, `settings` |  | Updates node-level execution settings. `settings` must include at least one supported setting. |
 | `setWorkflowMetadata` |  | `name`, `description` | Updates workflow metadata. `name` has a maximum length of 128 characters; `description` has a maximum length of 255 characters. |
+| `addTags` | `names` |  | Attaches tags to the workflow by name. Unknown names are auto-created. Idempotent. `names` must contain 1-50 names, each with a maximum length of 24 characters. |
+| `removeTags` | `names` |  | Detaches tags from the workflow by name. Unknown names are ignored. `names` must contain 1-50 names, each with a maximum length of 24 characters. |
 
 #### `setNodeSettings` fields <a href="#setnodesettings-fields" id="setnodesettings-fields"></a>
 
@@ -985,7 +987,10 @@ Update an existing workflow in n8n by applying an ordered batch of targeted part
 - Credential auto-assignment runs only for nodes added in the current call.
 - HTTP Request nodes are skipped during credential auto-assignment and must be configured manually.
 - The resulting workflow is validated before saving. Validation warnings are returned in `validationWarnings`.
-- Marks the workflow with `aiBuilderAssisted` metadata and `builderVariant: mcp`.
+- Marks the workflow with `aiBuilderAssisted` metadata and `builderVariant: mcp`, unless the batch only contains `addTags` and `removeTags` operations.
+- `addTags` and `removeTags` fail if tags are disabled on the instance.
+- `addTags` only creates missing tags when the user has the `tag:create` global permission. Without it, the call fails and lists the tag names that don't exist yet.
+- Use `list_workflow_tags` to discover existing tag names before applying tag operations.
 
 ---
 


### PR DESCRIPTION
> [!WARNING]
> **This is a test run of the MCP Docs Automation v2 n8n workflow. Do not merge. Close it once reviewed.**

Automated draft. The n8n MCP docs need an update because n8n-io/n8n PR #31446 was approved and is about to ship.

**Source PR:** https://github.com/n8n-io/n8n/pull/31446 - (test-mode override)
**Source PR author:** test-mode
**Pages updated:** Tools reference

**MCP files changed in the source PR:**
- `packages/cli/src/modules/mcp/mcp.service.ts` (modified)
- `packages/cli/src/modules/mcp/mcp.types.ts` (modified)
- `packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts` (modified)
- `packages/cli/src/modules/mcp/tools/list-tags.tool.ts` (added)
- `packages/cli/src/modules/mcp/tools/schemas.ts` (modified)
- `packages/cli/src/modules/mcp/tools/search-workflows.tool.ts` (modified)
- `packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts` (modified)
- `packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts` (modified)
- `packages/cli/src/modules/mcp/tools/workflow-validation.utils.ts` (modified)

> Drafted automatically by the *MCP Docs Automation v2* n8n workflow. The source PR is approved but **not merged yet** - confirm it landed unchanged before merging this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents new tag operations for the n8n MCP `update_workflow` tool and clarifies metadata and permission behavior, so users know how to manage tags safely and predictably. Previously, tagging via `update_workflow` was not supported and metadata was always marked; now tag-only batches skip metadata marking.

- Adds `addTags` and `removeTags` operations to `update_workflow`: 1–50 names per call, each ≤24 chars; idempotent; unknown names are created on add and ignored on remove.
- Notes failure conditions: both operations fail if tags are disabled; `addTags` auto-creation requires `tag:create` global permission or the call fails listing missing names.
- Clarifies that `aiBuilderAssisted` and `builderVariant: mcp` are not set when the batch contains only tag operations.
- Points to `list_workflow_tags` to discover existing tag names before applying tag operations.
- Reviewer checklist: verify tool names, limits, and failure cases match `n8n-io/n8n#31446`.

<sup>Written for commit 2f7ef45e8512a2678934a4b65f52a8b0f1c0bfdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

