### PR TITLE
docs: add exception to internal link check

### DIFF
--- a/.github/scripts/check_internal_links.py
+++ b/.github/scripts/check_internal_links.py
@@ -8,7 +8,10 @@ This script covers the gap by resolving each relative link as a local file.
 GitBook rules enforced (see docs/contribute + the internal-linking guide):
   1. An internal link must end in `.md` (a folder page ends in `/README.md`).
      A trailing slash or a bare path does NOT resolve — GitBook falls back to
-     the raw GitHub source URL and the link 404s on the live site.
+     the raw GitHub source URL and the link 404s on the live site. The sole
+     documented exception is a bare `./`, which GitBook resolves natively to
+     the current folder's own README.md (see the style guide's "Link to the
+     current page's parent page" section).
   2. A relative `.md` link must point at a file that exists.
   3. Relative `../` links can't cross GitBook spaces (top-level folders under
      docs/). Cross-space links must use an app.gitbook.com URL, so a relative
@@ -520,6 +523,20 @@ def classify(md_file: Path, src_rel: str, target: str):
         if not resolved.exists():
             rel = os.path.relpath(resolved, REPO_ROOT)
             return ("missing-asset", f"asset not found: {target} -> {rel}")
+        return None
+
+    # Rule 1 exception: `./` is the documented way to link to the current
+    # folder's own parent page (its README.md) -- see the style guide's
+    # "Link to the current page's parent page" section. GitBook resolves this
+    # bare directory-self-reference natively, unlike other trailing-slash
+    # folder links, so it doesn't 404 the way Rule 1 assumes.
+    if path_part == "./":
+        resolved = (src_dir / "README.md").resolve()
+        if not resolved.exists():
+            rel = os.path.relpath(resolved, REPO_ROOT)
+            return ("missing-target", f"target not found: {target} -> {rel}")
+        if anchor is not None:
+            return classify_anchor(resolved, anchor, target)
         return None
 
     # Rule 1: internal doc links must end in .md.

--- a/docs/contribute/style-guide-for-n8n-docs.md
+++ b/docs/contribute/style-guide-for-n8n-docs.md
@@ -545,7 +545,7 @@ Use the file name on its own:
 
 **Link to the current page's parent page**
 
-Use `./` only if the current folder's landing page is a `README.md` — it points there:
+Use `./` only if the current folder's landing page is a `README.md`, it points there:
 
 ```
 [link to a parent page](./)

--- a/docs/contribute/style-guide-for-n8n-docs.md
+++ b/docs/contribute/style-guide-for-n8n-docs.md
@@ -146,7 +146,7 @@ Retrieved on its own, a section that leans on its neighbours arrives stripped of
 Connect each page to the others on its topic. Explicit, descriptive links let an agent follow a path directly instead of guessing a URL, and they group your pages into a topic cluster that AI search reads as a signal of depth.
 
 * **Always link the prerequisites and the next step**, at minimum.
-* **Link parents and children both ways.** An overview or section landing page lists and links to every child page; each child links back to its parent with `./`.
+* **Link parents and children both ways.** An overview or section landing page lists and links to every child page; each child links back to its parent.
 * **Aim for a cluster of five or more interlinked pages** on the same topic. AI search cites connected clusters far more than standalone pages.
 * **Link in the body, at the first meaningful mention**, with descriptive anchor text that names the target: [Configure the Schedule Trigger](configure-schedule-trigger.md), not "click here". Link the first mention, not every mention.
 * **Link to separate topics; don't link for missing context.** A link can't stand in for context this section needs. If a section can't be understood without the linked page, restate the key fact instead (see [Keep each section self-contained](#keep-each-section-self-contained)).
@@ -545,11 +545,13 @@ Use the file name on its own:
 
 **Link to the current page's parent page**
 
-Use `./`, which points at the parent page — the `README.md` landing page of the current folder (`understand-workflows`):
+Use `./` only if the current folder's landing page is a `README.md` — it points there:
 
 ```
 [link to a parent page](./)
 ```
+
+If the parent is a named page instead (no `README.md` in this folder, e.g. `connect-to-n8n-mcp-server.md`), link to that file directly rather than using `./`.
 
 **Link to a page in a different subfolder in the same space**
 


### PR DESCRIPTION
## Summary

Fixes a false positive in the `internal-links` CI check for the `./` link pattern.

`[Configure n8n](./)` is a documented way to link to a folder's own parent page (its `README.md`) — see the style guide's "Link to the current page's parent page" section. GitBook resolves this bare directory-self-reference natively, but the checker's Rule 1 (internal links must end in `.md`) had no exception for it, so it was flagged as `no-md-extension` even though the link works correctly on the live site.

Also adds clarification in style guide that not all parent pages are directly reachable via ./

## Changes

- `.github/scripts/check_internal_links.py`: added a special case that resolves a bare `./` target against the linking file's own directory `README.md`, before the `.md`-extension rule is applied. Falls through to the existing `missing-target` / anchor checks so a genuinely broken `./` (missing `README.md`) is still caught.
- Updated the module docstring's Rule 1 description to note this documented exception.
- - Updated style guide

## Test plan

- [x] Ran the exact failing CI command (`check_internal_links.py` against the changed `docs/deploy/...` files) — now exits 0 with no errors.
- [x] Ran the checker against the full `docs/` tree — only 2 pre-existing, unrelated errors remain (`absolute-path` in a webhook doc, `cross-space-broken` in the license doc), confirming no regressions.
