### PR TITLE
fix(deploy): correct sandbox env var names for AI Assistant

### DIFF
--- a/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-ai-assistant.md
@@ -112,16 +112,16 @@ This means hosting two extra containers yourself: the sandbox API and a privileg
    ```bash
    N8N_INSTANCE_AI_SANDBOX_ENABLED=true
    N8N_INSTANCE_AI_SANDBOX_PROVIDER=n8n-sandbox
-   N8N_INSTANCE_AI_SANDBOX_API_URL=http://sandbox-api:8080
-   N8N_INSTANCE_AI_SANDBOX_API_KEY=my-sandbox-api-key
+   N8N_SANDBOX_SERVICE_URL=http://sandbox-api:8080
+   N8N_SANDBOX_SERVICE_API_KEY=my-sandbox-api-key
    ```
 
    | Variable | Description |
    | --- | --- |
    | `N8N_INSTANCE_AI_SANDBOX_ENABLED` | Set to `true`. |
    | `N8N_INSTANCE_AI_SANDBOX_PROVIDER` | Set to `n8n-sandbox`. |
-   | `N8N_INSTANCE_AI_SANDBOX_API_URL` | URL of the sandbox API, reachable from n8n. |
-   | `N8N_INSTANCE_AI_SANDBOX_API_KEY` | Must match `SANDBOX_API_KEYS` on the API container. |
+   | `N8N_SANDBOX_SERVICE_URL` | URL of the sandbox API, reachable from n8n. |
+   | `N8N_SANDBOX_SERVICE_API_KEY` | Must match `SANDBOX_API_KEYS` on the API container. |
 
 3. Add your model key (see [Choose a model provider](#choose-a-model-provider)) and restart n8n.
 
@@ -136,7 +136,7 @@ Expected response: `{"status":"ok"}`
 **Notes:**
 
 * Replace `my-sandbox-api-key` with your own secret, and set matching registration-token and runner-key secrets on the API and runner containers. See the [Docker Compose guide](../install-options/install-using-docker-compose.md) for the full set of variables and how they connect.
-* `N8N_INSTANCE_AI_SANDBOX_API_KEY` must match a value in `SANDBOX_API_KEYS` on the sandbox API container.
+* `N8N_SANDBOX_SERVICE_API_KEY` must match a value in `SANDBOX_API_KEYS` on the sandbox API container.
 * The runner pulls its sandbox image on first use. For air-gapped setups, preload that image into the runner's inner Docker.
 * Hostnames matter. The certificates are issued for `sandbox-api` and `sandbox-runner-<n>`, so keep those service names or regenerate certificates with matching SANs.
 
@@ -351,9 +351,9 @@ If AI Assistant doesn't appear or doesn't work, check for these issues.
 
 **Self-hosted sandbox (setup 2)**
 
-* `N8N_INSTANCE_AI_SANDBOX_API_KEY` matches `SANDBOX_API_KEYS` on the API container.
+* `N8N_SANDBOX_SERVICE_API_KEY` matches `SANDBOX_API_KEYS` on the API container.
 * The sandbox health check returns `{"status":"ok"}`.
-* `N8N_INSTANCE_AI_SANDBOX_API_URL` is reachable from the n8n container.
+* `N8N_SANDBOX_SERVICE_URL` is reachable from the n8n container.
 
 **Daytona (setup 3)**
 

--- a/docs/deploy/host-n8n/install-options/install-using-docker-compose.md
+++ b/docs/deploy/host-n8n/install-options/install-using-docker-compose.md
@@ -37,7 +37,7 @@ SANDBOX_API_RUNNER_REGISTRATION_TOKEN=change-me-registration-token
 SANDBOX_API_RUNNER_API_KEY=change-me-runner-key
 
 # Must match a value in SANDBOX_API_KEYS above — this is how n8n authenticates to the sandbox
-N8N_INSTANCE_AI_SANDBOX_API_KEY=change-me-api-key
+N8N_SANDBOX_SERVICE_API_KEY=change-me-api-key
 
 # Web search: secret for the bundled SearXNG instance — pick your own value
 SEARXNG_SECRET=change-me-searxng-secret
@@ -155,7 +155,7 @@ services:
       N8N_INSTANCE_AI_MODEL: anthropic/claude-opus-4-8
       N8N_INSTANCE_AI_SANDBOX_ENABLED: 'true'
       N8N_INSTANCE_AI_SANDBOX_IMAGE: ghcr.io/n8n-io/n8n-sandbox-service-sandbox:latest
-      N8N_INSTANCE_AI_SANDBOX_API_URL: http://sandbox-api:8080
+      N8N_SANDBOX_SERVICE_URL: http://sandbox-api:8080
 ```
 
 ## What you've just set up

--- a/docs/deploy/host-n8n/install-options/use-a-cloud-provider/deploy-to-digital-ocean.md
+++ b/docs/deploy/host-n8n/install-options/use-a-cloud-provider/deploy-to-digital-ocean.md
@@ -312,8 +312,8 @@ The AI Assistant needs a sandbox to run code in. You can add the same sandbox st
     - N8N_ENABLED_MODULES=instance-ai
     - N8N_INSTANCE_AI_SANDBOX_ENABLED=true
     - N8N_INSTANCE_AI_SANDBOX_PROVIDER=n8n-sandbox
-    - N8N_INSTANCE_AI_SANDBOX_API_URL=http://sandbox-api:8080
-    - N8N_INSTANCE_AI_SANDBOX_API_KEY=${SANDBOX_API_KEYS}
+    - N8N_SANDBOX_SERVICE_URL=http://sandbox-api:8080
+    - N8N_SANDBOX_SERVICE_API_KEY=${SANDBOX_API_KEYS}
     - N8N_INSTANCE_AI_SEARXNG_URL=http://searxng:8080
    depends_on:
     sandbox-api:

--- a/docs/deploy/host-n8n/install-options/use-a-cloud-provider/deploy-to-hetzner.md
+++ b/docs/deploy/host-n8n/install-options/use-a-cloud-provider/deploy-to-hetzner.md
@@ -295,8 +295,8 @@ The AI Assistant needs a sandbox to run code in. You can add the same sandbox st
     - N8N_ENABLED_MODULES=instance-ai
     - N8N_INSTANCE_AI_SANDBOX_ENABLED=true
     - N8N_INSTANCE_AI_SANDBOX_PROVIDER=n8n-sandbox
-    - N8N_INSTANCE_AI_SANDBOX_API_URL=http://sandbox-api:8080
-    - N8N_INSTANCE_AI_SANDBOX_API_KEY=${SANDBOX_API_KEYS}
+    - N8N_SANDBOX_SERVICE_URL=http://sandbox-api:8080
+    - N8N_SANDBOX_SERVICE_API_KEY=${SANDBOX_API_KEYS}
     - N8N_INSTANCE_AI_SEARXNG_URL=http://searxng:8080
    depends_on:
     sandbox-api:


### PR DESCRIPTION
**Cause:** `N8N_INSTANCE_AI_SANDBOX_API_URL` and `N8N_INSTANCE_AI_SANDBOX_API_KEY` are not read by n8n. Following the current docs yields a sandbox that n8n never contacts, and nothing in the logs points at the variable names.

**Verified** against a running n8n 2.37.0 (`@n8n/config`):

| Variable | Occurrences in 5900 `.js` files |
|---|---|
| `N8N_INSTANCE_AI_SANDBOX_API_URL` | 0 |
| `N8N_INSTANCE_AI_SANDBOX_API_KEY` | 0 |
| `N8N_SANDBOX_SERVICE_URL` | 4 |
| `N8N_SANDBOX_SERVICE_API_KEY` | 1 |

The authoritative list is `@n8n/config/dist/configs/instance-ai.config.js`. Note `docker/get-n8n.sh` already emits `N8N_SANDBOX_SERVICE_URL` / `N8N_SANDBOX_SERVICE_API_KEY`, so the one-line installer is unaffected — only the manual setup paths are.

**Impact:** 13 occurrences across 4 pages renamed. No prose or structural changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

