### PR TITLE
fix(deploy): external storage is available on self-hosted Business too

### DIFF
--- a/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/binary-data.md
+++ b/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/binary-data.md
@@ -23,7 +23,7 @@ layout:
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/ASsLuMLGKMy2O0q7awMF/" %}
 
-By default, n8n uses memory to store binary data. Enterprise users can choose to use an external service instead. Refer to [External storage](../../scaling/use-external-storage.md) for more information on using external storage for binary data. 
+By default, n8n uses memory to store binary data. On self-hosted Business and Enterprise plans, you can choose to use an external service instead. Refer to [External storage](../../scaling/use-external-storage.md) for more information on using external storage for binary data. 
 
 
 | Variable | Type  | Default  | Description |

--- a/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/executions.md
+++ b/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/executions.md
@@ -33,7 +33,7 @@ This page lists environment variables to configure workflow execution settings.
 | `EXECUTIONS_DATA_SAVE_ON_SUCCESS` | Enum string: `all`, `none` | `all` | Whether n8n saves execution data on success. |
 | `EXECUTIONS_DATA_SAVE_ON_PROGRESS` | Boolean | `false` | Whether to save progress for each node executed (true) or not (false). |
 | `EXECUTIONS_DATA_SAVE_MANUAL_EXECUTIONS` | Boolean | `true` | Whether to save data of executions when started manually. |
-| `N8N_EXECUTION_DATA_STORAGE_MODE` | Enum string: `database`, `filesystem`, `s3`, `azure` | `database` | Where n8n stores execution data. The `s3` and `azure` modes require a self-hosted Business or Enterprise license. Refer to [External data storage](external-data-storage.md) for the related storage variables. |
+| `N8N_EXECUTION_DATA_STORAGE_MODE` | Enum string: `database`, `filesystem`, `s3`, `azure` | `database` | Where n8n stores execution data. The `s3` and `azure` modes require a self-hosted Business or Enterprise plan. Refer to [External data storage](external-data-storage.md) for the related storage variables. |
 | `N8N_STORAGE_PATH` | String | `N8N_USER_FOLDER/storage` | Base path for filesystem storage. When `N8N_EXECUTION_DATA_STORAGE_MODE` is `filesystem`, n8n stores execution data here. n8n also uses this path for filesystem binary data. |
 | `EXECUTIONS_DATA_PRUNE` | Boolean | `true` | Whether to delete data of past executions on a rolling basis. |
 | `EXECUTIONS_DATA_MAX_AGE` | Number | `336` | The execution age (in hours) before it's deleted. |

--- a/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/executions.md
+++ b/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/executions.md
@@ -33,7 +33,7 @@ This page lists environment variables to configure workflow execution settings.
 | `EXECUTIONS_DATA_SAVE_ON_SUCCESS` | Enum string: `all`, `none` | `all` | Whether n8n saves execution data on success. |
 | `EXECUTIONS_DATA_SAVE_ON_PROGRESS` | Boolean | `false` | Whether to save progress for each node executed (true) or not (false). |
 | `EXECUTIONS_DATA_SAVE_MANUAL_EXECUTIONS` | Boolean | `true` | Whether to save data of executions when started manually. |
-| `N8N_EXECUTION_DATA_STORAGE_MODE` | Enum string: `database`, `filesystem`, `s3`, `azure` | `database` | Where n8n stores execution data. The `s3` and `azure` modes require an Enterprise license. Refer to [External data storage](external-data-storage.md) for the related storage variables. |
+| `N8N_EXECUTION_DATA_STORAGE_MODE` | Enum string: `database`, `filesystem`, `s3`, `azure` | `database` | Where n8n stores execution data. The `s3` and `azure` modes require a self-hosted Business or Enterprise license. Refer to [External data storage](external-data-storage.md) for the related storage variables. |
 | `N8N_STORAGE_PATH` | String | `N8N_USER_FOLDER/storage` | Base path for filesystem storage. When `N8N_EXECUTION_DATA_STORAGE_MODE` is `filesystem`, n8n stores execution data here. n8n also uses this path for filesystem binary data. |
 | `EXECUTIONS_DATA_PRUNE` | Boolean | `true` | Whether to delete data of past executions on a rolling basis. |
 | `EXECUTIONS_DATA_MAX_AGE` | Number | `336` | The execution age (in hours) before it's deleted. |

--- a/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/external-data-storage.md
+++ b/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/external-data-storage.md
@@ -44,9 +44,9 @@ Refer to [External storage](../../scaling/use-external-storage.md) for more info
 
 Storing execution data or binary data in Azure Blob Storage is available on:
 
-- **Self-hosted:** Enterprise
+- **Self-hosted:** Business, Enterprise
 
