### PR TITLE
ci: Introduce CLA bot

### DIFF
--- a/.github/workflows/ci-cla-check.yml
+++ b/.github/workflows/ci-cla-check.yml
@@ -1,0 +1,72 @@
+name: 'CI: CLA Check'
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('CI: CLA Check (PR #{0})', inputs.pr_number) || '' }}"
+
+# In-house replacement for the GitHub App "CLA Bot". The implementation lives in
+# n8n-io/github-actions/cla-check (SHA-pinned below); this workflow only binds it
+# to events. Change behaviour there, then bump the pin here.
+#
+# Triggers
+#   - pull_request_target (opened/synchronize/reopened): re-checks signatures
+#     whenever a PR is opened or new commits are pushed.
+#   - issue_comment (`/cla-check` on a PR): manual re-check after a contributor
+#     signs the CLA, without needing a push.
+#
+# Output
+#   - A commit status named "CLA Check" on the head SHA. Add this name to a
+#     ruleset's required-checks list to gate merges on it.
+#   - A single, edited-in-place PR comment listing unsigned contributors.
+#   - The `cla-signed` label, which community-PR triage tooling reads.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number to re-verify'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write
+
+concurrency:
+  # Concurrency is evaluated BEFORE the job-level `if` below, so a comment that
+  # isn't `/cla-check` (e.g. a bot's "StageReview" comment) still creates a run.
+  # If that run shared the PR's group (issue number == PR number) it would, with
+  # cancel-in-progress, cancel the in-progress pull_request_target check — then
+  # get skipped by the `if` and do nothing, leaving the "CLA Check" status stuck
+  # on pending. Keep comment-triggered runs in their own group so they can only
+  # ever cancel each other, never the PR push check that gates the merge. PR
+  # pushes and dispatch keep the head-based group (push debounce).
+  group: >-
+    cla-check-${{ github.event_name == 'issue_comment'
+      && format('comment-{0}', github.event.issue.number)
+      || github.event.pull_request.number
+      || github.event.inputs.pr_number
+      || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cla-check:
+    name: Verify CLA signatures
+    # Skip issue_comment unless it's on a PR and the body starts with /cla-check.
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/cla-check'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Defaults for the CLA endpoints, status context, comment marker and label
+      # are already n8n's production values.
+      - uses: n8n-io/github-actions/cla-check@931777df53ace1bdb31d2bf5c63c9f2d27451c35 # cla-check/v1.0.0
+        with:
+          app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
+          private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+


### PR DESCRIPTION
# Summary

Introduces CLA Bot to this repository. It's out in-house battletested CLA Assistant alternative. Our monorepo n8n-io/n8n already relies on this and this consolidates our platforms to just a singular platform

# After merging

1. Sync the data from CLA assistant to CLA Bot (already done)
2. Remove CLA Assistant linkage
3. Run a script to trigger CLA check for each open PR
4. Update PR required checks to match the new CLA status check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces CLA Assistant with our in-house CLA bot, backed by `n8n-io/github-actions/cla-check`, to gate merges with a single "CLA Check" status. It posts one edited PR comment listing unsigned contributors, applies the cla-signed label, and re-checks on PR updates, `/cla-check` comments, or manual dispatch without canceling in-progress PR checks.

**Migration**
- Remove CLA Assistant from repo settings and required checks; add "CLA Check" as required.
- Trigger re-verification for open PRs via workflow_dispatch (pr_number) or the provided script.
- Ensure `N8N_ASSISTANT_APP_ID` and `N8N_ASSISTANT_PRIVATE_KEY` secrets are set.

<sup>Written for commit 8412879c0d683549433d7b3d364a1bdd3f16f6df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

