### PR TITLE
[TEST - do not merge] docs: update n8n MCP server docs for n8n#35964

### DIFF
--- a/docs/connect/connect-to-n8n-mcp-server/mcp-server-tools-reference.md
+++ b/docs/connect/connect-to-n8n-mcp-server/mcp-server-tools-reference.md
@@ -384,10 +384,10 @@ Search for projects accessible to the current user. Use this to resolve a projec
 {% hint style="info" %}
 **Feature availability**
 
-`search_folders` is available from n8n 2.14.0.
+`search_folders` is available from n8n 2.14.0. It's only registered when the instance is licensed for folders.
 {% endhint %}
 
-Search for folders within a project.
+Search for folders within a project. Use this to resolve a folder name to an ID before creating a workflow in a folder, creating or updating a folder, or moving workflows into a folder.
 
 #### Parameters <a href="#parameters" id="parameters"></a>
 
@@ -405,12 +405,131 @@ Search for folders within a project.
 | `data[].id` | `string` | The unique identifier of the folder |
 | `data[].name` | `string` | The name of the folder |
 | `data[].parentFolderId` | `string | null` | The ID of the parent folder, or null if at project root |
+| `data[].path` | `string[]` | The folder's full name path from the project root, ending with the folder's own name. Use it to tell same-named folders apart and to present folders to the user by name |
 | `count` | `integer` | Total number of matching folders |
+| `error` | `string` | Error message explaining why the search failed. Present only on failure |
 
 #### Notes <a href="#notes" id="notes"></a>
 
 - Maximum result limit is 100.
 - This tool enables MCP clients to create workflows in a specific folder.