-It isn't available on n8n Cloud. Add an [Enterprise license key](../../manage-your-license.md) to unlock this feature.
+It isn't available on n8n Cloud. Add a Business or Enterprise [license key](../../manage-your-license.md) to unlock this feature.
 {% endhint %}
 
 To store execution data in Azure Blob Storage, set `N8N_EXECUTION_DATA_STORAGE_MODE` to `azure`. To store binary data in Azure Blob Storage, set `N8N_DEFAULT_BINARY_DATA_MODE` to `azure` (refer to [External storage](../../scaling/use-external-storage.md#storing-n8ns-binary-data-in-azure-blob-storage)). A single container can hold both. Configure the variables below; `N8N_EXTERNAL_STORAGE_AZURE_CONTAINER_NAME` is always required.

--- a/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/external-data-storage.md
+++ b/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/external-data-storage.md
@@ -46,7 +46,7 @@ Storing execution data or binary data in Azure Blob Storage is available on:
 
 - **Self-hosted:** Business, Enterprise
 
-It isn't available on n8n Cloud. Add a Business or Enterprise [license key](../../manage-your-license.md) to unlock this feature.
+It isn't available on n8n Cloud. Add your [license key](../../manage-your-license.md) to unlock this feature.
 {% endhint %}
 
 To store execution data in Azure Blob Storage, set `N8N_EXECUTION_DATA_STORAGE_MODE` to `azure`. To store binary data in Azure Blob Storage, set `N8N_DEFAULT_BINARY_DATA_MODE` to `azure` (refer to [External storage](../../scaling/use-external-storage.md#storing-n8ns-binary-data-in-azure-blob-storage)). A single container can hold both. Configure the variables below; `N8N_EXTERNAL_STORAGE_AZURE_CONTAINER_NAME` is always required.

--- a/docs/deploy/host-n8n/configure-n8n/scaling/use-external-storage.md
+++ b/docs/deploy/host-n8n/configure-n8n/scaling/use-external-storage.md
@@ -45,7 +45,7 @@ S3 binary data storage is available on:
 
 It isn't available on n8n Cloud.
 
-You will need a Business or Enterprise [license key](../manage-your-license.md) for external storage. n8n won't start in `s3` binary data mode without a valid license: set `N8N_DEFAULT_BINARY_DATA_MODE` to another mode or upgrade your license.
+Activate your [license key](../manage-your-license.md) before you enable external storage. n8n won't start in `s3` binary data mode without a valid license: set `N8N_DEFAULT_BINARY_DATA_MODE` to another mode or upgrade your plan.
 {% endhint %}
 
 ### Setup <a href="#setup" id="setup"></a>
@@ -148,7 +148,7 @@ Azure Blob Storage for binary data is available on:
 
 It isn't available on n8n Cloud.
 
-You will need a Business or Enterprise [license key](../manage-your-license.md) for external storage. n8n won't start in `azure` binary data mode without a valid license: set `N8N_DEFAULT_BINARY_DATA_MODE` to another mode or upgrade your license.
+Activate your [license key](../manage-your-license.md) before you enable external storage. n8n won't start in `azure` binary data mode without a valid license: set `N8N_DEFAULT_BINARY_DATA_MODE` to another mode or upgrade your plan.
 {% endhint %}
 
 ### Azure setup
@@ -201,7 +201,7 @@ In [queue mode](enable-queue-mode.md), set `N8N_EXECUTION_DATA_STORAGE_MODE` and
 {% hint style="warning" %}
 **License required to start**
 
-S3 execution data storage requires a valid Business or Enterprise [license key](../manage-your-license.md). If you set `N8N_EXECUTION_DATA_STORAGE_MODE=s3` without a valid license, n8n won't start. To start n8n again, switch the mode back to `database` or `filesystem`, or restore a valid license.
+S3 execution data storage requires a Business or Enterprise plan with an active [license key](../manage-your-license.md). If you set `N8N_EXECUTION_DATA_STORAGE_MODE=s3` without a valid license, n8n won't start. To start n8n again, switch the mode back to `database` or `filesystem`, or restore a valid license.
 {% endhint %}
 
 After you enable S3 execution data storage, n8n writes the data of any new execution to your S3 bucket in this format:

--- a/docs/deploy/host-n8n/configure-n8n/scaling/use-external-storage.md
+++ b/docs/deploy/host-n8n/configure-n8n/scaling/use-external-storage.md
@@ -24,7 +24,7 @@ layout:
 
 External storage is available on:
 
-- **Self-hosted:** Enterprise
+- **Self-hosted:** Business, Enterprise
 
 It isn't available on n8n Cloud.
 
@@ -41,11 +41,11 @@ n8n supports [AWS S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welc
 
 S3 binary data storage is available on:
 
-- **Self-hosted:** Enterprise
+- **Self-hosted:** Business, Enterprise
 
 It isn't available on n8n Cloud.
 
-You will need an [Enterprise license key](../manage-your-license.md) for external storage. n8n won't start in `s3` binary data mode without a valid license: set `N8N_DEFAULT_BINARY_DATA_MODE` to another mode or upgrade your license.
+You will need a Business or Enterprise [license key](../manage-your-license.md) for external storage. n8n won't start in `s3` binary data mode without a valid license: set `N8N_DEFAULT_BINARY_DATA_MODE` to another mode or upgrade your license.
 {% endhint %}
 
 ### Setup <a href="#setup" id="setup"></a>
@@ -144,11 +144,11 @@ n8n supports [Azure Blob Storage](https://learn.microsoft.com/en-us/azure/storag
 
 Azure Blob Storage for binary data is available on:
 
-- **Self-hosted:** Enterprise
+- **Self-hosted:** Business, Enterprise
 
 It isn't available on n8n Cloud.
 
-You will need an [Enterprise license key](../manage-your-license.md) for external storage. n8n won't start in `azure` binary data mode without a valid license: set `N8N_DEFAULT_BINARY_DATA_MODE` to another mode or upgrade your license.
+You will need a Business or Enterprise [license key](../manage-your-license.md) for external storage. n8n won't start in `azure` binary data mode without a valid license: set `N8N_DEFAULT_BINARY_DATA_MODE` to another mode or upgrade your license.
 {% endhint %}
 
 ### Azure setup
@@ -201,7 +201,7 @@ In [queue mode](enable-queue-mode.md), set `N8N_EXECUTION_DATA_STORAGE_MODE` and
 {% hint style="warning" %}
 **License required to start**
 
-S3 execution data storage requires a valid [Enterprise license key](../manage-your-license.md). If you set `N8N_EXECUTION_DATA_STORAGE_MODE=s3` without a valid license, n8n won't start. To start n8n again, switch the mode back to `database` or `filesystem`, or restore a valid license.
+S3 execution data storage requires a valid Business or Enterprise [license key](../manage-your-license.md). If you set `N8N_EXECUTION_DATA_STORAGE_MODE=s3` without a valid license, n8n won't start. To start n8n again, switch the mode back to `database` or `filesystem`, or restore a valid license.
 {% endhint %}
 
 After you enable S3 execution data storage, n8n writes the data of any new execution to your S3 bucket in this format:


### PR DESCRIPTION
Closes DOC-2255. Reported by a community member via Arseny Ivanov in #team-docs ([thread](https://n8nio.slack.com/archives/C0AR629T62Z/p1787753447382529)).

## Problem

The external storage pages said the feature is Enterprise only. The pricing page has self-hosted Business ticked for "External storage in S3", so the two disagreed and a community member noticed.

## Source of truth

[`license-management-setup/entities/product/production_business.yml`](https://github.com/n8n-io/license-management-setup/blob/main/entities/product/production_business.yml) is the source of truth for which plan gets which license feature. On self-hosted Business, all four storage flags are enabled:

| Feature | Flag | Business | Enterprise |
|---|---|---|---|
| Binary data in S3 | `feat:binaryDataS3` | Yes | Yes |
| Binary data in Azure Blob | `feat:binaryDataAz` | Yes | Yes |
| Execution data in S3 | `feat:executionDataS3` | Yes | Yes |
| Execution data in Azure Blob | `feat:executionDataAz` | Yes | Yes |

So the docs were the wrong side, and wrong on all four, not just the S3 binary-data row that the pricing page covers.

## Changes

**Plan availability** — `Self-hosted: Enterprise` becomes `Self-hosted: Business, Enterprise` on:

- `use-external-storage.md`: the page-level hint, the S3 binary-data hint, and the Azure binary-data hint
- `external-data-storage.md`: the Azure Blob Storage hint

**Prose that named the plan** —

- `executions.md`: the `N8N_EXECUTION_DATA_STORAGE_MODE` row no longer says the `s3` and `azure` modes need an Enterprise license
- `binary-data.md`: "Enterprise users can choose to use an external service" now names both plans

**License-key wording** (second commit) — the old "You will need an Enterprise license key" sat three lines under the availability bullet and would have kept telling a Business customer to upgrade. Rather than change it to "a Business or Enterprise license key", these sentences now just say a license must be active. There is one license key; which features it unlocks depends on your plan, which is how `manage-your-license.md` (titled plain "License key") and the glossary describe it. Naming two plans implies two key products. The tier is already stated in the bullet directly above.

Tier order and the `Self-hosted:` bullet format follow the [style guide](https://docs.n8n.io/contribute/style-guide-for-n8n-docs) feature-availability rules. Vale is clean on every changed line.

## Not changed: the n8n Cloud line

The same license config gives Cloud Enterprise these flags too, but that isn't a customer-facing capability — external storage is configured only through `N8N_DEFAULT_BINARY_DATA_MODE`, `N8N_EXECUTION_DATA_STORAGE_MODE` and `N8N_EXTERNAL_STORAGE_*`, and Cloud users can't set that class of variable. "It isn't available on n8n Cloud" is correct, so it stays.