### PR TITLE
ci: flag app.gitbook.com URLs that target the page's own space

### DIFF
--- a/.github/scripts/check_internal_links.py
+++ b/.github/scripts/check_internal_links.py
@@ -16,6 +16,13 @@ GitBook rules enforced (see docs/contribute + the internal-linking guide):
      page path is checked against a `.md` file in the target space, EXCEPT for
      GitBook-generated subtrees (see GENERATED_PATH_PREFIXES) that have no `.md`
      source to resolve against, e.g. the OpenAPI-rendered API reference.
+  4. The inverse of rule 3: an app.gitbook.com URL must NOT target the space the
+     linking page already lives in. Such a link renders fine (GitBook rewrites it
+     to an in-site href on the published site), but it opts out of GitBook's
+     rename tracking -- relative `.md` links are kept up to date when a page
+     moves, a hardcoded space-ID URL isn't -- so it rots silently. It's also
+     unverifiable in a GitBook preview, since it resolves against published
+     content instead of the revision under review.
 
 External URLs (http/https), mailto:, in-page anchors (#...), and links inside
 code blocks are ignored. See EXCLUDE_FILES for intentional example links.
@@ -194,8 +201,11 @@ def iter_targets(text: str):
             yield i, m.group(1).strip()
 
 
-def classify_cross_space(target: str):
+def classify_cross_space(target: str, src_rel: str):
     """Validate an app.gitbook.com/s/<id>/<path> cross-space link.
+
+    `src_rel` is the repo-relative path of the file holding the link, used to
+    reject a URL pointing back into that file's own space (rule 4).
 
     Returns (category, message) if broken, "unknown" if the space ID isn't in
     the table (can't verify — e.g. the reusable-content utility space), or None
@@ -213,6 +223,15 @@ def classify_cross_space(target: str):
         _STATS["unknown_space_ids"].add(space_id)
         _STATS["unknown_space_links"] += 1
         return "unknown"
+    # Rule 4: the cross-space form aimed at the linking page's own space. Checked
+    # before the path lookups below so the message names the wrong link form
+    # rather than reporting a (possibly valid) target as missing.
+    if space_of(src_rel) == folder:
+        return (
+            "same-space-absolute",
+            f"app.gitbook.com URL targets this page's own space '{folder}'; "
+            f"use a relative .md link so GitBook keeps it updated on rename: {target}",
+        )
     page_path = page_path.strip("/")
     base = DOCS_ROOT / folder
     if page_path == "":
@@ -234,12 +253,15 @@ def classify_cross_space(target: str):
     return broken
 
 
-def classify(md_file: Path, line: int, target: str):
-    """Return (category, message) for a broken link, or None if the link is fine."""
+def classify(md_file: Path, src_rel: str, target: str):
+    """Return (category, message) for a broken link, or None if the link is fine.
+
+    `src_rel` is md_file as a repo-relative posix path (the caller already has it).
+    """
     # Cross-space app.gitbook.com links: validate against the space-ID table
     # before the generic http scheme is skipped below.
     if APP_GITBOOK_RE.match(target):
-        result = classify_cross_space(target)
+        result = classify_cross_space(target, src_rel)
         return None if result == "unknown" else result
 
     # Strip anchor and query.
@@ -294,7 +316,6 @@ def classify(md_file: Path, line: int, target: str):
         resolved_rel = resolved.relative_to(REPO_ROOT).as_posix()
     except ValueError:
         return None
-    src_rel = md_file.relative_to(REPO_ROOT).as_posix()
     src_space, dst_space = space_of(src_rel), space_of(resolved_rel)
     if src_space and dst_space and src_space != dst_space:
         return (
@@ -345,7 +366,7 @@ def main() -> int:
         raw = md_file.read_text(encoding="utf-8", errors="replace")
         text = strip_code(blank_gitbook_native(raw))
         for line, target in iter_targets(text):
-            result = classify(md_file, line, target)
+            result = classify(md_file, rel, target)
             if result is None:
                 continue
             category, message = result

--- a/.github/scripts/tests/fixtures/links/docs/spacea/.gitbook/assets/img.png
+++ b/.github/scripts/tests/fixtures/links/docs/spacea/.gitbook/assets/img.png
@@ -1,0 +1,1 @@
+not-a-real-png

--- a/.github/scripts/tests/fixtures/links/docs/spacea/README.md
+++ b/.github/scripts/tests/fixtures/links/docs/spacea/README.md
@@ -1,0 +1,1 @@
+# Space A landing

--- a/.github/scripts/tests/fixtures/links/docs/spacea/page-one.md
+++ b/.github/scripts/tests/fixtures/links/docs/spacea/page-one.md
@@ -1,0 +1,1 @@
+# Page one

--- a/.github/scripts/tests/fixtures/links/docs/spacea/sub/page-two.md
+++ b/.github/scripts/tests/fixtures/links/docs/spacea/sub/page-two.md
@@ -1,0 +1,1 @@
+# Page two

--- a/.github/scripts/tests/fixtures/links/docs/spaceb/other.md
+++ b/.github/scripts/tests/fixtures/links/docs/spaceb/other.md
@@ -1,0 +1,1 @@
+# Other page

--- a/.github/scripts/tests/test_check_internal_links.py
+++ b/.github/scripts/tests/test_check_internal_links.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Network-free tests for check_internal_links.py, run against a checked-in fake
+repo tree under tests/fixtures/links. Locks in all five link rules (same-space
+absolute, cross-space relative, cross-space broken, .md extension, target
+exists), asset and absolute-path handling, and the parsing helpers that decide
+what counts as a link at all.
+
+Also asserts that the space-ID table still parses out of the real style guide.
+That table is scraped from Markdown with a regex, so reformatting it would
+silently empty the map and make every cross-space link unverifiable while the
+job still exits 0 -- the one failure mode this checker can't self-report.
+
+Run: python3 .github/scripts/tests/test_check_internal_links.py
+"""
+import importlib.util
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "check_internal_links.py"
+FIXTURE_REPO = HERE / "fixtures" / "links"
+
+spec = importlib.util.spec_from_file_location("cil", SCRIPT)
+cil = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cil)
+
+checks = []
+
+
+def check(name, cond):
+    checks.append((name, bool(cond)))
+
+
+def classify(src_rel, target):
+    """Run classify() for a link written in fixture file `src_rel`."""
+    return cil.classify(FIXTURE_REPO / src_rel, src_rel, target)
+
+
+def category(src_rel, target):
+    result = classify(src_rel, target)
+    return result[0] if result else None
+
+
+def main():
+    # --- Real style guide: the space table must still parse -------------------
+    # Run before the fixture overrides below, while the module still points at
+    # the real repo.
+    real_spaces = cil.load_space_ids()
+    check("space-ID table parses out of the real style guide", len(real_spaces) == 9)
+    check("space table maps integrations", real_spaces.get("BKcbOzIWja8NfqKDcqHc") == "integrations")
+    check("space table maps deploy", real_spaces.get("jm0ZYRpZIPWge2ZSiDYO") == "deploy")
+
+    # --- Point the module at the fixture tree ---------------------------------
+    # Functions read these globals at call time.
+    cil.REPO_ROOT = FIXTURE_REPO
+    cil.DOCS_ROOT = FIXTURE_REPO / "docs"
+    cil.SPACE_ID_TO_FOLDER = {"SA": "spacea", "SB": "spaceb"}
+
+    A = "docs/spacea/page-one.md"          # a page in space A
+    A_SUB = "docs/spacea/sub/page-two.md"  # a page one level deeper
+
+    # --- Rule 4 (new): app.gitbook.com URL into the page's own space ----------
+    check("same-space app.gitbook.com link is flagged",
+          category(A, "https://app.gitbook.com/s/SA/sub/page-two") == "same-space-absolute")
+    check("same-space flagged even when the target exists",
+          category(A, "https://app.gitbook.com/s/SA/README") == "same-space-absolute")
+    check("same-space flagged from a nested page",
+          category(A_SUB, "https://app.gitbook.com/s/SA/page-one") == "same-space-absolute")
+    check("same-space flagged with an anchor",
+          category(A, "https://app.gitbook.com/s/SA/page-one#some-heading") == "same-space-absolute")
+    same_space = classify(A, "https://app.gitbook.com/s/SA/page-one")
+    check("same-space message names the space and the fix",
+          same_space is not None
+          and "own space 'spacea'" in same_space[1]
+          and "relative .md link" in same_space[1])
+
+    # --- Rule 3: genuine cross-space links still behave -----------------------
+    check("valid cross-space link passes",
+          category(A, "https://app.gitbook.com/s/SB/other") is None)
+    check("broken cross-space link is flagged",
+          category(A, "https://app.gitbook.com/s/SB/nope") == "cross-space-broken")
+    check("cross-space link to a space root passes",
+          category(A, "https://app.gitbook.com/s/SB") is None)
+    check("cross-space traversal out of the space is flagged",
+          category(A, "https://app.gitbook.com/s/SB/../spacea/page-one") == "cross-space-broken")
+    check("unknown space ID is skipped, not flagged",
+          category(A, "https://app.gitbook.com/s/UNKNOWN/whatever") is None)
+    check("relative link crossing spaces is flagged",
+          category(A, "../spaceb/other.md") == "cross-space-relative")
+
+    # --- Rules 1 and 2: extension and existence -------------------------------
+    check("same-space relative link passes", category(A, "sub/page-two.md") is None)
+    check("relative link up and back down passes", category(A_SUB, "../page-one.md") is None)
+    check("link without .md is flagged", category(A, "sub/page-two") == "no-md-extension")
+    check("trailing-slash link is flagged", category(A, "sub/") == "no-md-extension")
+    check("missing .md target is flagged", category(A, "gone.md") == "missing-target")
+    check("absolute path is flagged", category(A, "/spacea/page-one.md") == "absolute-path")
+
+    # --- Assets ---------------------------------------------------------------
+    check("existing asset passes", category(A, ".gitbook/assets/img.png") is None)
+    check("missing asset is flagged", category(A, ".gitbook/assets/nope.png") == "missing-asset")
+
+    # --- Non-links ------------------------------------------------------------
+    check("external URL is ignored", category(A, "https://example.com/page") is None)
+    check("mailto is ignored", category(A, "mailto:help@n8n.io") is None)
+    check("pure anchor is ignored", category(A, "#a-heading") is None)
+    check("templating is ignored", category(A, "{{ variable }}") is None)
+
+    # --- Parsing helpers: what counts as a link -------------------------------
+    fenced = "```\n[x](broken.md)\n```\n[y](page-one.md)\n"
+    check("links inside fenced code are dropped",
+          [t for _, t in cil.iter_targets(cil.strip_code(fenced))] == ["page-one.md"])
+    check("links inside inline code are dropped",
+          [t for _, t in cil.iter_targets(cil.strip_code("`[x](broken.md)` text"))] == [])
+    check("strip_code preserves line numbers",
+          cil.strip_code(fenced).count("\n") == fenced.count("\n"))
+
+    card = '<table data-view="cards"><tr><td><a href="no-md-here/">x</a></td></tr></table>\n'
+    check("GitBook card-table links are dropped",
+          [t for _, t in cil.iter_targets(cil.blank_gitbook_native(card))] == [])
+    button = '<a href="no-md-here/" class="button primary">Go</a>\n'
+    check("GitBook button links are dropped",
+          [t for _, t in cil.iter_targets(cil.blank_gitbook_native(button))] == [])
+
+    check("footnote definitions aren't treated as links",
+          [t for _, t in cil.iter_targets("[^1]: some explanatory text\n")] == [])
+    check("reference definitions are treated as links",
+          [t for _, t in cil.iter_targets("[ref]: page-one.md\n")] == ["page-one.md"])
+    check("filenames with parens are captured whole",
+          [t for _, t in cil.iter_targets("[x]((node-name).all.md)")] == ["(node-name).all.md"])
+
+    # --- space_of -------------------------------------------------------------
+    check("space_of reads the top-level folder", cil.space_of(A) == "spacea")
+    check("space_of is None for a file directly under docs/",
+          cil.space_of("docs/loose.md") is None)
+    check("space_of is None outside docs/", cil.space_of("skills/SKILL.md") is None)
+
+    failed = [n for n, ok in checks if not ok]
+    for n, ok in checks:
+        print(f"  {'PASS' if ok else 'FAIL'}  {n}")
+    if failed:
+        print(f"\n{len(failed)} FAILED")
+        return 1
+    print(f"\nAll {len(checks)} checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -19,3 +19,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run gitbook_preview_links tests
         run: python3 .github/scripts/tests/test_gitbook_preview_links.py
+
+  check-internal-links:
+    name: runner / check-internal-links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Run check_internal_links tests
+        run: python3 .github/scripts/tests/test_check_internal_links.py

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ yarn.lock
 ## Ignore ephemeral doc-tool output
 output.csv
 _doctools/*.csv
+
+## Python bytecode from running .github/scripts helpers and their tests
+__pycache__/
+*.pyc

--- a/docs/contribute/style-guide-for-n8n-docs.md
+++ b/docs/contribute/style-guide-for-n8n-docs.md
@@ -578,6 +578,8 @@ For example, to link from a page in the `administer` space to `docs/deploy/host-
 [link to a page](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/user-management)
 ```
 
+Use this form only for a page in a *different* space. For a page in the space you're already editing, use a relative `.md` link instead. GitBook renders both forms, but a space URL drops out of GitBook's rename tracking, so the link breaks when someone moves the target page. It also escapes the revision on a GitBook preview, resolving against published content instead of your changes. The `internal-links` CI check reports these as `same-space-absolute`.
+
 Each top-level folder under `docs/` is a separate space:
 
 | Space folder | Space ID |

--- a/docs/deploy/host-n8n/deploy-as-an-oem-integration/set-up-token-exchange.md
+++ b/docs/deploy/host-n8n/deploy-as-an-oem-integration/set-up-token-exchange.md
@@ -107,7 +107,7 @@ The embed login endpoint doesn't require `N8N_TOKEN_EXCHANGE_ENABLED`, and the t
 {% hint style="info" %}
 **File-based configuration**
 
-You can add `_FILE` to individual variables to provide their configuration in a separate file. Refer to [Keeping sensitive data in separate files](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/basic-configuration#keeping-sensitive-data-in-separate-files) for more details.
+You can add `_FILE` to individual variables to provide their configuration in a separate file. Refer to [Keeping sensitive data in separate files](../configure-n8n/basic-configuration.md#keeping-sensitive-data-in-separate-files) for more details.
 {% endhint %}
 
 For example, for large or multi-line JSON, store the trusted keys in a file and set `N8N_TOKEN_EXCHANGE_TRUSTED_KEYS_FILE=/path/to/trusted-keys.json`.


### PR DESCRIPTION
Closes DOC-2243.

## Problem

`check_internal_links.py` enforces the space rule in one direction only. A **relative** link that crosses spaces is an error (`cross-space-relative`). The inverse — an `app.gitbook.com/s/<id>/...` URL aimed at the space the linking page already lives in — wasn't checked at all.

Found while reviewing #5271, where `n8n-nodes-langchain.agent/README.md` (integrations space) links to `https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/mcp-servers` — the integrations space. CI passed.

## Why it's worth catching

Not a rendering bug. GitBook rewrites these to in-site hrefs on the published site — verified against the one live instance of this on main. Two real costs:

1. **Rename tracking.** The style guide already says relative `.md` links "are automatically kept up to date when pages move or are renamed". A hardcoded space-ID URL isn't, so it rots when the target moves.
2. **Unreviewable in preview.** These always escape the revision and resolve against published content. A reviewer clicking one on a GitBook preview gets the live page, or a 404 when the target is new in that PR.

## Changes

- **New `same-space-absolute` rule**, at the same severity as the existing `cross-space-relative` rule. `classify_cross_space()` now takes the source path; `classify()`'s `line` parameter was unused, so it carries the path instead of widening the signature.
- **Fixed the one pre-existing violation** in `set-up-token-exchange.md` — the only one repo-wide.
- **First tests for this script.** It had none. 37 checks covering every rule, the asset/absolute-path branches, and the parsing helpers.
- **Wired into the existing `script-tests.yml`**, which already triggers on `.github/scripts/**`.
- **Style guide**: one sentence making the rule explicit, so the error message traces to written guidance.
- **`.gitignore`**: `__pycache__/`, since this PR encourages running the tests locally.

The highest-value test isn't the new rule — it's the guard that the space-ID table still parses out of the style guide's Markdown. That table is scraped with a regex; reformatting it would silently empty the map and make *every* cross-space link unverifiable while the job still exits 0. That's the one failure mode this checker can't self-report.

## Verification

- 37/37 pass. Mutation test (disabling the rule) yields 5 clean FAILs, so the coverage isn't vacuous.
- Full-repo A/B on an identical tree: byte-identical output before and after. No regression in existing detection.
- Positive test against #5271's file reports `same-space-absolute` at the correct line.
- Vale clean on both changed doc lines.

## Not included

Anchor validation. `#fragment` is stripped and discarded, so nothing verifies deep links resolve to real headings — the largest remaining gap. It needs handling for GitBook auto-anchors, legacy explicit `<a id="...">` tags, and footnote anchors, so it wants its own ticket.