+- When several folders match a name, use the `path` values to ask the user which one they meant.
+
+---
+
+### create_folder <a href="#createfolder" id="createfolder"></a>
+
+{% hint style="info" %}
+**Feature availability**
+
+`create_folder` is only registered when the instance is licensed for folders.
+{% endhint %}
+
+Create a folder in a project, optionally nested under an existing folder.
+
+#### Parameters <a href="#parameters" id="parameters"></a>
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectId` | `string` | Yes | The ID of the project to create the folder in. Use `search_projects` to resolve a project name to an ID. |
+| `name` | `string` | Yes | The name of the folder to create |
+| `parentFolderId` | `string` | No | Parent folder ID to nest the new folder under. It must belong to the same project. Use `search_folders` to find it. Omit it or pass `"0"` to create the folder at the project root. |
+
+#### Output <a href="#output" id="output"></a>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | The ID of the folder |
+| `name` | `string` | The name of the folder |
+| `parentFolderId` | `string | null` | The ID of the parent folder, or null if the folder is at the project root |
+| `error` | `string` | Error message explaining why the operation failed. Present only on failure |
+
+#### Notes <a href="#notes" id="notes"></a>
+
+- Requires the `folder:create` permission on the project. Without it, the tool returns `Project not found or access denied`.
+- If the user named a parent folder, resolve it with `search_folders` first. When several folders match the name, ask the user which one they meant before creating.
+- When a folder ID can't be found, the error message points you at `search_folders` to look up a valid folder ID.
+- After creation, confirm the folder to the user by name, not ID.
+
+---
+
+### update_folder <a href="#updatefolder" id="updatefolder"></a>
+
+{% hint style="info" %}
+**Feature availability**
+
+`update_folder` is only registered when the instance is licensed for folders.
+{% endhint %}
+
+Rename a folder, move it under another folder in the same project, or both.
+
+#### Parameters <a href="#parameters" id="parameters"></a>
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectId` | `string` | Yes | The ID of the project the folder belongs to. Use `search_projects` to resolve a project name to an ID. |
+| `folderId` | `string` | Yes | The ID of the folder to update. Use `search_folders` to find it by name. |
+| `name` | `string` | No | New name for the folder (rename) |
+| `parentFolderId` | `string` | No | New parent folder ID to move the folder under. It must belong to the same project and must not be a descendant of the folder being moved. Pass `"0"` to move the folder to the project root. Omit to leave the folder where it is. |
+
+#### Output <a href="#output" id="output"></a>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | The ID of the folder |
+| `name` | `string` | The name of the folder |
+| `parentFolderId` | `string | null` | The ID of the parent folder, or null if the folder is at the project root |
+| `error` | `string` | Error message explaining why the operation failed. Present only on failure |
+
+#### Notes <a href="#notes" id="notes"></a>
+
+- Provide at least one of `name` or `parentFolderId`. Otherwise the tool returns `Provide at least one of name or parentFolderId`.
+- Requires the `folder:update` permission on the project. Without it, the tool returns `Project not found or access denied`.
+- Resolve folders by name with `search_folders` first. When several folders match a name, ask the user which one they meant before updating.
+- After the update, confirm the result to the user using folder names, not IDs.
+
+---
+
+### move_workflows_to_folder <a href="#moveworkflowstofolder" id="moveworkflowstofolder"></a>
+
+{% hint style="info" %}
+**Feature availability**
+
+`move_workflows_to_folder` is only registered when the instance is licensed for folders.
+{% endhint %}
+
+Move one or more existing workflows into a folder, or to the project root. The destination folder must be in the same project as the workflows.
+
+#### Parameters <a href="#parameters" id="parameters"></a>
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `workflowIds` | `string[]` | Yes (min 1, max 20) | The IDs of the workflows to move (up to 20 at a time) |
+| `folderId` | `string` | Yes | The ID of the destination folder. It must belong to the project that owns the workflows. Use `search_folders` to find it by name. Pass `"0"` to move the workflows to the project root. |
+
+#### Output <a href="#output" id="output"></a>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `folder` | `object` | The destination folder. Omitted when moving to the project root |
+| `folder.id` | `string` | The ID of the destination folder |
+| `folder.name` | `string` | The name of the destination folder |
+| `moved` | `array` | Workflows that were moved successfully |
+| `moved[].workflowId` | `string` | The ID of the moved workflow |
+| `moved[].name` | `string` | The name of the moved workflow |
+| `failed` | `array` | Workflows that couldn't be moved, with the reason for each |
+| `failed[].workflowId` | `string` | The ID of the workflow that couldn't be moved |
+| `failed[].error` | `string` | Why the workflow couldn't be moved |
+| `error` | `string` | Error message explaining why the move failed. Present only on failure |
+
+#### Notes <a href="#notes" id="notes"></a>
+
+- Requires the `workflow:update` permission on each workflow and the `folder:read` permission on the destination folder.
+- Moves may partially succeed. Report any entries in `failed` to the user.
+- If none of the workflows could be moved, the response returns the error `None of the workflows could be moved`.
+- Archived workflows and workflows that aren't available to MCP tools can't be moved.
+- Resolve the folder by name with `search_folders` first. When several folders match the name, ask the user which one they meant before moving.
+- After moving, confirm the destination to the user by folder name, not ID.
 
 ---
 
@@ -877,7 +996,7 @@ Create a workflow in n8n from validated SDK code. Parses the code into a workflo
 | `name` | `string` | No | Optional workflow name (max 128 chars). If not provided, uses the name from the code. |
 | `description` | `string` | No | Workflow description. Text longer than 255 characters is shortened to 255 before saving. |
 | `projectId` | `string` | No | Project ID to create the workflow in. Defaults to the user's personal project. Use `search_projects` first if the user names a project. |
-| `folderId` | `string` | No | Folder ID to create the workflow in. Requires `projectId` to be set. Use `search_folders` to find a folder by name within a project. |
+| `folderId` | `string` | No | Folder ID to create the workflow in. Requires `projectId` to be set. Use `search_folders` to find a folder by name within a project. When several folders match the name, ask the user which one they meant before creating. |
 
 #### Output <a href="#output" id="output"></a>
 
