### PR TITLE
ci: validate #anchor fragments in internal links

### DIFF
--- a/.github/scripts/check_internal_links.py
+++ b/.github/scripts/check_internal_links.py
@@ -418,9 +418,12 @@ def heading_ids(path: Path) -> tuple:
     headings = strip_code(raw, inline=False)
     explicit = set(EXPLICIT_ID_RE.findall(markup))
     slugs = set()
-    for line in headings.split("\n"):
+    # Walk both views in step: judge id-presence on the markup line (so an
+    # `<a id="...">` shown inside backticks doesn't count as a real anchor) while
+    # slugging the heading line (which keeps its code spans).
+    for line, line_markup in zip(headings.split("\n"), markup.split("\n")):
         m = HEADING_RE.match(line)
-        if m and not re.search(r'<a\b[^>]*\bid="', m.group(1)):
+        if m and not re.search(r'<a\b[^>]*\bid="', line_markup):
             s = anchor_slug(m.group(1))
             if s:
                 slugs.add(s)

--- a/.github/scripts/check_internal_links.py
+++ b/.github/scripts/check_internal_links.py
@@ -23,9 +23,17 @@ GitBook rules enforced (see docs/contribute + the internal-linking guide):
      moves, a hardcoded space-ID URL isn't -- so it rots silently. It's also
      unverifiable in a GitBook preview, since it resolves against published
      content instead of the revision under review.
+  5. A `#anchor` must match a heading on the target page. Checked against the
+     explicit `id="..."` markup that 93% of headings carry, following
+     `{% include %}` blocks so headings from reusable content count. Reported as
+     a WARNING, not an error: where the target heading has no explicit id, or an
+     include can't be resolved, the anchor is left unchecked rather than guessed
+     at, so a miss costs coverage instead of a false alarm. A bare `#` with no
+     anchor is reported separately as `empty-anchor`. Both warn until the repo's
+     existing broken anchors are fixed; `--strict-anchors` fails on them now.
 
