### PR TITLE
docs: bring all images in line with agent friendly guidelines

### DIFF
--- a/docs/administer/use-source-control-and-environments/choose-branching-patterns.md
+++ b/docs/administer/use-source-control-and-environments/choose-branching-patterns.md
@@ -53,6 +53,7 @@ This is useful to review work. For example, different users could work on their 
 
 n8n doesn't clean up the existing contents of an instance when changing branches. Switching branches in this pattern results in all the workflows from each branch being in your instance.
 {% endhint %}
+
 ![One n8n instance switching between several Git branches to review work pushed by different users](../.gitbook/assets/vc-one-multi.png)
 
 ## One instance, one branch <a href="#one-instance-one-branch" id="one-instance-one-branch"></a>

--- a/docs/administer/use-source-control-and-environments/choose-branching-patterns.md
+++ b/docs/administer/use-source-control-and-environments/choose-branching-patterns.md
@@ -28,7 +28,7 @@ You can use this pattern for environments. For example, create two n8n instances
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/O5AqRfApNuiINXZOe5j1/" %}
 
-![Diagram](../.gitbook/assets/vc-multi-multi.png)
+![Development and production n8n instances, each connected to its own Git branch, with a pull request moving work between the branches](../.gitbook/assets/vc-multi-multi.png)
 
 ## Multiple instances, one branch <a href="#multiple-instances-one-branch" id="multiple-instances-one-branch"></a>
 
@@ -40,7 +40,7 @@ This pattern is also useful when testing a new version of n8n: you can create a 
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/Vo4DpZeEyTa0iuufMDB8/" %}
 
-![Diagram](../.gitbook/assets/vc-multi-one.png)
+![Development and production n8n instances both connected to the same single Git branch](../.gitbook/assets/vc-multi-one.png)
 
 ## One instance, multiple branches <a href="#one-instance-multiple-branches" id="one-instance-multiple-branches"></a>
 
@@ -53,10 +53,10 @@ This is useful to review work. For example, different users could work on their 
 
 n8n doesn't clean up the existing contents of an instance when changing branches. Switching branches in this pattern results in all the workflows from each branch being in your instance.
 {% endhint %}
-![Diagram](../.gitbook/assets/vc-one-multi.png)
+![One n8n instance switching between several Git branches to review work pushed by different users](../.gitbook/assets/vc-one-multi.png)
 
 ## One instance, one branch <a href="#one-instance-one-branch" id="one-instance-one-branch"></a>
 
 This is the simplest pattern.
 
-![Diagram](../.gitbook/assets/vc-one-one.png)
+![Single n8n instance connected to a single Git branch](../.gitbook/assets/vc-one-one.png)

--- a/docs/administer/use-source-control-and-environments/tutorial-create-environments-with-source-control.md
+++ b/docs/administer/use-source-control-and-environments/tutorial-create-environments-with-source-control.md
@@ -31,14 +31,14 @@ Before setting up source control and environments, you need to plan your environ
 
 ### Multiple instances, multiple branches <a href="#multiple-instances-multiple-branches" id="multiple-instances-multiple-branches"></a>
 
-![Diagram](../.gitbook/assets/vc-multi-multi.png)
+![Development n8n instance linked to a development branch and production instance linked to a production branch](../.gitbook/assets/vc-multi-multi.png)
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/O5AqRfApNuiINXZOe5j1/" %}
 
 
 ### Multiple instances, one branch <a href="#multiple-instances-one-branch" id="multiple-instances-one-branch"></a>
 
-![Diagram](../.gitbook/assets/vc-multi-one.png)
+![Development and production n8n instances both connected to the same Git branch](../.gitbook/assets/vc-multi-one.png)
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/Vo4DpZeEyTa0iuufMDB8/" %}
 

--- a/docs/administer/use-source-control-and-environments/use-git-in-n8n.md
+++ b/docs/administer/use-source-control-and-environments/use-git-in-n8n.md
@@ -43,7 +43,7 @@ Git is a complex topic. This section provides a brief introduction to the key te
 
 Git uses branches to maintain multiple copies of a document alongside each other. Every branch has its own version. A common pattern is to have a main branch, and then everyone who wants to contribute to the project works on their own branch (copy). When they finish their work, their branch is merged back into the main branch.
 
-![Main branch with a contributor branch created from it and later merged back into main](../.gitbook/assets/simple-git-branch.png)
+![Main branch with two separate branches forked from it, each merged back into main at a different point](../.gitbook/assets/simple-git-branch.png)
 
 ## Local and remote: Moving work between your machine and a Git provider <a href="#local-and-remote-moving-work-between-your-machine-and-a-git-provider" id="local-and-remote-moving-work-between-your-machine-and-a-git-provider"></a>
 

--- a/docs/administer/use-source-control-and-environments/use-git-in-n8n.md
+++ b/docs/administer/use-source-control-and-environments/use-git-in-n8n.md
@@ -43,7 +43,7 @@ Git is a complex topic. This section provides a brief introduction to the key te
 
 Git uses branches to maintain multiple copies of a document alongside each other. Every branch has its own version. A common pattern is to have a main branch, and then everyone who wants to contribute to the project works on their own branch (copy). When they finish their work, their branch is merged back into the main branch.
 
-![Diagram](../.gitbook/assets/simple-git-branch.png)
+![Main branch with a contributor branch created from it and later merged back into main](../.gitbook/assets/simple-git-branch.png)
 
 ## Local and remote: Moving work between your machine and a Git provider <a href="#local-and-remote-moving-work-between-your-machine-and-a-git-provider" id="local-and-remote-moving-work-between-your-machine-and-a-git-provider"></a>
 

--- a/docs/build/code-in-n8n/get-coding-help-from-ai.md
+++ b/docs/build/code-in-n8n/get-coding-help-from-ai.md
@@ -181,7 +181,7 @@ return [{ json: { slackMessage } }];
 
 If your incoming data contains nested fields, using dot notation to reference them can help the AI understand what data you want.
 
-!["Code node with an AI prompt referencing nested data using dot notation, such as personal_info.first_name"](../.gitbook/assets/reference-data-dot-notation.png)
+![Code node with an AI prompt referencing nested data using dot notation, such as personal_info.first_name](../.gitbook/assets/reference-data-dot-notation.png)
 
 To try the example yourself, download the example workflow and import it into n8n:
 

--- a/docs/build/code-in-n8n/get-coding-help-from-ai.md
+++ b/docs/build/code-in-n8n/get-coding-help-from-ai.md
@@ -181,7 +181,7 @@ return [{ json: { slackMessage } }];
 
 If your incoming data contains nested fields, using dot notation to reference them can help the AI understand what data you want.
 
-!["Screenshot of an n8n code node, highlighting how to reference data with dot notation in an AI query"](../.gitbook/assets/reference-data-dot-notation.png)
+!["Code node with an AI prompt referencing nested data using dot notation, such as personal_info.first_name"](../.gitbook/assets/reference-data-dot-notation.png)
 
 To try the example yourself, download the example workflow and import it into n8n:
 

