### PR TITLE
[TEST - do not merge] docs: update n8n MCP server docs for n8n#31446

### DIFF
--- a/docs/connect/connect-to-n8n-mcp-server/mcp-server-tools-reference.md
+++ b/docs/connect/connect-to-n8n-mcp-server/mcp-server-tools-reference.md
@@ -946,6 +946,8 @@ Update an existing workflow in n8n by applying an ordered batch of targeted part
 | `setNodeDisabled` | `nodeName`, `disabled` |  | Enables or disables a node. |
 | `setNodeSettings` | `nodeName`, `settings` |  | Updates node-level execution settings. `settings` must include at least one supported setting. |
 | `setWorkflowMetadata` |  | `name`, `description` | Updates workflow metadata. `name` has a maximum length of 128 characters; `description` has a maximum length of 255 characters. |
+| `addTags` | `names` |  | Attaches tags to the workflow by name. Provide 1-50 names, each 1-24 characters. Unknown names are auto-created. Idempotent. |
+| `removeTags` | `names` |  | Detaches tags from the workflow by name. Provide 1-50 names, each 1-24 characters. Unknown names are ignored. |
 
 #### `setNodeSettings` fields <a href="#setnodesettings-fields" id="setnodesettings-fields"></a>
 
@@ -985,7 +987,9 @@ Update an existing workflow in n8n by applying an ordered batch of targeted part
 - Credential auto-assignment runs only for nodes added in the current call.
 - HTTP Request nodes are skipped during credential auto-assignment and must be configured manually.
 - The resulting workflow is validated before saving. Validation warnings are returned in `validationWarnings`.
-- Marks the workflow with `aiBuilderAssisted` metadata and `builderVariant: mcp`.
+- Marks the workflow with `aiBuilderAssisted` metadata and `builderVariant: mcp`, unless the batch contains only tag operations.
+- `addTags` and `removeTags` fail if workflow tags are disabled on the instance.
+- `addTags` only auto-creates unknown tag names when the user has the `tag:create` global permission. Otherwise the update fails and the error lists the tag names that don't exist.
 
 ---
 


### PR DESCRIPTION
> [!WARNING]
> **This is a test run of the MCP Docs Automation v2 n8n workflow. Do not merge. Close it once reviewed.**

Automated draft. The n8n MCP docs need an update because n8n-io/n8n PR #31446 was approved and is about to ship.

**Source PR:** https://github.com/n8n-io/n8n/pull/31446 - (test-mode override)
**Source PR author:** test-mode
**Pages updated:** Tools reference

**MCP files changed in the source PR:**
- `packages/cli/src/modules/mcp/mcp.service.ts` (modified)
- `packages/cli/src/modules/mcp/mcp.types.ts` (modified)
- `packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts` (modified)
- `packages/cli/src/modules/mcp/tools/list-tags.tool.ts` (added)
- `packages/cli/src/modules/mcp/tools/schemas.ts` (modified)
- `packages/cli/src/modules/mcp/tools/search-workflows.tool.ts` (modified)
- `packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts` (modified)
- `packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts` (modified)
- `packages/cli/src/modules/mcp/tools/workflow-validation.utils.ts` (modified)

> Drafted automatically by the *MCP Docs Automation v2* n8n workflow. The source PR is approved but **not merged yet** - confirm it landed unchanged before merging this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents tag management in the MCP server `updateWorkflow` tool to match n8n#31446. Clarifies how to add/remove tags and when these operations are allowed or rejected.

- Adds `addTags` and `removeTags` operations. Accepts `names` (1–50 items, each 1–24 chars). `addTags` is idempotent and auto-creates unknown names; `removeTags` ignores unknown names.
- Notes behavior changes: skip marking `aiBuilderAssisted` and `builderVariant: mcp` when the batch contains only tag operations.
- Adds constraints: both tag operations fail if workflow tags are disabled; `addTags` only auto-creates when the user has `tag:create` permission, otherwise the update fails and lists the unknown names.

<sup>Written for commit eac227680b0276dc33a7e7b6a33196e5007cd86d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