-External URLs (http/https), mailto:, in-page anchors (#...), and links inside
-code blocks are ignored. See EXCLUDE_FILES for intentional example links.
+External URLs (http/https), mailto:, and links inside code blocks are ignored.
+See EXCLUDE_FILES for intentional example links.
 
 Usage:
     python3 .github/scripts/check_internal_links.py [files...]
@@ -253,6 +261,166 @@ def classify_cross_space(target: str, src_rel: str):
     return broken
 
 
+# --------------------------------------------------------------------------- #
+# Anchor validation (rule 5)
+# --------------------------------------------------------------------------- #
+
+# GitBook generates these from `[^1]` footnote markers; there's no heading to
+# match them against, so they're always accepted.
+FOOTNOTE_ANCHOR_RE = re.compile(r"^user-content-fn-")
+EXPLICIT_ID_RE = re.compile(r'id="([^"]+)"')
+HEADING_RE = re.compile(r"^#{1,6}\s+(.*?)\s*$")
+# `{% include %}` in both forms GitBook emits: a reusable block URL, and a path
+# relative to the reusable-content space root.
+INCLUDE_URL_RE = re.compile(
+    r'\{%\s*include\s+"https?://app\.gitbook\.com/s/[^/]+/~/reusable/([A-Za-z0-9]+)/?"\s*%\}'
+)
+INCLUDE_REL_RE = re.compile(r'\{%\s*include\s+"(\.gitbook/includes/[^"]+)"\s*%\}')
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", s.lower())
+
+
+def _first_heading(path: Path) -> str:
+    try:
+        for line in path.read_text(encoding="utf-8", errors="replace").split("\n"):
+            m = HEADING_RE.match(line)
+            if m:
+                return re.sub(r"<a\b[^>]*>.*?</a>", "", m.group(1)).strip()
+    except OSError:
+        pass
+    return ""
+
+
+_REUSABLE_BLOCKS: dict | None = None
+
+
+def reusable_blocks() -> dict:
+    """Map reusable block ID -> include file, parsed from REUSABLE_CONTENT_INDEX.md.
+
+    That index is generated externally and runs stale, so a block ID missing here
+    isn't an error: the page that includes it is simply treated as unverifiable
+    (see heading_ids). Matches the index's Name against include filenames three
+    ways -- exact stem, normalized stem, normalized first heading -- which
+    resolves all but one block today.
+    """
+    global _REUSABLE_BLOCKS
+    if _REUSABLE_BLOCKS is not None:
+        return _REUSABLE_BLOCKS
+    blocks: dict = {}
+    incl_root = DOCS_ROOT / "reusable-content" / ".gitbook" / "includes"
+    files = list(incl_root.rglob("*.md")) if incl_root.is_dir() else []
+    by_stem = {p.stem: p for p in files}
+    by_norm = {_norm(p.stem): p for p in files}
+    by_heading: dict = {}
+    for p in files:
+        h = _first_heading(p)
+        if h:
+            by_heading.setdefault(_norm(h), p)
+    row = re.compile(r"^\|\s*`([A-Za-z0-9]+)`\s*\|\s*([^|]+?)\s*\|")
+    try:
+        text = (REPO_ROOT / "REUSABLE_CONTENT_INDEX.md").read_text(encoding="utf-8")
+    except OSError:
+        text = ""
+    for line in text.split("\n"):
+        m = row.match(line)
+        if not m:
+            continue
+        bid, name = m.group(1), m.group(2)
+        hit = by_stem.get(name) or by_norm.get(_norm(name)) or by_heading.get(_norm(name))
+        if hit:
+            blocks[bid] = hit
+    _REUSABLE_BLOCKS = blocks
+    return blocks
+
+
+def anchor_slug(heading: str) -> str:
+    """Approximate GitBook's heading slug.
+
+    Used ONLY to suppress anchors that may point at a heading with no explicit
+    `id=`, never to assert one is broken. A wrong guess therefore costs a missed
+    detection, not a false positive.
+    """
+    h = re.sub(r"<a\b[^>]*>.*?</a>", "", heading)
+    h = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", h)  # link -> its text
+    h = h.strip().lower().replace("`", "")
+    h = re.sub(r"[*_]", "", h)
+    h = re.sub(r"[^a-z0-9\s.-]", "", h)
+    return re.sub(r"\s+", "-", h.strip())
+
+
+_HEADING_IDS: dict = {}
+
+
+def heading_ids(path: Path) -> tuple:
+    """Return (explicit_ids, slug_ids, resolved) for a page, following includes.
+
+    `explicit_ids` come from `id="..."` markup and are authoritative -- 93% of
+    headings carry it. `slug_ids` are guessed for headings that don't, and are
+    only used to stay quiet. `resolved` is False when an `{% include %}` couldn't
+    be resolved, in which case the page's anchors aren't checked at all.
+    """
+    key = str(path)
+    if key in _HEADING_IDS:
+        return _HEADING_IDS[key]
+    _HEADING_IDS[key] = (set(), set(), True)  # cycle guard
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return _HEADING_IDS[key]
+    text = strip_code(raw)
+    explicit = set(EXPLICIT_ID_RE.findall(text))
+    slugs = set()
+    for line in text.split("\n"):
+        m = HEADING_RE.match(line)
+        if m and not re.search(r'<a\b[^>]*\bid="', m.group(1)):
+            s = anchor_slug(m.group(1))
+            if s:
+                slugs.add(s)
+    resolved = True
+    blocks = reusable_blocks()
+    for bid in INCLUDE_URL_RE.findall(text):
+        inc = blocks.get(bid)
+        if inc is None:
+            resolved = False
+            continue
+        e, s, r = heading_ids(inc)
+        explicit |= e
+        slugs |= s
+        resolved = resolved and r
+    for rel in INCLUDE_REL_RE.findall(text):
+        inc = DOCS_ROOT / "reusable-content" / rel
+        if not inc.is_file():
+            resolved = False
+            continue
+        e, s, r = heading_ids(inc)
+        explicit |= e
+        slugs |= s
+        resolved = resolved and r
+    _HEADING_IDS[key] = (explicit, slugs, resolved)
+    return _HEADING_IDS[key]
+
+
+def classify_anchor(target_page: Path, anchor: str, target: str):
+    """Validate a `#fragment` against the target page's heading IDs."""
+    if anchor == "":
+        return ("empty-anchor", f"link ends in a bare '#' with no anchor: {target}")
+    if FOOTNOTE_ANCHOR_RE.match(anchor):
+        return None
+    explicit, slugs, resolved = heading_ids(target_page)
+    if anchor in explicit:
+        return None
+    if not resolved:
+        return None  # unresolvable include on the target page: can't verify
+    if anchor in slugs:
+        return None  # heading has no explicit id: unverifiable, stay quiet
+    return (
+        "broken-anchor",
+        f"no heading with id '{anchor}' on the target page: {target}",
+    )
+
+
 def classify(md_file: Path, src_rel: str, target: str):
     """Return (category, message) for a broken link, or None if the link is fine.
 
@@ -266,10 +434,14 @@ def classify(md_file: Path, src_rel: str, target: str):
 
     # Strip anchor and query.
     path_part = target.split("#", 1)[0].split("?", 1)[0].strip()
+    anchor = target.split("#", 1)[1].strip() if "#" in target else None
 
     # Skip: external, mailto/other schemes, protocol-relative, pure anchors,
     # templating/liquid, and empty (pure-anchor) targets.
     if not path_part:
+        # In-page anchor: validate against this file's own headings.
+        if anchor is not None:
+            return classify_anchor(md_file, anchor, target)
         return None
     if re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*:", path_part):  # scheme: http:, mailto:, tel:
         return None
@@ -323,6 +495,10 @@ def classify(md_file: Path, src_rel: str, target: str):
             f"relative link crosses space {src_space} -> {dst_space} "
             f"(use an app.gitbook.com URL): {target}",
         )
+
+    # Rule 5: the target page exists, so check the anchor resolves on it.
+    if anchor is not None:
+        return classify_anchor(resolved, anchor, target)
     return None
 
 
@@ -338,6 +514,11 @@ def main() -> int:
         action="store_true",
         help="Treat cross-space relative links as warnings, not errors.",
     )
+    ap.add_argument(
+        "--strict-anchors",
+        action="store_true",
+        help="Fail on broken anchors instead of warning (see rule 5).",
+    )
     args = ap.parse_args()
 
     if args.files:
@@ -346,6 +527,10 @@ def main() -> int:
         files = discover_files()
 
     warn_categories = {"cross-space-relative"} if args.warn_cross_space else set()
+    if not args.strict_anchors:
+        # Phase 1: every rule-5 finding warns. Promote once the existing backlog
+        # of broken anchors is cleared, so the check starts from a clean repo.
+        warn_categories |= {"broken-anchor", "empty-anchor"}
 
     errors: list[str] = []
     warnings: list[str] = []

--- a/.github/scripts/check_internal_links.py
+++ b/.github/scripts/check_internal_links.py
@@ -154,9 +154,15 @@ def blank_gitbook_native(text: str) -> str:
     return text
 
 
-def strip_code(text: str) -> str:
+def strip_code(text: str, inline: bool = True) -> str:
     """Blank out fenced code blocks and inline code so their example links
-    aren't parsed, while preserving line numbers."""
+    aren't parsed, while preserving line numbers.
+
+    Pass inline=False to keep inline code spans. Heading extraction needs that:
+    GitBook slugifies a heading including its inline code, so dropping the span
+    would compute the wrong slug (`### Using `$if()` (advanced)` -> "using-advanced"
+    instead of "using-if-advanced").
+    """
     lines = text.split("\n")
     out = []
     fence = None  # active fence marker (``` or ~~~)
@@ -178,7 +184,7 @@ def strip_code(text: str) -> str:
             out.append("")
             continue
         # Drop inline code spans on the line.
-        out.append(re.sub(r"`[^`]*`", "", line))
+        out.append(re.sub(r"`[^`]*`", "", line) if inline else line)
     return "\n".join(out)
 
 
@@ -266,8 +272,10 @@ def classify_cross_space(target: str, src_rel: str):
 # --------------------------------------------------------------------------- #
 
 # GitBook generates these from `[^1]` footnote markers; there's no heading to
-# match them against, so they're always accepted.
-FOOTNOTE_ANCHOR_RE = re.compile(r"^user-content-fn-")
+# match them against, so they're always accepted. Anchored to the numeric form
+# GitBook actually emits, so a hand-written `#user-content-fn-something` isn't
+# waved through.
+FOOTNOTE_ANCHOR_RE = re.compile(r"^user-content-fn-\d+$")
 EXPLICIT_ID_RE = re.compile(r'id="([^"]+)"')
 HEADING_RE = re.compile(r"^#{1,6}\s+(.*?)\s*$")
 # `{% include %}` in both forms GitBook emits: a reusable block URL, and a path
@@ -293,6 +301,26 @@ def _first_heading(path: Path) -> str:
     return ""
 
 
+def _frontmatter_title(path: Path) -> str:
+    """The `title:` value from a file's YAML frontmatter, or "".
+
+    Some include files carry the index's Name here rather than in the filename
+    or first heading (for example vector-store-mode.md is "Operation Mode").
+    """
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").split("\n")
+    except OSError:
+        return ""
+    if not lines or lines[0].strip() != "---":
+        return ""
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        if line.startswith("title:"):
+            return line[len("title:"):].strip().strip("'\"")
+    return ""
+
+
 _REUSABLE_BLOCKS: dict | None = None
 
 
@@ -301,9 +329,9 @@ def reusable_blocks() -> dict:
 
     That index is generated externally and runs stale, so a block ID missing here
     isn't an error: the page that includes it is simply treated as unverifiable
-    (see heading_ids). Matches the index's Name against include filenames three
-    ways -- exact stem, normalized stem, normalized first heading -- which
-    resolves all but one block today.
+    (see heading_ids). Matches the index's Name against include filenames four
+    ways -- exact stem, normalized stem, normalized first heading, normalized
+    frontmatter title -- which resolves every block in the index today.
     """
     global _REUSABLE_BLOCKS
     if _REUSABLE_BLOCKS is not None:
@@ -314,10 +342,14 @@ def reusable_blocks() -> dict:
     by_stem = {p.stem: p for p in files}
     by_norm = {_norm(p.stem): p for p in files}
     by_heading: dict = {}
+    by_title: dict = {}
     for p in files:
         h = _first_heading(p)
         if h:
             by_heading.setdefault(_norm(h), p)
+        t = _frontmatter_title(p)
+        if t:
+            by_title.setdefault(_norm(t), p)
     row = re.compile(r"^\|\s*`([A-Za-z0-9]+)`\s*\|\s*([^|]+?)\s*\|")
     try:
         text = (REPO_ROOT / "REUSABLE_CONTENT_INDEX.md").read_text(encoding="utf-8")
@@ -328,7 +360,12 @@ def reusable_blocks() -> dict:
         if not m:
             continue
         bid, name = m.group(1), m.group(2)
-        hit = by_stem.get(name) or by_norm.get(_norm(name)) or by_heading.get(_norm(name))
+        hit = (
+            by_stem.get(name)
+            or by_norm.get(_norm(name))
+            or by_heading.get(_norm(name))
+            or by_title.get(_norm(name))
+        )
         if hit:
             blocks[bid] = hit
     _REUSABLE_BLOCKS = blocks
@@ -368,8 +405,12 @@ def heading_ids(path: Path) -> tuple:
     try:
         raw = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
+        # Unreadable: mark unresolved so the page's anchors are skipped rather
+        # than every one of them reported missing.
+        _HEADING_IDS[key] = (set(), set(), False)
         return _HEADING_IDS[key]
-    text = strip_code(raw)
+    # Keep inline code: GitBook slugifies a heading including its code spans.
+    text = strip_code(raw, inline=False)
     explicit = set(EXPLICIT_ID_RE.findall(text))
     slugs = set()
     for line in text.split("\n"):

--- a/.github/scripts/check_internal_links.py
+++ b/.github/scripts/check_internal_links.py
@@ -409,11 +409,16 @@ def heading_ids(path: Path) -> tuple:
         # than every one of them reported missing.
         _HEADING_IDS[key] = (set(), set(), False)
         return _HEADING_IDS[key]
-    # Keep inline code: GitBook slugifies a heading including its code spans.
-    text = strip_code(raw, inline=False)
-    explicit = set(EXPLICIT_ID_RE.findall(text))
+    # Two views of the page. `markup` drops inline code, so an `id="..."` or an
+    # `{% include %}` shown as an example inside backticks isn't mistaken for the
+    # real thing (which would invent ids and silently suppress real warnings).
+    # `headings` keeps inline code, because GitBook slugifies a heading including
+    # its code spans.
+    markup = strip_code(raw)
+    headings = strip_code(raw, inline=False)
+    explicit = set(EXPLICIT_ID_RE.findall(markup))
     slugs = set()
-    for line in text.split("\n"):
+    for line in headings.split("\n"):
         m = HEADING_RE.match(line)
         if m and not re.search(r'<a\b[^>]*\bid="', m.group(1)):
             s = anchor_slug(m.group(1))
@@ -421,7 +426,7 @@ def heading_ids(path: Path) -> tuple:
                 slugs.add(s)
     resolved = True
     blocks = reusable_blocks()
-    for bid in INCLUDE_URL_RE.findall(text):
+    for bid in INCLUDE_URL_RE.findall(markup):
         inc = blocks.get(bid)
         if inc is None:
             resolved = False
@@ -430,7 +435,7 @@ def heading_ids(path: Path) -> tuple:
         explicit |= e
         slugs |= s
         resolved = resolved and r
-    for rel in INCLUDE_REL_RE.findall(text):
+    for rel in INCLUDE_REL_RE.findall(markup):
         inc = DOCS_ROOT / "reusable-content" / rel
         if not inc.is_file():
             resolved = False

--- a/.github/scripts/tests/fixtures/links/REUSABLE_CONTENT_INDEX.md
+++ b/.github/scripts/tests/fixtures/links/REUSABLE_CONTENT_INDEX.md
@@ -3,3 +3,4 @@
 | ID | Name | Parent space | Include snippet | Preview | Used in |
 |----|------|--------------|-----------------|---------|---------|
 | `BLOCK1` | shared-block | `RS` | x | y | docs/spacea/with-include.md |
+| `BLOCK2` | Some Indexed Name | `RS` | x | y | docs/spacea/with-include.md |

--- a/.github/scripts/tests/fixtures/links/REUSABLE_CONTENT_INDEX.md
+++ b/.github/scripts/tests/fixtures/links/REUSABLE_CONTENT_INDEX.md
@@ -1,0 +1,5 @@
+# Reusable content index (fixture)
+
+| ID | Name | Parent space | Include snippet | Preview | Used in |
+|----|------|--------------|-----------------|---------|---------|
+| `BLOCK1` | shared-block | `RS` | x | y | docs/spacea/with-include.md |

--- a/.github/scripts/tests/fixtures/links/docs/reusable-content/.gitbook/includes/frontmatter-named.md
+++ b/.github/scripts/tests/fixtures/links/docs/reusable-content/.gitbook/includes/frontmatter-named.md
@@ -1,0 +1,5 @@
+---
+title: Some Indexed Name
+---
+
+## Frontmatter block heading <a href="#frontmatter-block-heading" id="frontmatter-block-heading"></a>

--- a/.github/scripts/tests/fixtures/links/docs/reusable-content/.gitbook/includes/shared-block.md
+++ b/.github/scripts/tests/fixtures/links/docs/reusable-content/.gitbook/includes/shared-block.md
@@ -1,0 +1,3 @@
+## Shared heading <a href="#shared-heading" id="shared-heading"></a>
+
+Reusable body.

--- a/.github/scripts/tests/fixtures/links/docs/spacea/bad-include.md
+++ b/.github/scripts/tests/fixtures/links/docs/spacea/bad-include.md
@@ -1,0 +1,3 @@
+# With an unresolvable include
+
+{% include "https://app.gitbook.com/s/RS/~/reusable/NOTINDEXED/" %}

--- a/.github/scripts/tests/fixtures/links/docs/spacea/code-heading.md
+++ b/.github/scripts/tests/fixtures/links/docs/spacea/code-heading.md
@@ -1,0 +1,5 @@
+# Code heading page
+
+## Using `$if()` (advanced)
+
+No explicit id, so its anchor must be suppressed rather than flagged.

--- a/.github/scripts/tests/fixtures/links/docs/spacea/documents-markup.md
+++ b/.github/scripts/tests/fixtures/links/docs/spacea/documents-markup.md
@@ -1,0 +1,6 @@
+# Page that documents markup in prose
+
+To pin an anchor, write `<a href="#example" id="example"></a>` in the heading.
+Pull in shared text with `{% include "https://app.gitbook.com/s/RS/~/reusable/BLOCK1/" %}`.
+
+## Real heading <a href="#real-heading" id="real-heading"></a>

--- a/.github/scripts/tests/fixtures/links/docs/spacea/id-in-code-heading.md
+++ b/.github/scripts/tests/fixtures/links/docs/spacea/id-in-code-heading.md
@@ -1,0 +1,6 @@
+# Page documenting anchor markup in a heading
+
+## Write `<a id="example"></a>` to pin an anchor
+
+That id is an example inside backticks, not a real anchor, so this heading
+still needs its own slug computed.

--- a/.github/scripts/tests/fixtures/links/docs/spacea/page-one.md
+++ b/.github/scripts/tests/fixtures/links/docs/spacea/page-one.md
@@ -1,1 +1,9 @@
 # Page one
+
+## Section one <a href="#section-one" id="section-one"></a>
+
+Body text.
+
+## Plain heading with no explicit id
+
+Body text.

--- a/.github/scripts/tests/fixtures/links/docs/spacea/sub/page-two.md
+++ b/.github/scripts/tests/fixtures/links/docs/spacea/sub/page-two.md
@@ -1,1 +1,3 @@
 # Page two
+
+## Target section <a href="#target-section" id="target-section"></a>

--- a/.github/scripts/tests/fixtures/links/docs/spacea/with-include.md
+++ b/.github/scripts/tests/fixtures/links/docs/spacea/with-include.md
@@ -1,0 +1,3 @@
+# With a resolvable include
+
+{% include "https://app.gitbook.com/s/RS/~/reusable/BLOCK1/" %}

--- a/.github/scripts/tests/test_check_internal_links.py
+++ b/.github/scripts/tests/test_check_internal_links.py
@@ -102,8 +102,60 @@ def main():
     # --- Non-links ------------------------------------------------------------
     check("external URL is ignored", category(A, "https://example.com/page") is None)
     check("mailto is ignored", category(A, "mailto:help@n8n.io") is None)
-    check("pure anchor is ignored", category(A, "#a-heading") is None)
     check("templating is ignored", category(A, "{{ variable }}") is None)
+
+    # --- Rule 5: anchor validation ------------------------------------------
+    cil._REUSABLE_BLOCKS = None   # rebuild the block map against the fixtures
+    cil._HEADING_IDS = {}
+
+    check("in-page anchor matching an explicit id passes",
+          category(A, "#section-one") is None)
+    check("in-page anchor matching nothing is flagged",
+          category(A, "#no-such-heading") == "broken-anchor")
+    check("cross-file anchor matching an explicit id passes",
+          category(A, "sub/page-two.md#target-section") is None)
+    check("cross-file anchor matching nothing is flagged",
+          category(A, "sub/page-two.md#no-such-heading") == "broken-anchor")
+    check("bare '#' with no anchor is its own category",
+          category(A, "sub/page-two.md#") == "empty-anchor")
+    check("footnote anchors are always accepted",
+          category(A, "#user-content-fn-1") is None)
+    broken = classify(A, "#no-such-heading")
+    check("broken-anchor message names the missing id",
+          broken is not None and "no heading with id 'no-such-heading'" in broken[1])
+
+    # Suppression: never assert on what we can't verify.
+    check("anchor on a heading with no explicit id is left unchecked",
+          category(A, "#plain-heading-with-no-explicit-id") is None)
+    check("headings from a resolvable include count",
+          category("docs/spacea/with-include.md", "#shared-heading") is None)
+    check("a page with an unresolvable include has anchors left unchecked",
+          category("docs/spacea/bad-include.md", "#anything-at-all") is None)
+
+    # A missing page is reported as missing, not as a broken anchor.
+    check("anchor on a missing target reports the target, not the anchor",
+          category(A, "gone.md#whatever") == "missing-target")
+    check("cross-space relative wins over anchor checking",
+          category(A, "../spaceb/other.md#nope") == "cross-space-relative")
+
+    # --- Include resolution -------------------------------------------------
+    check("reusable block index resolves BLOCK1 by name",
+          "BLOCK1" in cil.reusable_blocks())
+    check("unindexed block stays unresolved",
+          "NOTINDEXED" not in cil.reusable_blocks())
+    exp, slugs, resolved = cil.heading_ids(FIXTURE_REPO / "docs/spacea/bad-include.md")
+    check("unresolvable include sets resolved=False", resolved is False)
+    exp2, _, resolved2 = cil.heading_ids(FIXTURE_REPO / "docs/spacea/with-include.md")
+    check("resolvable include sets resolved=True and pulls in its ids",
+          resolved2 is True and "shared-heading" in exp2)
+
+    # --- anchor_slug --------------------------------------------------------
+    check("anchor_slug lowercases and hyphenates",
+          cil.anchor_slug("Section One") == "section-one")
+    check("anchor_slug drops backticks and parens",
+          cil.anchor_slug("Using `$if()` (advanced)") == "using-if-advanced")
+    check("anchor_slug keeps a link's text",
+          cil.anchor_slug("See [the guide](x.md)") == "see-the-guide")
 
     # --- Parsing helpers: what counts as a link -------------------------------
     fenced = "```\n[x](broken.md)\n```\n[y](page-one.md)\n"

--- a/.github/scripts/tests/test_check_internal_links.py
+++ b/.github/scripts/tests/test_check_internal_links.py
@@ -149,6 +149,34 @@ def main():
     check("resolvable include sets resolved=True and pulls in its ids",
           resolved2 is True and "shared-heading" in exp2)
 
+    # --- Regressions caught in review (cubic on PR #5280) -------------------
+    # strip_code() used to delete inline code from heading lines too, so a
+    # heading's guessed slug lost its code span and stopped suppressing the
+    # matching anchor -- the exact false positive rule 5 exists to avoid.
+    check("heading extraction keeps inline code spans",
+          cil.strip_code("### Using `$if()` (advanced)", inline=False)
+          == "### Using `$if()` (advanced)")
+    check("strip_code still drops inline code by default",
+          cil.strip_code("text `code` more") == "text  more")
+    check("a heading with inline code slugs the same via the pipeline as raw",
+          cil.anchor_slug(cil.strip_code("Using `$if()` (advanced)", inline=False))
+          == cil.anchor_slug("Using `$if()` (advanced)"))
+    check("an anchor on an inline-code heading is suppressed, not flagged",
+          category("docs/spacea/code-heading.md", "#using-if-advanced") is None)
+
+    # An unreadable page must be treated as unverifiable, not as "verified with
+    # no ids" (which would flag every anchor on it).
+    _, _, missing_resolved = cil.heading_ids(FIXTURE_REPO / "docs/spacea/does-not-exist.md")
+    check("an unreadable page is marked unresolved", missing_resolved is False)
+
+    check("non-numeric user-content-fn anchors are not waved through",
+          category(A, "#user-content-fn-not-a-footnote") == "broken-anchor")
+    check("numeric footnote anchors still pass",
+          category(A, "#user-content-fn-12") is None)
+
+    check("a block whose index Name is only in frontmatter resolves",
+          cil.reusable_blocks().get("BLOCK2") is not None)
+
     # --- anchor_slug --------------------------------------------------------
     check("anchor_slug lowercases and hyphenates",
           cil.anchor_slug("Section One") == "section-one")

--- a/.github/scripts/tests/test_check_internal_links.py
+++ b/.github/scripts/tests/test_check_internal_links.py
@@ -174,6 +174,15 @@ def main():
     check("numeric footnote anchors still pass",
           category(A, "#user-content-fn-12") is None)
 
+    # An id= or {% include %} shown as an example inside backticks must not be
+    # mistaken for real markup, or it would invent ids and suppress real warnings.
+    check("an id= documented inside inline code is not treated as a real anchor",
+          category("docs/spacea/documents-markup.md", "#example") == "broken-anchor")
+    check("a real heading id on the same page still resolves",
+          category("docs/spacea/documents-markup.md", "#real-heading") is None)
+    check("an include shown inside inline code doesn't pull in its headings",
+          category("docs/spacea/documents-markup.md", "#shared-heading") == "broken-anchor")
+
     check("a block whose index Name is only in frontmatter resolves",
           cil.reusable_blocks().get("BLOCK2") is not None)
 

--- a/.github/scripts/tests/test_check_internal_links.py
+++ b/.github/scripts/tests/test_check_internal_links.py
@@ -183,6 +183,15 @@ def main():
     check("an include shown inside inline code doesn't pull in its headings",
           category("docs/spacea/documents-markup.md", "#shared-heading") == "broken-anchor")
 
+    # An <a id> inside backticks on a heading line must not count as that
+    # heading's explicit id, or the heading gets neither an id nor a slug and
+    # its real anchor is falsely reported broken.
+    check("an <a id> in a heading's inline code doesn't suppress its slug",
+          category("docs/spacea/id-in-code-heading.md",
+                   "#write-to-pin-an-anchor") is None)
+    check("and that documented id isn't treated as a real anchor",
+          category("docs/spacea/id-in-code-heading.md", "#example") == "broken-anchor")
+
     check("a block whose index Name is only in frontmatter resolves",
           cil.reusable_blocks().get("BLOCK2") is not None)
 


### PR DESCRIPTION
Closes DOC-2245. Follows #5277.

## Problem

`check_internal_links.py` stripped and discarded every `#fragment`, so a deep link passed as long as the *page* existed. Nothing caught a dead anchor, and renaming a heading silently orphaned every inbound link.

Two bugs of this class landed in one week, with different root causes:

- **DOC-2230** / #5278 — GitBook prefixes `id-` and keeps the period on digit-leading headings, so `### 1. Already running…` is at `#id-1.-already-running…`
- **DOC-2244** / #5279 — explicit anchor markup strips underscores, so `### installed_nodes <a id="installednodes">` is at `#installednodes`

Neither is predictable by eye. That's the case for automating it.

## What this adds

Rule 5: an anchor must match a heading on the target page. Covers in-page (`](#x)`) and relative (`](y.md#x)`) links, resolving `{% include %}` in both forms so headings from reusable content count.

## Design: conservative on purpose

A link checker nobody trusts is worse than no checker, so every ambiguous case stays silent:

- **93% of headings carry explicit `id=` markup.** Those are authoritative and drive the check.
- **For the other 7%, the slug is guessed only to stay quiet** — never to assert a break. A wrong guess costs a missed detection, not a false alarm.
- **Pages with an unresolvable `{% include %}` are skipped entirely.** `REUSABLE_CONTENT_INDEX.md` is generated externally and runs stale — 14 of 109 block IDs didn't resolve by name alone. Three-tier matching (exact stem → normalized stem → normalized first heading) recovers 13 of those 14; the last one just suppresses its pages.
- **Footnote anchors (`user-content-fn-N`)** are always accepted; GitBook generates them from `[^N]` markers with no heading to match.

This suppression is load-bearing: it's what turned 3 false positives in the Filter/If/Switch pages into correct passes.

## Severity

Findings **warn**, they don't fail. The repo has 61 pre-existing broken anchors, so failing immediately would just block unrelated PRs. `--strict-anchors` promotes them to errors — that's the follow-up once the backlog is cleared.

Because CI passes only changed files, a PR sees warnings for the file it touches. Both DOC-2230 and DOC-2244 were introduced by edits to the linking file, so this catches the observed pattern. (The rename-breaks-inbound-links case needs a repo-wide pass and is deliberately out of scope.)

## Verification

- **55/55 tests pass**, up from 37. New cases cover explicit-id matching, include resolution, all three suppression paths, footnotes, and `anchor_slug`.
- **Five mutation tests** — disabling anchor validation, the include guard, the slug suppression, the footnote whitelist, and the empty-anchor branch each produce clean FAILs, so the coverage isn't vacuous.
- **No regression.** Full-repo A/B against main gives byte-identical errors: `absolute-path=1, cross-space-broken=1`. The 61 anchor findings are all new warnings.
- Reports 60 `broken-anchor` + 1 `empty-anchor` repo-wide, matching an independent ad-hoc scan after its 3 include false positives are accounted for.

## What the 61 findings are

Not fixed here — this PR is tooling only. Triaged by cluster:

| Count | Where | Cause |
| --- | --- | --- |
| 53 | `expression-reference/README.md` → 8 siblings | IDs are `dollarbinary`, `dollarexecution`…, links say `#binary`, `#execution` |
| 8 | toolmcp.md, mcpClient.md → httprequest.md | `#using-bearer-auth` / `#using-header-auth` don't exist as headings |
| 7 | vectorstoreweaviate.md | headings end `-parameters`, links drop the suffix |
| 4 | set-up-ai-assistant.md | fixed by #5278 |
| 1 | expression-reference/README.md:658 | `](root.md#)` — bare `#` |
| 1 | install-with-npm.md | `#n8n-with-tunnel`, unverified |

Worth noting the httprequest.md cluster sits in the hint that #5271 restructures, so that PR carries the broken anchors forward.