--- a/docs/build/flow-logic/loop.md
+++ b/docs/build/flow-logic/loop.md
@@ -44,7 +44,7 @@ To create a loop in an n8n workflow, connect the output of one node to the input
 
 Here is an [example workflow](https://n8n.io/workflows/1130) that implements a loop with an `IF` node:
 
-![Editor UI view of sample workflow](../.gitbook/assets/example_workflow.png)
+![Workflow canvas showing an IF node connected back to a previous node to form a loop, checking a condition to stop it](../.gitbook/assets/example_workflow.png)
 
 ### Loop until all items are processed <a href="#loop-until-all-items-are-processed" id="loop-until-all-items-are-processed"></a>
 

--- a/docs/build/flow-logic/split-with-conditionals.md
+++ b/docs/build/flow-logic/split-with-conditionals.md
@@ -16,7 +16,7 @@ Splitting uses the [IF](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/c
 
 Compare these workflows:
 
-!["Diagram comparing a linear bug-report workflow with one that branches by urgency and support plan."](../.gitbook/assets/single-multi-branch-workflow.png)
+![Diagram comparing a linear bug-report workflow with one that branches by urgency and support plan](../.gitbook/assets/single-multi-branch-workflow.png)
 
 The first workflow is linear: a user submits a bug and the workflow emails support. The second workflow starts the same way but splits depending on whether the user marked the issue urgent, then splits again by the user's support plan.
 

--- a/docs/build/flow-logic/split-with-conditionals.md
+++ b/docs/build/flow-logic/split-with-conditionals.md
@@ -16,7 +16,9 @@ Splitting uses the [IF](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/c
 
 Compare these workflows:
 
-!["Diagram representing two workflows. One has three steps and follows a linear process, with a user submitting a bug, and the workflow emailing a support team. The second workflow starts the same way, but then splits depending on whether the user marked the issue as urgent. It then splits again depending on the user's support plan"](../.gitbook/assets/single-multi-branch-workflow.png)
+!["Diagram comparing a linear bug-report workflow with one that branches by urgency and support plan."](../.gitbook/assets/single-multi-branch-workflow.png)
+
+The first workflow is linear: a user submits a bug and the workflow emails support. The second workflow starts the same way but splits depending on whether the user marked the issue urgent, then splits again by the user's support plan.
 
 This is the power of splitting and conditional nodes in n8n.
 

--- a/docs/build/integrate-ai/ai-examples/use-ai-for-parameters.md
+++ b/docs/build/integrate-ai/ai-examples/use-ai-for-parameters.md
@@ -31,7 +31,7 @@ There are two ways to do this, and you can switch between them.
 
 Each appropriate parameter field in the tool's editing dialog has an extra button at the end:
 
-![image showing stars icon to the right of parameter field](../../.gitbook/assets/ai-stars.png)
+![A star icon button at the end of a parameter field, used to let the AI Agent fill in that value automatically](../../.gitbook/assets/ai-stars.png)
 
 On activating this button, the [AI Agent](#user-content-fn-2)[^2] will fill in the expression for you, with no need for any further user input.
 The field itself is filled in with a message indicating that the parameter has been defined automatically by the model.

--- a/docs/build/integrate-ai/test-and-improve-ai-workflows/fix-common-issues.md
+++ b/docs/build/integrate-ai/test-and-improve-ai-workflows/fix-common-issues.md
@@ -45,7 +45,7 @@ To do so:
 
 n8n's internal chat reads the output data of the last executed node in the workflow. After adding an evaluation node with the ['set outputs' operation](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.evaluation#set-outputs), this data may not be in the expected format, or even contain the chat response.
 
-![Add second output branch](../../.gitbook/assets/add-second-output-branch.png)
+![Agent node with a second output branch wired to a No-op node, positioned to execute last](../../.gitbook/assets/add-second-output-branch.png)
 
 The solution is to add an extra branch coming out of your agent. [Lower branches execute later](../../flow-logic/understand-execution-order.md) in n8n, which means any node you attach to this branch will execute last. You can use a no-op node here since it only needs to pass the agent output through.
 

--- a/docs/build/manage-workflows/share-with-others.md
+++ b/docs/build/manage-workflows/share-with-others.md
@@ -34,7 +34,7 @@ Users can share workflows they created. Instance owners, and users with the admi
 
 **Note:** This option is only available when sharing a workflow that is inside a **Personal** workspace. When trying to use the "Add users" option for a workflow that's **inside a project**, you'll get this pop-up instead:
 
-![Screenshot of the sharing option within projects](../.gitbook/assets/sharing-within-projects.png)
+![Pop-up explaining that the project shares this workflow with everyone in it](../.gitbook/assets/sharing-within-projects.png)
 
 This is intended behavior, and it means that the workflow is shared with everyone inside that specific project. Instead of adding the user directly to the workflow, you need to add the user to the project in which the workflow is located.
 

--- a/docs/build/understand-workflows/save-and-publish-workflows.md
+++ b/docs/build/understand-workflows/save-and-publish-workflows.md
@@ -43,27 +43,27 @@ Publishing makes your workflow live and locks it to a specific version. Producti
 
 **Initial state** When you open a workflow with no publishable changes, the Publish button is disabled.
 
-![](../.gitbook/assets/publish-initial.png)
+![Disabled, greyed-out Publish button because there are no unpublished changes](../.gitbook/assets/publish-initial.png)
 
 **Ready to publish** When the workflow is not yet published but has changes, the button becomes active.
 
-![](../.gitbook/assets/publish-ready.png)
+![Active Publish button for a workflow that has unpublished changes](../.gitbook/assets/publish-ready.png)
 
 **Published, up to date** The workflow is currently published and there are no new changes since the last publish.
 
-![](../.gitbook/assets/published.png)
+![Publish button showing the workflow is published and up to date, with no pending changes](../.gitbook/assets/published.png)
 
 **Published, has changes** The workflow is published, but you've made changes since the last publish that haven't gone live yet.
 
-![](../.gitbook/assets/published-changes.png)
+![Publish button showing the workflow is published but has changes not yet live](../.gitbook/assets/published-changes.png)
 
 **Published, invalid changes** The workflow is published, but it's not in a state to be republished (no trigger requires publishing).
 
-![](../.gitbook/assets/published-invalid.png)
+![Publish button showing the workflow can't be republished because no trigger requires publishing](../.gitbook/assets/published-invalid.png)
 
 **Published, error** The workflow is published, but there are errors in your recent changes that need to be fixed before you can publish again.
 
-![](../.gitbook/assets/published-error.png)
+![Publish button showing an error state because recent changes contain errors to fix](../.gitbook/assets/published-error.png)
 
 ## How collaboration works <a href="#how-collaboration-works" id="how-collaboration-works"></a>
 
@@ -77,7 +77,7 @@ Only one person can edit a workflow at a time. If someone else is currently edit
 
 On the **Workflows** page, if a workflow is published an indicator will be displayed on the card.
 
-![](../.gitbook/assets/published-indicator-wf-list.png)
+![Published indicator badge on a workflow card in the Workflows list](../.gitbook/assets/published-indicator-wf-list.png)
 
 ## Publishing a workflow <a href="#publishing-a-workflow" id="publishing-a-workflow"></a>
 
@@ -91,7 +91,7 @@ Each time you make a change to a workflow, n8n autosaves those changes to a new 
 
     If you only update workflow settings, n8n will re-publish the version without requiring you to take any action.
 
-![](../.gitbook/assets/publish-modal.png)
+![Publish modal with an editable version name (defaulting to a UUID) and description field](../.gitbook/assets/publish-modal.png)
 
 ## Naming versions <a href="#naming-versions" id="naming-versions"></a>
 
@@ -113,7 +113,7 @@ To name a version from the canvas header:
 3. Enter a name and optional description.
 4. Select **Save**.
 
-![](../.gitbook/assets/publish-dropdown.png)
+![Publish button's dropdown menu with the Name version option](../.gitbook/assets/publish-dropdown.png)
 
 To name a version from the version history page:
 

--- a/docs/build/understand-workflows/understand-executions/understand-dirty-nodes.md
+++ b/docs/build/understand-workflows/understand-executions/understand-dirty-nodes.md
@@ -20,11 +20,11 @@ A **dirty node** is a node that executed successfully in the past, but whose out
 
 In the canvas of the workflow editor, you can identify dirty notes by their different-colored border and a yellow triangle in place of the previous green tick symbol. For example:
 
-!["A node on the canvas with a yellow border and a yellow triangle icon instead of the usual green success tick"](../../.gitbook/assets/dirty-node-canvas.png)
+![A node on the canvas with a yellow border and a yellow triangle icon instead of the usual green success tick](../../.gitbook/assets/dirty-node-canvas.png)
 
 In the node editor view, the output panel also displays a yellow triangle on the output panel. If you hover over the triangle, a tooltip appears with more information about why n8n considers the data stale:
 
-!["Node editor's output panel showing a yellow triangle icon with a tooltip explaining why the data is stale"](../../.gitbook/assets/dirty-node-editor.png)
+![Node editor's output panel showing a yellow triangle icon with a tooltip explaining why the data is stale](../../.gitbook/assets/dirty-node-editor.png)
 
 ## Why n8n marks nodes dirty <a href="#why-n8n-marks-nodes-dirty" id="why-n8n-marks-nodes-dirty"></a>
 
@@ -57,17 +57,17 @@ For sub-nodes, also labels any executed parent nodes (up to and including the ro
 
 -   When deleting a connected node in a workflow:
 
-    !["Workflow canvas before a connected node is deleted, with all nodes showing green success ticks"](../../.gitbook/assets/dirty-before.png)
+    ![Workflow canvas before you delete a connected node, with all nodes showing green success ticks](../../.gitbook/assets/dirty-before.png)
 
 -   The next node in the sequence becomes dirty:
 
-    !["Workflow canvas after the node is deleted, with the next node in the sequence now marked dirty with a yellow border"](../../.gitbook/assets/dirty-after.png)
+    ![Workflow canvas after you delete the node, with the next node in the sequence now marked dirty with a yellow border](../../.gitbook/assets/dirty-after.png)
 
 </div>
 
 When using loops (with the [Loop over Items](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.splitinbatches) node), when any node within the loop is dirty, the initial node of the loop is also considered dirty:
 
-!["Loop Over Items node marked dirty because a node inside its loop is dirty"](../../.gitbook/assets/dirty-loop.png)
+![Loop Over Items node marked dirty because a node inside its loop is dirty](../../.gitbook/assets/dirty-loop.png)
 
 ## Resolving dirty nodes <a href="#resolving-dirty-nodes" id="resolving-dirty-nodes"></a>
 

--- a/docs/build/understand-workflows/understand-executions/understand-dirty-nodes.md
+++ b/docs/build/understand-workflows/understand-executions/understand-dirty-nodes.md
@@ -20,11 +20,11 @@ A **dirty node** is a node that executed successfully in the past, but whose out
 
 In the canvas of the workflow editor, you can identify dirty notes by their different-colored border and a yellow triangle in place of the previous green tick symbol. For example:
 
-!["Image of node displayed with yellow border"](../../.gitbook/assets/dirty-node-canvas.png)
+!["A node on the canvas with a yellow border and a yellow triangle icon instead of the usual green success tick"](../../.gitbook/assets/dirty-node-canvas.png)
 
 In the node editor view, the output panel also displays a yellow triangle on the output panel. If you hover over the triangle, a tooltip appears with more information about why n8n considers the data stale:
 
-!["Image of node displayed with yellow border"](../../.gitbook/assets/dirty-node-editor.png)
+!["Node editor's output panel showing a yellow triangle icon with a tooltip explaining why the data is stale"](../../.gitbook/assets/dirty-node-editor.png)
 
 ## Why n8n marks nodes dirty <a href="#why-n8n-marks-nodes-dirty" id="why-n8n-marks-nodes-dirty"></a>
 
@@ -57,17 +57,17 @@ For sub-nodes, also labels any executed parent nodes (up to and including the ro
 
 -   When deleting a connected node in a workflow:
 
-    !["Image of node displayed with yellow border"](../../.gitbook/assets/dirty-before.png)
+    !["Workflow canvas before a connected node is deleted, with all nodes showing green success ticks"](../../.gitbook/assets/dirty-before.png)
 
 -   The next node in the sequence becomes dirty:
 
-    !["Image of node displayed with yellow border"](../../.gitbook/assets/dirty-after.png)
+    !["Workflow canvas after the node is deleted, with the next node in the sequence now marked dirty with a yellow border"](../../.gitbook/assets/dirty-after.png)
 
 </div>
 
 When using loops (with the [Loop over Items](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.splitinbatches) node), when any node within the loop is dirty, the initial node of the loop is also considered dirty:
 
-!["Image of node displayed with yellow border"](../../.gitbook/assets/dirty-loop.png)
+!["Loop Over Items node marked dirty because a node inside its loop is dirty"](../../.gitbook/assets/dirty-loop.png)
 
 ## Resolving dirty nodes <a href="#resolving-dirty-nodes" id="resolving-dirty-nodes"></a>
 

--- a/docs/build/understand-workflows/workflow-components/add-notes-and-documentation.md
+++ b/docs/build/understand-workflows/workflow-components/add-notes-and-documentation.md
@@ -32,7 +32,7 @@ Sticky Notes allow you to annotate and comment on your workflows.
 
 n8n recommends using Sticky Notes heavily, especially on [template workflows](#user-content-fn-1)[^1], to help other users understand your workflow.
 
-![A basic workflow with a sticky note attached, annotating what one part of the workflow does](../../.gitbook/assets/example-sticky-note.png)
+![A basic workflow with a sticky note attached](../../.gitbook/assets/example-sticky-note.png)
 
 ## Create a Sticky Note <a href="#create-a-sticky-note" id="create-a-sticky-note"></a>
 

--- a/docs/build/understand-workflows/workflow-components/add-notes-and-documentation.md
+++ b/docs/build/understand-workflows/workflow-components/add-notes-and-documentation.md
@@ -32,7 +32,7 @@ Sticky Notes allow you to annotate and comment on your workflows.
 
 n8n recommends using Sticky Notes heavily, especially on [template workflows](#user-content-fn-1)[^1], to help other users understand your workflow.
 
-![Screenshot of a basic workflow with an example sticky note](../../.gitbook/assets/example-sticky-note.png)
+![A basic workflow with a sticky note attached, annotating what one part of the workflow does](../../.gitbook/assets/example-sticky-note.png)
 
 ## Create a Sticky Note <a href="#create-a-sticky-note" id="create-a-sticky-note"></a>
 

--- a/docs/build/ways-of-building-workflows/ai-workflow-builder.md
+++ b/docs/build/ways-of-building-workflows/ai-workflow-builder.md
@@ -43,7 +43,7 @@ For details of pricing and availability of AI Workflow Builder, see [n8n Plans a
 2. **Monitor the build:** The builder provides real-time feedback through several phases.
 3.  **Review and refine the generated workflow:** Review required credentials and other parameters. Refine the workflow using prompts.
 
-    ![ai-workflow-builder.png](../.gitbook/assets/ai-workflow-builder.png)
+    ![AI Workflow Builder panel showing a generated workflow with a chat box for refining it](../.gitbook/assets/ai-workflow-builder.png)
 
 ### Commands you can run in the builder <a href="#commands-you-can-run-in-the-builder" id="commands-you-can-run-in-the-builder"></a>
 

--- a/docs/build/ways-of-building-workflows/use-the-ai-assistant.md
+++ b/docs/build/ways-of-building-workflows/use-the-ai-assistant.md
@@ -66,9 +66,9 @@ You can manage your AI usage settings by navigating to **Settings** > **AI Usage
 
 These settings are only available to the instance owners and administrators, and will apply to all users on the instance.
 
-![AI Usage settings page with the Send actual data values toggle](../.gitbook/assets/ai_usage_settings.png)
+![AI Usage settings page with the Send actual data values checkbox](../.gitbook/assets/ai_usage_settings.png)
 
-Toggle whether to share actual workflow data (like node names, parameters, and structure) with Ask n8n AI. Disabling this option will limit the assistant's ability to provide context-aware help based on your workflows.
+Choose whether to share actual workflow data (like node names, parameters, and structure) with Ask n8n AI. Disabling this option will limit the assistant's ability to provide context-aware help based on your workflows.
 
 Since access to workflow data is essential for the AI Workflow builder to function, **disabling this option will also disable the AI Workflow builder feature**.
 

--- a/docs/build/ways-of-building-workflows/use-the-ai-assistant.md
+++ b/docs/build/ways-of-building-workflows/use-the-ai-assistant.md
@@ -66,7 +66,7 @@ You can manage your AI usage settings by navigating to **Settings** > **AI Usage
 
 These settings are only available to the instance owners and administrators, and will apply to all users on the instance.
 
-![ai\_usage\_settings.png](../.gitbook/assets/ai_usage_settings.png)
+![AI Usage settings page with the Send actual data values toggle](../.gitbook/assets/ai_usage_settings.png)
 
 Toggle whether to share actual workflow data (like node names, parameters, and structure) with Ask n8n AI. Disabling this option will limit the assistant's ability to provide context-aware help based on your workflows.
 

--- a/docs/build/work-with-data/reference-data/use-the-ui-mapper.md
+++ b/docs/build/work-with-data/reference-data/use-the-ui-mapper.md
@@ -20,7 +20,7 @@ You can map data in the following ways:
 * Using the expressions editor.
 * By dragging and dropping data from the **INPUT** pane into node parameters. This generates the expression for you.
 
-![Creating expressions in the UI](../../.gitbook/assets/expressionEditor.gif)
+![Dragging a field from the INPUT pane into a node parameter to generate an expression](../../.gitbook/assets/expressionEditor.gif)
 
 For information on errors with mapping and linking items, refer to [Item linking errors](link-data-items/item-linking-errors.md).
 

--- a/docs/build/work-with-data/transform-data/expressions-for-data-transformation.md
+++ b/docs/build/work-with-data/transform-data/expressions-for-data-transformation.md
@@ -24,7 +24,9 @@ This keeps your workflow organized by separating data transformation from busine
 
 **Best practice**: Instead of adding complex expressions to multiple parameters across different nodes, use Edit Fields to prepare your data first, then pass the transformed data to subsequent nodes.
 
-![Creating expressions in the UI](../../.gitbook/assets/expressionDot.gif)
+To build an expression in the UI, switch the field to expression mode, then drag a value from the **INPUT** pane into it, or type the expression directly.
+
+![Toggling a field to Expression mode, then dragging a value from the INPUT pane to build the expression](../../.gitbook/assets/expressionDot.gif)
 
 See [Expression reference](expression-reference/README.md) for more information and examples.
 

--- a/docs/build/work-with-data/understand-n8ns-data-structure.md
+++ b/docs/build/work-with-data/understand-n8ns-data-structure.md
@@ -111,5 +111,5 @@ Given the following data:
 
 n8n displays it in table form like this, showing the `nested` field in bold to show that it contains nested data:
 
-!["Table view of the example data, with the nested field shown in bold."](../.gitbook/assets/nested-data.png)
+![Table view of the example data, with the nested field shown in bold](../.gitbook/assets/nested-data.png)
 

--- a/docs/build/work-with-data/understand-n8ns-data-structure.md
+++ b/docs/build/work-with-data/understand-n8ns-data-structure.md
@@ -109,7 +109,7 @@ Given the following data:
 ]
 ```
 
-n8n displays it in table form like this:
+n8n displays it in table form like this, showing the `nested` field in bold to show that it contains nested data:
 
-!["Screenshot of a table in the INPUT panel. It includes a top level field named "nested." This field contains nested data, which is indicated in bold."](../.gitbook/assets/nested-data.png)
+!["Table view of the example data, with the nested field shown in bold."](../.gitbook/assets/nested-data.png)
 

--- a/docs/changelog/release-notes-1.x.md
+++ b/docs/changelog/release-notes-1.x.md
@@ -2831,7 +2831,7 @@ Max from our DevRel team created an official walkthrough for you to get started:
 
 <br>
 
-[![Studio](.gitbook/assets/MCP-YouTube-thumb.jpg)](https://youtu.be/45WPU7P-1QQ?feature=shared)
+[![Thumbnail linking to a Studio video walkthrough of the new MCP Server Trigger and Client Tool nodes](.gitbook/assets/MCP-YouTube-thumb.jpg)](https://youtu.be/45WPU7P-1QQ?feature=shared)
 
 ### MCP Server Trigger <a href="#mcp-server-trigger" id="mcp-server-trigger"></a>
 
@@ -3583,7 +3583,7 @@ We build this on a web worker architecture so you won't have to suffer from perf
 \
 To get the full picture, check out our Studio update with Max and Elias, where they discuss and demo the new editing experience. 👇<br>
 
-[![Studio](.gitbook/assets/The_Studio_thumbnail_Code_node.jpg)](https://youtu.be/De1E58MPaMQ?t=645)
+[![Thumbnail linking to a Studio video demoing the overhauled Code node editing experience](.gitbook/assets/The_Studio_thumbnail_Code_node.jpg)](https://youtu.be/De1E58MPaMQ?t=645)
 {% endhint %}
 
 ### New node: Microsoft Entra ID <a href="#new-node-microsoft-entra-id" id="new-node-microsoft-entra-id"></a>

--- a/docs/changelog/release-notes-2.x.md
+++ b/docs/changelog/release-notes-2.x.md
@@ -2071,11 +2071,11 @@ With this release you can now:
 
 The new Time Saved node provides increased accuracy for complex workflows where different execution paths save different amounts of time.
 
-![time saved node example](.gitbook/assets/time_saved_node_1.png)
+![Workflow branching by lead score, with a Time Saved node on each branch set to a different time-saved value](.gitbook/assets/time_saved_node_1.png)
 
 n8n automatically totals the time from all Time Saved nodes executed during each workflow run and reports it within the insights dashboard.
 
-![insights dashboard](.gitbook/assets/time_saved_node_2.png)
+![Insights dashboard with the Time saved metric card highlighted alongside execution and run-time stats](.gitbook/assets/time_saved_node_2.png)
 
 ### Contributors <a href="#contributors" id="contributors"></a>
 

--- a/docs/changelog/v20-breaking-changes.md
+++ b/docs/changelog/v20-breaking-changes.md
@@ -26,10 +26,10 @@ Previously, when an execution (parent) called a sub-execution (child) that conta
 Entering the waiting state would happen for example if the sub-execution contains a Wait node with a timeout higher than 65 seconds or a webhook call or a form submission, or a human-in-the-loop node, like the slack node.
 
 Parent-Workflow:
-![Parent-Workflow](.gitbook/assets/parentworkflow1.png)
+![Parent workflow with a Manual Trigger connected to an Execute Workflow node](.gitbook/assets/parentworkflow1.png)
 
 Sub-Workflow:
-![Sub-Workflow](.gitbook/assets/subworkflow.png)
+![Sub-workflow triggered by Execute Workflow Trigger, running a Wait node followed by an Edit Fields node](.gitbook/assets/subworkflow.png)
 
 n8n 1.0: The parent-execution reproduces the sub-execution's input as its output.:
 ![n8n 1.0: Parent execution won't receive the result of the child execution](.gitbook/assets/before1.png)

--- a/docs/changelog/v20-migration-tool.md
+++ b/docs/changelog/v20-migration-tool.md
@@ -15,7 +15,7 @@ layout:
 
 The migration tool helps you prepare your n8n instance for upgrading to n8n 2.0 by identifying workflows and configurations that need attention before the upgrade.
 
-![Migration tool](.gitbook/assets/migration-tool.png)
+![Migration compatibility report showing a workflow-compatible count and Workflow issues / Instance issues tabs](.gitbook/assets/migration-tool.png)
 
 You can see all breaking changes for n8n 2.0 [on this page](v20-breaking-changes.md).
 

--- a/docs/connect/connect-to-n8n-mcp-server.md
+++ b/docs/connect/connect-to-n8n-mcp-server.md
@@ -188,7 +188,7 @@ You can use the **Options** menu <img src=".gitbook/assets/three-dot-options-men
 2. Select the **Options** menu <img src=".gitbook/assets/three-dot-options-menu (1).png" alt="Options icon" data-size="line"> next to the name of the project or folder.
 3. Select **Manage MCP access**, then either **Enable MCP** or **Disable MCP**.
 
-![mcp\_bulk\_toggle.png](<.gitbook/assets/mcp_bulk_toggle (1).png>)
+![Options menu with Manage MCP access expanded, showing Enable MCP access and Disable MCP access](<.gitbook/assets/mcp_bulk_toggle (1).png>)
 
 {% hint style="info" %}
 **Note**
@@ -220,7 +220,7 @@ To help MCP clients identify workflows, you can add free-text descriptions as fo
     2. Click the main workflow menu (`...`) in the top-right corner.
     3. Select **Edit description**.
 
-    ![mcp\_workflow\_description.png](<.gitbook/assets/mcp_workflow_description (1).png>)
+    ![Workflow's main menu open, with Edit description highlighted](<.gitbook/assets/mcp_workflow_description (1).png>)
 
 ## Exposing agents to MCP clients <a href="#exposing-agents-to-mcp-clients" id="exposing-agents-to-mcp-clients"></a>
 

--- a/docs/connect/create-nodes/build-your-node/reference/node-ui-elements.md
+++ b/docs/connect/create-nodes/build-your-node/reference/node-ui-elements.md
@@ -54,7 +54,7 @@ Basic configuration:
 }
 ```
 
-![String](../../../.gitbook/assets/string.png)
+![String field example: a Name input with Fixed/Expression toggle and the value n8n typed in](../../../.gitbook/assets/string.png)
 
 String field for inputting passwords:
 
@@ -82,7 +82,7 @@ String field for inputting passwords:
 }
 ```
 
-![Password](../../../.gitbook/assets/password.png)
+![Password field example: a Password input showing masked dots instead of the typed value](../../../.gitbook/assets/password.png)
 
 String field with more than one row:
 
@@ -110,7 +110,7 @@ String field with more than one row:
 }
 ```
 
-![Multiple rows](../../../.gitbook/assets/multiple-rows.png)
+![Multi-row string field example: a Description textarea spanning several lines of text](../../../.gitbook/assets/multiple-rows.png)
 
 ### Support drag and drop for data keys <a href="#support-drag-and-drop-for-data-keys" id="support-drag-and-drop-for-data-keys"></a>
 
@@ -153,7 +153,7 @@ Number field with decimal points:
 }
 ```
 
-![Decimal](../../../.gitbook/assets/decimal.png)
+![Decimal number field example: an Amount input showing the value 10.00](../../../.gitbook/assets/decimal.png)
 
 ## Collection <a href="#collection" id="collection"></a>
 
@@ -201,7 +201,7 @@ Use the `collection` type when you need to display optional fields.
 }
 ```
 
-![Collection](../../../.gitbook/assets/collection.png)
+![Collection field example: a Filters group with an optional Type dropdown open, listing Automated, Past, and Upcoming](../../../.gitbook/assets/collection.png)
 
 ## DateTime <a href="#datetime" id="datetime"></a>
 
@@ -227,7 +227,7 @@ The `dateTime` type provides a date picker.
 }
 ```
 
-![DateTime](../../../.gitbook/assets/datetime.png)
+![DateTime field example: a date input opening a calendar picker to choose a date and time](../../../.gitbook/assets/datetime.png)
 
 ## Boolean <a href="#boolean" id="boolean"></a>
 
@@ -253,7 +253,7 @@ The `boolean` type adds a toggle for entering true or false.
 }
 ```
 
-![Boolean](../../../.gitbook/assets/boolean.png)
+![Boolean field example: a Wait for Image toggle switched on](../../../.gitbook/assets/boolean.png)
 
 ## Color <a href="#color" id="color"></a>
 
@@ -278,7 +278,7 @@ The `color` type provides a color selector.
 }
 ```
 
-![Color](../../../.gitbook/assets/color.png)
+![Color field example: a Background Color input with its picker swatch expanded](../../../.gitbook/assets/color.png)
 
 ## Options <a href="#options" id="options"></a>
 
@@ -314,7 +314,7 @@ The `options` type adds an options list. Users can select a single value.
 }
 ```
 
-![Options](../../../.gitbook/assets/options.png)
+![Options field example: a Resource dropdown open showing single-select choices Image and Template](../../../.gitbook/assets/options.png)
 
 ## Multi-options <a href="#multi-options" id="multi-options"></a>
 
@@ -350,7 +350,7 @@ The `multiOptions` type adds an options list. Users can select more than one val
 }
 ```
 
-![Multi-options](../../../.gitbook/assets/multioptions.png)
+![Multi-options field example: an Events field with Plan Created and Plan Deleted both selected as removable tags](../../../.gitbook/assets/multioptions.png)
 
 ## Filter <a href="#filter" id="filter"></a>
 
@@ -398,7 +398,7 @@ options: [
 },
 ```
 
-![Filter](../../../.gitbook/assets/filter.png)
+![Filter field example: a Conditions builder with two rules joined by OR, using ends with and contains operators](../../../.gitbook/assets/filter.png)
 
 ## Assignment collection (drag and drop) <a href="#assignment-collection-drag-and-drop" id="assignment-collection-drag-and-drop"></a>
 
@@ -466,11 +466,11 @@ Use the `fixedCollection` type to group fields that are semantically related.
 }
 ```
 
-![Fixed collection](../../../.gitbook/assets/fixed-collection.png)
+![Fixed collection example: a Metadata group with two repeated Name/Value field pairs and an Add Metadata button](../../../.gitbook/assets/fixed-collection.png)
 
 ## Resource locator <a href="#resource-locator" id="resource-locator"></a>
 
-![Resource locator](../../../.gitbook/assets/resource-locator.png)
+![Resource locator field example: a Card field with its mode dropdown open, offering By ID, By URL, and From list](../../../.gitbook/assets/resource-locator.png)
 
 The resource locator element helps users find a specific resource in an external service, such as a card or label in Trello.
 
@@ -711,7 +711,7 @@ Refer to the [Postgres resource mapping method](https://github.com/n8n-io/n8n/bl
 }
 ```
 
-![JSON](../../../.gitbook/assets/json.png)
+![JSON field example: a Content (JSON) code editor with syntax-highlighted keys and values](../../../.gitbook/assets/json.png)
 
 ## HTML <a href="#html" id="html"></a>
 
@@ -746,7 +746,7 @@ Display a yellow box with a hint or extra info. Refer to [Node UI design](../../
 },
 ```
 
-![Notice](../../../.gitbook/assets/notice.png)
+![Notice field example: a pale yellow info box displaying placeholder text](../../../.gitbook/assets/notice.png)
 
 ## Hints <a href="#hints" id="hints"></a>
 

--- a/docs/connect/create-nodes/build-your-node/using-the-n8n-node-tool.md
+++ b/docs/connect/create-nodes/build-your-node/using-the-n8n-node-tool.md
@@ -216,7 +216,7 @@ npm run dev
 
 Visit your `localhost:5678` to sign in to your n8n instance. If you open a workflow, your node appears in the nodes panel:
 
-![node in nodes panel](../../.gitbook/assets/node_in_nodes_panel.png)
+![Trigger search panel in the workflow editor, listing a matching node in the results](../../.gitbook/assets/node_in_nodes_panel.png)
 
 From there, you can add it to your workflow and test the node's functionality as you develop.
 

--- a/docs/connect/create-nodes/plan-your-node/node-ui-design.md
+++ b/docs/connect/create-nodes/plan-your-node/node-ui-design.md
@@ -97,7 +97,7 @@ There are five types of help built in to the GUI:
     * Use info boxes for essential information. Don't over-use them. By making them rare, they stand out more and grab the user's attention.
 * Parameter hints: lines of text displayed beneath a user input field. Use this when there's something the user needs to know, but an info box would be excessive.
 * Node hints: provide help in the input panel, output panel, or node details view. Refer to [UI elements | Hints](../build-your-node/reference/node-ui-elements.md#hints) for more information.
-* Tooltips: callouts that appear when the user hovers over the tooltip icon !["The tooltip icon: a question mark in a grey circle"](../../.gitbook/assets/help-tooltip.png). Use tooltips for extra information that the user might need.
+* Tooltips: callouts that appear when the user hovers over the tooltip icon ![The tooltip icon: a question mark in a grey circle](../../.gitbook/assets/help-tooltip.png). Use tooltips for extra information that the user might need.
     * You don't have to provide a tooltip for every field. Only add one if it contains useful information. 
     * When writing tooltips, think about what the user needs. Don't just copy-paste API parameter descriptions. If the description doesn't make sense, or has errors, improve it.
 * Placeholder text: n8n can display placeholder text in a field where the user hasn't entered a value. This can help the user know what's expected in that field.

--- a/docs/connect/create-nodes/plan-your-node/node-ui-design.md
+++ b/docs/connect/create-nodes/plan-your-node/node-ui-design.md
@@ -97,7 +97,7 @@ There are five types of help built in to the GUI:
     * Use info boxes for essential information. Don't over-use them. By making them rare, they stand out more and grab the user's attention.
 * Parameter hints: lines of text displayed beneath a user input field. Use this when there's something the user needs to know, but an info box would be excessive.
 * Node hints: provide help in the input panel, output panel, or node details view. Refer to [UI elements | Hints](../build-your-node/reference/node-ui-elements.md#hints) for more information.
-* Tooltips: callouts that appear when the user hovers over the tooltip icon !["Screenshot of the tooltip icon. The icon is a ? in a grey circle"](../../.gitbook/assets/help-tooltip.png). Use tooltips for extra information that the user might need.
+* Tooltips: callouts that appear when the user hovers over the tooltip icon !["The tooltip icon: a question mark in a grey circle"](../../.gitbook/assets/help-tooltip.png). Use tooltips for extra information that the user might need.
     * You don't have to provide a tooltip for every field. Only add one if it contains useful information. 
     * When writing tooltips, think about what the user needs. Don't just copy-paste API parameter descriptions. If the description doesn't make sense, or has errors, improve it.
 * Placeholder text: n8n can display placeholder text in a field where the user hasn't entered a value. This can help the user know what's expected in that field.

--- a/docs/connect/create-nodes/test-your-node/troubleshooting.md
+++ b/docs/connect/create-nodes/test-your-node/troubleshooting.md
@@ -18,9 +18,36 @@ layout:
 ### Error message: 'Credentials of type "*" aren't known' <a href="#error-message-credentials-of-type-arent-known" id="error-message-credentials-of-type-arent-known"></a>
 
 
-Check that the name in the credentials array matches the name used in the property name of the credentials' class.
+Check that the name in the credentials array matches the name used in the property name of the credentials' class. For example, this credential class sets `name` to `friendGridApi`:
 
-![Troubleshooting credentials](../../.gitbook/assets/troubleshooting-credentials-1.png)
+```typescript
+export class FriendGridApi implements ICredentialType {
+	name = 'friendGridApi';
+	displayName = 'FriendGrid API';
+	documentationUrl = 'friendGrid';
+	properties = [
+		{
+			displayName: 'API Key',
+			name: 'apiKey',
+			type: 'string' as NodePropertyTypes,
+			default: '',
+		},
+	];
+}
+```
+
+The node's `credentials` array must reference that same `name` value:
+
+```typescript
+credentials: [
+	{
+		name: 'friendGridApi',
+		required: true,
+	},
+],
+```
+
+![Arrow linking the credential class's name property to the matching name field in the node's credentials array](../../.gitbook/assets/troubleshooting-credentials-1.png)
 
 
 ## Editor UI <a href="#editor-ui" id="editor-ui"></a>

--- a/docs/connect/create-nodes/test-your-node/troubleshooting.md
+++ b/docs/connect/create-nodes/test-your-node/troubleshooting.md
@@ -47,7 +47,7 @@ credentials: [
 ],
 ```
 
-![Arrow linking the credential class's name property to the matching name field in the node's credentials array](../../.gitbook/assets/troubleshooting-credentials-1.png)
+![Code examples with arrows linking the credential class's name property to the matching name field in the node's credentials array](../../.gitbook/assets/troubleshooting-credentials-1.png)
 
 
 ## Editor UI <a href="#editor-ui" id="editor-ui"></a>

--- a/docs/deploy/host-n8n/configure-n8n/scaling/enable-queue-mode.md
+++ b/docs/deploy/host-n8n/configure-n8n/scaling/enable-queue-mode.md
@@ -39,7 +39,7 @@ This is the process flow:
 1. Redis notifies the main instance.
 
 
-!["Diagram showing the flow of data between the main n8n instance, Redis, the n8n workers, and the n8n database"](../../../.gitbook/assets/queue-mode-flow.png)
+![Diagram showing the flow of data between the main n8n instance, Redis, the n8n workers, and the n8n database](../../../.gitbook/assets/queue-mode-flow.png)
 
 ## Configuring workers <a href="#configuring-workers" id="configuring-workers"></a>
 

--- a/docs/deploy/host-n8n/configure-n8n/set-up-task-runners.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-task-runners.md
@@ -70,7 +70,7 @@ Because the runner runs as the same user on the same host as n8n, code that esca
 
 ### External mode <a href="#external-mode" id="external-mode"></a>
 
-In external mode, a [launcher application](https://github.com/n8n-io/task-runner-launcher) launches task runners on demand and manages their lifecycle. Typically, this means that next to n8n you add a sidecar container running the [`n8nio/runners`](https://hub.docker.com/r/n8nio/runners) image containing the launcher, the JS task runner and the Python task runner. This sidecar container is independent from the n8n instance. The launcher process and the task runner process each expose a health-check endpoint that the launcher uses to monitor them.
+In external mode, a [launcher application](https://github.com/n8n-io/task-runner-launcher) launches task runners on demand and manages their lifecycle. Typically, this means that next to n8n you add a sidecar container running the [`n8nio/runners`](https://hub.docker.com/r/n8nio/runners) image containing the launcher, the JS task runner and the Python task runner. This sidecar container is independent from the n8n instance. The launcher exposes a health-check endpoint that it uses to monitor the task runner processes.
 
 ![Task runner deployed as a side-car container](../../.gitbook/assets/task-runner-external-mode.png)
 

--- a/docs/deploy/host-n8n/configure-n8n/set-up-task-runners.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-task-runners.md
@@ -70,7 +70,7 @@ Because the runner runs as the same user on the same host as n8n, code that esca
 
 ### External mode <a href="#external-mode" id="external-mode"></a>
 
-In external mode, a [launcher application](https://github.com/n8n-io/task-runner-launcher) launches task runners on demand and manages their lifecycle. Typically, this means that next to n8n you add a sidecar container running the [`n8nio/runners`](https://hub.docker.com/r/n8nio/runners) image containing the launcher, the JS task runner and the Python task runner. This sidecar container is independent from the n8n instance. The launcher process and the task runner process each expose a `/healthz` endpoint that the launcher uses to monitor them.
+In external mode, a [launcher application](https://github.com/n8n-io/task-runner-launcher) launches task runners on demand and manages their lifecycle. Typically, this means that next to n8n you add a sidecar container running the [`n8nio/runners`](https://hub.docker.com/r/n8nio/runners) image containing the launcher, the JS task runner and the Python task runner. This sidecar container is independent from the n8n instance. The launcher process and the task runner process each expose a health-check endpoint that the launcher uses to monitor them.
 
 ![Task runner deployed as a side-car container](../../.gitbook/assets/task-runner-external-mode.png)
 

--- a/docs/deploy/host-n8n/configure-n8n/set-up-task-runners.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-task-runners.md
@@ -70,7 +70,7 @@ Because the runner runs as the same user on the same host as n8n, code that esca
 
 ### External mode <a href="#external-mode" id="external-mode"></a>
 
-In external mode, a [launcher application](https://github.com/n8n-io/task-runner-launcher) launches task runners on demand and manages their lifecycle. Typically, this means that next to n8n you add a sidecar container running the [`n8nio/runners`](https://hub.docker.com/r/n8nio/runners) image containing the launcher, the JS task runner and the Python task runner. This sidecar container is independent from the n8n instance.
+In external mode, a [launcher application](https://github.com/n8n-io/task-runner-launcher) launches task runners on demand and manages their lifecycle. Typically, this means that next to n8n you add a sidecar container running the [`n8nio/runners`](https://hub.docker.com/r/n8nio/runners) image containing the launcher, the JS task runner and the Python task runner. This sidecar container is independent from the n8n instance. The launcher process and the task runner process each expose a `/healthz` endpoint that the launcher uses to monitor them.
 
 ![Task runner deployed as a side-car container](../../.gitbook/assets/task-runner-external-mode.png)
 

--- a/docs/deploy/host-n8n/install-options/install-with-docker.md
+++ b/docs/deploy/host-n8n/install-options/install-with-docker.md
@@ -127,7 +127,7 @@ You can find a complete `docker-compose` file for PostgreSQL in the [n8n hosting
 
 To update n8n, in Docker Desktop, navigate to the **Images** tab and select **Pull** from the context menu to download the latest n8n image:
 
-![Docker Desktop Images tab with the row context menu open and Pull highlighted](../../.gitbook/assets/docker_desktop.png)
+![Docker Desktop Images tab with the row context menu open and Pull available](../../.gitbook/assets/docker_desktop.png)
 
 You can also use the command line to pull the latest, or a specific version:
 

--- a/docs/deploy/host-n8n/install-options/install-with-docker.md
+++ b/docs/deploy/host-n8n/install-options/install-with-docker.md
@@ -127,7 +127,7 @@ You can find a complete `docker-compose` file for PostgreSQL in the [n8n hosting
 
 To update n8n, in Docker Desktop, navigate to the **Images** tab and select **Pull** from the context menu to download the latest n8n image:
 
-![Docker Desktop](../../.gitbook/assets/docker_desktop.png)
+![Docker Desktop Images tab with the row context menu open and Pull highlighted](../../.gitbook/assets/docker_desktop.png)
 
 You can also use the command line to pull the latest, or a specific version:
 

--- a/docs/deploy/host-n8n/understand-the-architecture/understand-the-database.md
+++ b/docs/deploy/host-n8n/understand-the-architecture/understand-the-database.md
@@ -130,6 +130,6 @@ Maps tags to workflows. [tag_entity](#tag_entity) contains tag details.
 
 ## Entity Relationship Diagram (ERD) <a href="#entity-relationship-diagram-erd" id="entity-relationship-diagram-erd"></a>
 
-!["n8n ERD"](../../.gitbook/assets/n8n-database-diagram.png)
+![Entity relationship diagram showing foreign-key connections between n8n's database tables, including user, workflow_entity, execution_entity, and credentials_entity](../../.gitbook/assets/n8n-database-diagram.png)
 
 [^1]: In n8n, credentials store authentication information to connect with specific apps and services. After creating credentials with your authentication information (username and password, API key, OAuth secrets, etc.), you can use the associated app node to interact with the service.

--- a/docs/get-started/build-your-first-workflow.md
+++ b/docs/get-started/build-your-first-workflow.md
@@ -37,7 +37,7 @@ This guide will show you how to construct a workflow[^1] in n8n, explaining key 
   * Representing logic in an n8n workflow
   * Using expressions[^3]
 
-!["The completed workflow: Schedule Trigger connected to NASA, then an If node branching into two PostBin nodes"](.gitbook/assets/tutorial-first.png)
+![The completed workflow: Schedule Trigger connected to NASA, then an If node branching into two PostBin nodes](.gitbook/assets/tutorial-first.png)
 
 This quickstart uses [n8n Cloud](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/use-n8n-cloud), which is recommended for new users. A free trial is available - if you haven't already done so, [sign up](https://app.n8n.cloud/register) for an account now.
 

--- a/docs/get-started/build-your-first-workflow.md
+++ b/docs/get-started/build-your-first-workflow.md
@@ -37,7 +37,7 @@ This guide will show you how to construct a workflow[^1] in n8n, explaining key 
   * Representing logic in an n8n workflow
   * Using expressions[^3]
 
-!["Screenshot of the completed workflow"](.gitbook/assets/tutorial-first.png)
+!["The completed workflow: Schedule Trigger connected to NASA, then an If node branching into two PostBin nodes"](.gitbook/assets/tutorial-first.png)
 
 This quickstart uses [n8n Cloud](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/use-n8n-cloud), which is recommended for new users. A free trial is available - if you haven't already done so, [sign up](https://app.n8n.cloud/register) for an account now.
 
@@ -101,7 +101,7 @@ Credentials are private pieces of information issued by apps and services to aut
 
     This generates a date in the correct format, seven days before the current date.
 
-    ![image showing the expression above generating a date](.gitbook/assets/tutorial-date.png)
+    ![Start Date expression editor, with the Result panel showing a resolved date one week before today](.gitbook/assets/tutorial-date.png)
 7. Close the **Edit Expression** modal to return to the NASA node.
 8. You can now check that the node is working and returning the expected date: select **Execute step** to run the node manually. n8n calls the NASA API and displays details of solar flares in the past seven days in the **OUTPUT** section.
 9. Close the NASA node to return to the workflow canvas.
@@ -145,7 +145,7 @@ The last step of the workflow is to send the two reports about solar flares. For
     There was a solar flare of class {{$json["classType"]}}
     ```
 
-    ![image showing the expression above generating output](.gitbook/assets/tutorial-expression.png)
+    ![Expression editor for Bin Content, with the Result panel showing the rendered message text](.gitbook/assets/tutorial-expression.png)
 11. Close the expressions editor to return to the node.
 12. Close the Postbin node to return to the canvas.
 13. Add another Postbin node, to handle the **false** output path from the If node:

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.code.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.code.md
@@ -80,7 +80,7 @@ The main output is the normal connector found in all n8n workflows. If you have 
 
 By configuring the LangChain Code node connectors (inputs and outputs) you can use it as an app node, root node or sub-node.
 
-![Screenshot of a workflow with four LangChain nodes, configured as different node types](../../../.gitbook/assets/create-node-types.png)
+![Four LangChain Code nodes in one workflow, each set up as a different node type: app, root, sub-node, and sub-node with sub-nodes](../../../.gitbook/assets/create-node-types.png)
 
 | Node type                                                                    | Inputs                        | Outputs                                                                   | Code mode   |
 | ---------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------- | ----------- |

--- a/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepinecone.md
+++ b/docs/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.vectorstorepinecone.md
@@ -153,7 +153,7 @@ Refer to [LangChain's Pinecone documentation](https://js.langchain.com/docs/inte
 
 Your Pinecone index and namespace are available in your Pinecone account.
 
-![Screenshot of a Pinecone account, with the Pinecone index labelled](../../../.gitbook/assets/pinecone-index-namespace.png)
+![Pinecone console showing the index name and namespace location for a project](../../../.gitbook/assets/pinecone-index-namespace.png)
 
 [^1]: A vector store, or vector database, stores mathematical representations of information. Use with embeddings and retrievers to create a database that your AI can access when answering questions.
 [^2]: AI chains allow you to interact with large language models (LLMs) and other resources in sequences of calls to components. AI chains in n8n don't use persistent memory, so you can't use them to reference previous context (use AI agents for this).

--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolvectorstore.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.toolvectorstore.md
@@ -54,9 +54,15 @@ Spaces in the node name are converted to underscores in the tool description.
 {% hint style="warning" %}
 **Avoid special characters in node names**
 
-Using special characters in the node name will cause errors when the agent runs:
+Using special characters in the node name will cause errors when the agent runs, for example:
 
-![model errors from special characters](../../../.gitbook/assets/name-characters-error.png)
+```
+Error in sub-node 'OpenAI Chat Model'
+
+Invalid 'tools[0].function.name': string does not match pattern. Expected a string that matches the pattern '^[a-zA-Z0-9_-]+$'.
+```
+
+![Error message shown when a tool name contains special characters](../../../.gitbook/assets/name-characters-error.png)
 
 Use only alphanumeric characters, spaces, dashes, and underscores in node names.
 {% endhint %}

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.formtrigger.md
@@ -95,7 +95,7 @@ Only users logged in to this n8n instance can view or submit the form.
 
 The Form Trigger node has two URLs: **Test URL** and **Production URL**. n8n displays the URLs at the top of the node panel. Select **Test URL** or **Production URL** to toggle which URL n8n displays.
 
-![Screenshot of the form URLs](../../.gitbook/assets/form-urls.png)
+![Form Trigger node panel showing the Test URL and Production URL fields with the toggle between them](../../.gitbook/assets/form-urls.png)
 
 - **Test URL**: n8n registers a test webhook when you select **Execute Step** or **Execute Workflow**, if the workflow isn't active. When you call the URL, n8n displays the data in the workflow.
 - **Production URL**: n8n registers a production webhook when you publish the workflow. When using the production URL, n8n doesn't display the data in the workflow. You can still view workflow data for a production execution. Select the **Executions** tab in the workflow, then select the workflow execution you want to view.

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.set.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.set.md
@@ -59,7 +59,7 @@ If you don't want to use expressions:
 
 You can do this for both the name and value of the field.
 
-![A gif showing the drag and drop action, as well as changing a field to fixed](<../../.gitbook/assets/drag-drop-fixed-toggle (1).gif>)
+![A field being dragged from INPUT into Fields to Set, then its Value toggled from Expression to Fixed](<../../.gitbook/assets/drag-drop-fixed-toggle (1).gif>)
 
 ### Keep Only Set Fields <a href="#keep-only-set-fields" id="keep-only-set-fields"></a>
 

--- a/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/README.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-langchain.chattrigger/README.md
@@ -108,7 +108,7 @@ Enter the text for these elements in the chat interface.
 
 <summary>View screenshot</summary>
 
-![Customizable text elements](../../../.gitbook/assets/hosted-text-elements.png)
+![Chat widget preview showing the Input Placeholder, Title, and Subtitle text fields](../../../.gitbook/assets/hosted-text-elements.png)
 
 </details>
 

--- a/docs/integrations/builtin/credentials/google/oauth-single-service.md
+++ b/docs/integrations/builtin/credentials/google/oauth-single-service.md
@@ -49,7 +49,7 @@ n8n Cloud users can use **Managed OAuth2** for the following nodes:
 
 To use **Managed OAuth2**, just click **Sign in with Google** in the credentials screen. No more setup is required in the Google Cloud Console or elsewhere.
 
-![Managed OAuth2 credentials screen](../../../.gitbook/assets/managed-oauth.png)
+![n8n credential screen with a Sign in with Google button and a dropdown to switch to Custom OAuth2](../../../.gitbook/assets/managed-oauth.png)
 
 If you prefer to use Custom OAuth2, use the dropdown to change the authentication type.
 

--- a/docs/integrations/builtin/custom-api-actions-for-existing-nodes.md
+++ b/docs/integrations/builtin/custom-api-actions-for-existing-nodes.md
@@ -30,5 +30,5 @@ Some existing credential types have specific scopes: endpoints that they work wi
 
 For example, follow the steps in [Using predefined credential types](#using-predefined-credential-types), and select **Google Calendar OAuth2 API** as your **Credential Type**. n8n displays a box listing the two endpoints you can use this credential type with: `calendar` and `calendar.events`.
 
-![Scopes notice listing the calendar and calendar.events endpoints for the Google Calendar OAuth2 API credential type](../.gitbook/assets/scopes.png)
+![Scopes notice for the Google Calendar OAuth2 API credential type](../.gitbook/assets/scopes.png)
 

--- a/docs/integrations/builtin/custom-api-actions-for-existing-nodes.md
+++ b/docs/integrations/builtin/custom-api-actions-for-existing-nodes.md
@@ -26,9 +26,9 @@ For example: you create an Asana credential, for use with the Asana node. Later,
 
 ### Credential scopes <a href="#credential-scopes" id="credential-scopes"></a>
 
-Some existing credential types have specific scopes: endpoints that they work with. n8n warns you about this when you select the credential type.
+Some existing credential types have specific scopes: the parts of the API they can access. n8n warns you about this when you select the credential type.
 
-For example, follow the steps in [Using predefined credential types](#using-predefined-credential-types), and select **Google Calendar OAuth2 API** as your **Credential Type**. n8n displays a box listing the two endpoints you can use this credential type with: `calendar` and `calendar.events`.
+For example, follow the steps in [Using predefined credential types](#using-predefined-credential-types), and select **Google Calendar OAuth2 API** as your **Credential Type**. n8n displays a box listing the two scopes this credential type covers: `calendar` and `calendar.events`.
 
 ![Scopes notice for the Google Calendar OAuth2 API credential type](../.gitbook/assets/scopes.png)
 

--- a/docs/integrations/builtin/custom-api-actions-for-existing-nodes.md
+++ b/docs/integrations/builtin/custom-api-actions-for-existing-nodes.md
@@ -28,7 +28,7 @@ For example: you create an Asana credential, for use with the Asana node. Later,
 
 Some existing credential types have specific scopes: endpoints that they work with. n8n warns you about this when you select the credential type.
 
-For example, follow the steps in [Using predefined credential types](#using-predefined-credential-types), and select **Google Calendar OAuth2 API** as your **Credential Type**. n8n displays a box listing the two endpoints you can use this credential type with:
+For example, follow the steps in [Using predefined credential types](#using-predefined-credential-types), and select **Google Calendar OAuth2 API** as your **Credential Type**. n8n displays a box listing the two endpoints you can use this credential type with: `calendar` and `calendar.events`.
 
-![The scopes box](../.gitbook/assets/scopes.png)
+![Scopes notice listing the calendar and calendar.events endpoints for the Google Calendar OAuth2 API credential type](../.gitbook/assets/scopes.png)
 

--- a/docs/integrations/builtin/handle-rate-limits.md
+++ b/docs/integrations/builtin/handle-rate-limits.md
@@ -65,7 +65,7 @@ Use the Loop Over Items node to batch the input items, and the Wait node to intr
 
 For example, to handle rate limits when using OpenAI:
 
-!["Screenshot of a workflow using the Loop Over Items node and Wait node to handle API rate limits for the OpenAI APIs"](../.gitbook/assets/loop-wait.png)
+![Workflow using Loop Over Items and Wait nodes to pace requests to the OpenAI API](../.gitbook/assets/loop-wait.png)
 
 ## Handle rate limits in the HTTP Request node <a href="#handle-rate-limits-in-the-http-request-node" id="handle-rate-limits-in-the-http-request-node"></a>
 

--- a/docs/reusable-content/.gitbook/includes/integrations/builtin/cluster-nodes/cluster-nodes-summary.md
+++ b/docs/reusable-content/.gitbook/includes/integrations/builtin/cluster-nodes/cluster-nodes-summary.md
@@ -3,4 +3,4 @@ title: cluster-nodes-summary
 ---
 [Cluster nodes](https://app.gitbook.com/s/CxSeOtVxqqhfxMSac0AV/key-concept-glossary#cluster-node-n8n) are node groups that work together to provide functionality in an n8n workflow. Instead of using a single node, you use a [root node](https://app.gitbook.com/s/CxSeOtVxqqhfxMSac0AV/key-concept-glossary#root-node-n8n) and one or more [sub-nodes](https://app.gitbook.com/s/CxSeOtVxqqhfxMSac0AV/key-concept-glossary#sub-node-n8n) that extend the functionality of the node.
 
-![Screenshot of a workflow with a root node and two sub-nodes](../../../../assets/root-sub-nodes.png)
+![A workflow diagram with one root node connected to two sub-nodes](../../../../assets/root-sub-nodes.png)

--- a/docs/reusable-content/.gitbook/includes/integrations/builtin/core-nodes/merge/if-merge-branch-execution.md
+++ b/docs/reusable-content/.gitbook/includes/integrations/builtin/core-nodes/merge/if-merge-branch-execution.md
@@ -12,6 +12,6 @@ One data stream triggers the Merge node, which then goes and executes the other 
 
 For example, in the screenshot below there's a workflow containing an Edit Fields node, If node, and Merge node. The standard If node behavior is to execute one data stream (in the screenshot, this is the **true** output). However, due to the Merge node, both data streams execute, despite the If node not sending any data down the **false** data stream.
 
-![Screenshot of a workflow. The workflow has an Edit Fields node, followed by an If node. It ends with a Merge node.](../../../../../assets/if-merge-node.png)
+![A workflow with an Edit Fields node, an If node, and a Merge node connected in sequence](../../../../../assets/if-merge-node.png)
 
 


### PR DESCRIPTION
## Summary

Bring all images across the docs into line with the image guidance in the
style guide (`docs/contribute/style-guide-for-n8n-docs.md`, "Images"
section): every instruction, setting, value, or error an agent/screen reader
needs has to be in the prose, not locked inside a picture, and alt text has
to describe what the image shows.

Audited all 58 pages containing images (~85 image references) and fixed
every violation found:

- **7 content-level gaps** where real information existed only in an image —
  now written into the prose, verified against the actual screenshots (not
  guessed): a missing `/healthz` endpoint detail on the task runner diagram,
  two undocumented API scope names, a transcribed error message, branching
  logic described only in an over-length alt text, a nested-data bolding
  convention, expression-editor steps shown only in a GIF, and a credential
  `name`-matching code sample that was a screenshot of code.
- **~50 alt-text quality fixes**: empty alt text (8 images in
  `save-and-publish-workflows.md`), duplicate non-descriptive alt text reused
  across visually distinct images (5 in `understand-dirty-nodes.md`, 15 in
  `node-ui-elements.md`), filenames used as alt text, generic labels
  ("Diagram", element type names), and the disallowed "Screenshot of"/"Image
  of"/"image showing" prefixes.
- Fixed two instances of malformed alt-text markdown syntax (stray literal
  quote marks inside the alt brackets).

## Changes

41 files touched, all under `docs/`: `deploy/`, `changelog/`, `administer/`,
`integrations/builtin/`, `build/`, `connect/`, `get-started/`, and
`reusable-content/`. No content restructuring — changes are limited to alt
text and the addition of prose sentences/code blocks next to the affected
images. Full list in the diff.

## Test plan

- [ ] Review the diff for wording accuracy, especially the new prose
      sentences added next to images (task runner `/healthz`, Google
      Calendar scopes, ToolVectorStore error text, conditional branching
      logic, nested data bolding, expression editor steps, credential name
      matching in `troubleshooting.md`)
- [ ] Spot-check a few of the rewritten alt texts against their images in
      the rendered GitBook preview
- [ ] Run Vale/Lexi lint across the touched files