@@ -895,6 +1014,9 @@ Create a workflow in n8n from validated SDK code. Parses the code into a workflo
 | `targetProject.id` | `string` | The ID of the project |
 | `targetProject.name` | `string` | The display name of the project |
 | `targetProject.type` | `"personal" | "team"` | Whether the workflow was created in a personal or team project |
+| `targetFolder` | `object` | The folder the workflow was created in. Absent when the workflow was created at the project root |
+| `targetFolder.id` | `string` | The ID of the folder the workflow was created in |
+| `targetFolder.name` | `string` | The name of the folder the workflow was created in |
 | `note` | `string` | Additional notes about workflow creation, for example nodes skipped during credential auto-assignment or a description that was shortened to 255 characters |
 | `hint` | `string` | Actionable recovery hint, if available after an error |
 
@@ -907,7 +1029,8 @@ Create a workflow in n8n from validated SDK code. Parses the code into a workflo
 - Resolves webhook node IDs automatically.
 - `folderId` requires `projectId` to also be provided.
 - If the user names a target project, call `search_projects` first and pass the resolved `projectId`; don't guess.
-- After creation, tell the user which project the workflow was created in using the `targetProject` field.
+- If the user names a target folder, call `search_folders` first to resolve it.
+- After creation, tell the user which project the workflow was created in using the `targetProject` field, and which folder using the `targetFolder` field, if any.
 - From n8n 2.27.0, a `description` longer than 255 characters is truncated (not rejected); the response `note` mentions when this happens.
 
 ---


### PR DESCRIPTION
> [!WARNING]
> **This is a test run of the MCP Docs Automation v2 n8n workflow. Do not merge. Close it once reviewed.**

Automated draft. The n8n MCP docs need an update because n8n-io/n8n PR #35964 was approved and is about to ship.

**Source PR:** https://github.com/n8n-io/n8n/pull/35964 - (test-mode override)
**Source PR author:** test-mode
**Pages updated:** Tools reference

**MCP files changed in the source PR:**
- `packages/cli/src/modules/mcp/mcp-protected-resource.ts` (modified)
- `packages/cli/src/modules/mcp/mcp-scopes.ts` (modified)
- `packages/cli/src/modules/mcp/mcp.service.ts` (modified)
- `packages/cli/src/modules/mcp/tools/create-folder.tool.ts` (added)
- `packages/cli/src/modules/mcp/tools/folder-error.utils.ts` (added)
- `packages/cli/src/modules/mcp/tools/move-workflows-to-folder.tool.ts` (added)
- `packages/cli/src/modules/mcp/tools/schemas.ts` (modified)
- `packages/cli/src/modules/mcp/tools/search-folders.tool.ts` (modified)
- `packages/cli/src/modules/mcp/tools/update-folder.tool.ts` (added)
- `packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts` (modified)
- `packages/cli/src/modules/mcp/tools/workflow-validation.utils.ts` (modified)

> Drafted automatically by the *MCP Docs Automation v2* n8n workflow. The source PR is approved but **not merged yet** - confirm it landed unchanged before merging this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the n8n MCP server Tools reference to cover folder management and clarify folder behavior. Clients gain new folder capabilities and must handle new fields and license-gated tool registration.

- Adds create_folder, update_folder, and move_workflows_to_folder: parameters, outputs, permission requirements, same-project constraints, root destination via "0", and partial-success reporting for moves.
- Expands search_folders: notes license-gated registration, adds path and error fields, and guidance for disambiguating same-named folders; reiterates 100-result cap.
- Updates create_workflow_from_code: clarifies folderId requires projectId, advises resolving folders first, and documents a new targetFolder object in the response.
- Clarifies expected error messages and permission checks across folder tools and cross-references search_folders for resolution steps.

**Review focus**
- Confirm tool names, parameter/field names, required vs optional flags, limits (e.g., max 20 workflowIds), and the "0" root semantics match runtime behavior.
- Verify license-gated registration statements and quoted error messages align with the implementation.

<sup>Written for commit 96c767c97d73413b75a94999985f6f1a3de2253d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

