### PR TITLE
docs: fix broken in-page anchors on Understand the database (DOC-2244)

### DIFF
--- a/docs/deploy/host-n8n/understand-the-architecture/understand-the-database.md
+++ b/docs/deploy/host-n8n/understand-the-architecture/understand-the-database.md
@@ -61,7 +61,7 @@ Lists the [community nodes](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/commu
 
 ### installed_packages <a href="#installedpackages" id="installedpackages"></a>
 
-Details of npm community nodes packages installed in your n8n instance. [installed_nodes](#installed_nodes) lists each individual node. `installed_packages` lists npm packages, which may contain more than one node.
+Details of npm community nodes packages installed in your n8n instance. [`installed_nodes`](#installednodes) lists each individual node. `installed_packages` lists npm packages, which may contain more than one node.
 
 ### migrations <a href="#migrations" id="migrations"></a>
 
@@ -98,7 +98,7 @@ Maps workflows to users.
 
 ### tag_entity <a href="#tagentity" id="tagentity"></a>
 
-All workflow tags created in the n8n instance. This table lists the tags. [workflows_tags](#workflows_tags) records which workflows have which tags.
+All workflow tags created in the n8n instance. This table lists the tags. [`workflows_tags`](#workflowstags) records which workflows have which tags.
 
 ### user <a href="#user" id="user"></a>
 
@@ -126,7 +126,7 @@ Counts workflow IDs and their status.
 
 ### workflows_tags <a href="#workflowstags" id="workflowstags"></a>
 
-Maps tags to workflows. [tag_entity](#tag_entity) contains tag details.
+Maps tags to workflows. [`tag_entity`](#tagentity) contains tag details.
 
 ## Entity Relationship Diagram (ERD) <a href="#entity-relationship-diagram-erd" id="entity-relationship-diagram-erd"></a>
 


### PR DESCRIPTION
Closes DOC-2244.

Three in-page links on [Understand the database](https://docs.n8n.io/deploy/host-n8n/understand-the-architecture/understand-the-database) pointed at anchors that don't exist, so clicking them did nothing.

The table-name headings carry explicit anchor markup that strips the underscore, but the body links kept it:

| Line | Was | Now |
| --- | --- | --- |
| 64 | `#installed_nodes` | `#installednodes` |
| 101 | `#workflows_tags` | `#workflowstags` |
| 129 | `#tag_entity` | `#tagentity` |

## Verified against the live page

GitBook does not rewrite these. The rendered HTML has the body link keeping the underscore while the heading ID doesn't have it, and the sidebar TOC using the correct stripped form:

```
body link:   href=".../understand-the-database#installed_nodes"   <- dead
heading id:  id="installednodes"                                   <- actual
sidebar TOC: href="#installednodes"                                <- correct
```

Zero elements on the page carried the underscored IDs. After this change all three in-page anchors resolve to a real heading ID, and those are the only in-page anchors on the page.

## Also included

The three link texts are now code-formatted, matching `installed_packages` which was already formatted that way on the same line. This also clears three pre-existing `Vale.Spelling` errors on those lines, which would otherwise have surfaced as new findings just because the diff touches them.

## Related

Same bug class as #5278 / DOC-2230 (broken anchors from a heading-ID mismatch), different root cause — that one was GitBook's `id-N.-` prefix on digit-leading headings, this is underscore stripping.

Found by an ad-hoc scan while working on #5277. Neither failure mode is predictable by eye, so automating the check is tracked in DOC-2245: `check_internal_links.py` currently strips and discards every `#fragment`, so nothing catches this class today.