### PR TITLE
docs: part 3 - apply style/terminology to top 50 pages (build, connect, administer)

### DIFF
--- a/docs/administer/README.md
+++ b/docs/administer/README.md
@@ -27,7 +27,7 @@ Administer n8n by controlling access, securing credentials, managing changes, an
 This section helps you run n8n securely and reliably as usage grows.
 
 {% hint style="info" %}
-Enterprise teams often spend more time in this section. SSO, directory integration, change control, and centralized logging become more important at scale. Features covered here, including user management basics, credential security, and operational monitoring, are also useful outside Enterprise.
+Enterprise teams often spend more time in this section. SSO, directory integration, change control, and centralized logging become more important at scale. Many features covered here, including user management basics, credential security, and operational monitoring, are also useful outside Enterprise.
 {% endhint %}
 
 ### A typical administration workflow
@@ -42,11 +42,11 @@ Decide who can sign in, what they can do, and how you organize work. Start with 
 {% step %}
 ### Protect secrets
 
-Store and share credentials. Use [Manage credentials](manage-credentials/README.md) to reduce secret sprawl.
+Store and share credentials safely. Use [Manage credentials](manage-credentials/README.md) to reduce secret sprawl.
 {% endstep %}
 
 {% step %}
-### Move changes between environments
+### Move changes safely
 
 Use Git-backed workflows to promote changes between environments. See [Use source control and environments](use-source-control-and-environments/README.md).
 {% endstep %}

--- a/docs/administer/README.md
+++ b/docs/administer/README.md
@@ -27,7 +27,7 @@ Administer n8n by controlling access, securing credentials, managing changes, an
 This section helps you run n8n securely and reliably as usage grows.
 
 {% hint style="info" %}
-Enterprise teams often spend more time in this section. SSO, directory integration, change control, and centralized logging become more important at scale. Many features covered here are also useful outside Enterprise, including user management basics, credential security, and operational monitoring.
+Enterprise teams often spend more time in this section. SSO, directory integration, change control, and centralized logging become more important at scale. Features covered here, including user management basics, credential security, and operational monitoring, are also useful outside Enterprise.
 {% endhint %}
 
 ### A typical administration workflow
@@ -36,17 +36,17 @@ Enterprise teams often spend more time in this section. SSO, directory integrati
 {% step %}
 ### Control access
 
-Decide who can sign in, what they can do, and how work is organized. Start with [Manage users and access](manage-users-and-access/README.md).
+Decide who can sign in, what they can do, and how you organize work. Start with [Manage users and access](manage-users-and-access/README.md).
 {% endstep %}
 
 {% step %}
 ### Protect secrets
 
-Store and share credentials safely. Use [Manage credentials](manage-credentials/README.md) to reduce secret sprawl.
+Store and share credentials. Use [Manage credentials](manage-credentials/README.md) to reduce secret sprawl.
 {% endstep %}
 
 {% step %}
-### Move changes safely
+### Move changes between environments
 
 Use Git-backed workflows to promote changes between environments. See [Use source control and environments](use-source-control-and-environments/README.md).
 {% endstep %}

--- a/docs/administer/manage-credentials/use-external-secret-stores.md
+++ b/docs/administer/manage-credentials/use-external-secret-stores.md
@@ -301,7 +301,7 @@ When enabled, **Project Editors** can:
 {% hint style="info" %}
 **Global vault access**
 
-Global vaults created in **Settings** > **External Secrets** are visible in **Project** > **Settings** but are read-only for project roles. Only instance admins can change or delete global vaults.
+Global vaults created in **Settings** > **External Secrets** are visible in **Project** > **Settings** but are read-only for project roles. Only instance admins can modify or delete global vaults.
 {% endhint %}
 
 ### Custom roles <a href="#custom-roles" id="custom-roles"></a>

--- a/docs/administer/manage-credentials/use-external-secret-stores.md
+++ b/docs/administer/manage-credentials/use-external-secret-stores.md
@@ -1,5 +1,5 @@
 ---
-title: External secrets
+title: Use external secret stores
 description: Use an external secrets vault with n8n.
 contentType: howto
 nodeTitle: Use external secret stores
@@ -11,7 +11,7 @@ layout:
     visible: false
 ---
 
-# External secrets <a href="#external-secrets" id="external-secrets"></a>
+# Use external secret stores <a href="#external-secrets" id="external-secrets"></a>
 
 {% hint style="info" %}
 **Feature availability**
@@ -20,15 +20,13 @@ External secrets are available on:
 
 - **n8n Cloud:** Enterprise
 - **Self-hosted:** Enterprise
-
-* n8n supports the following secret providers: 1Password (via [Connect Server](https://developer.1password.com/docs/connect/get-started/)), AWS Secrets Manager, Azure Key Vault, GCP Secrets Manager, HashiCorp Vault, and Infisical.
-* From n8n 2.10.0 you can connect multiple vaults per secret provider. Older versions only support one vault per provider.
-* From n8n 2.13.0, if enabled, project editors can use external secrets within their projects, and project admins can also manage project vaults.
-* n8n doesn't support [HashiCorp Vault Secrets](https://developer.hashicorp.com/hcp/docs/vault-secrets).
 {% endhint %}
 
-* Credentials stored in External secrets stores only resolve in Credentials fields, not in any other fields supporting expressions.
+n8n supports the following secret providers: 1Password (using [Connect Server](https://developer.1password.com/docs/connect/get-started/)), AWS Secrets Manager, Azure Key Vault, GCP Secrets Manager, HashiCorp Vault, and Infisical. n8n doesn't support [HashiCorp Vault Secrets](https://developer.hashicorp.com/hcp/docs/vault-secrets).
 
+From n8n 2.10.0 you can connect multiple vaults per secret provider. Older versions only support one vault per provider.
+
+Credentials stored in an external secrets store only resolve in credential fields, not in any other fields supporting expressions.
 
 You can use an external secrets store to manage credentials[^1] for n8n.
 
@@ -68,7 +66,7 @@ n8n only supports plaintext values for secrets, not JSON objects.
 1. Enter the credentials for your provider. Refer to the provider-specific sections below for details.
 1. **Save** your configuration.
 
-As long as this store is connected, you can reference its secrets in credentials.
+As long as you keep this store connected, you can reference its secrets in credentials.
 
 ### 1Password <a href="#1password" id="1password"></a>
 
@@ -150,12 +148,12 @@ For more IAM permission policy examples, consult the [AWS documentation](https:/
 {% hint style="info" %}
 **Feature availability**
 
-The **Azure Cloud** setting is available from n8n 2.35.0. Earlier versions connect to Azure Public Cloud only. Existing configurations are unaffected: they continue to use Azure Public Cloud.
+The **Azure Cloud** setting is available from n8n 2.35.0. Earlier versions connect to Azure Public Cloud only. Existing configurations continue to use Azure Public Cloud without changes.
 {% endhint %}
 
 Provide your **tenant ID**, **client ID**, and **client secret**. Refer to the Azure documentation to [register a Microsoft Entra ID app and create a service principal](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal). n8n supports only single-line values for secrets.
 
-Select the **Azure Cloud** environment your Key Vault is hosted in. This sets the vault URL and the Microsoft Entra authority host:
+Select the **Azure Cloud** environment that hosts your Key Vault. This sets the vault URL and the Microsoft Entra authority host:
 
 | Azure Cloud | Vault URL suffix | Entra authority host |
 |-------------|------------------|----------------------|
@@ -302,7 +300,7 @@ When enabled, **Project Editors** can:
 {% hint style="info" %}
 **Global vault access**
 
-Global vaults created in **Settings** > **External Secrets** are visible in **Project** > **Settings** but are read-only for project roles. Only instance admins can modify or delete global vaults.
+Global vaults created in **Settings** > **External Secrets** are visible in **Project** > **Settings** but are read-only for project roles. Only instance admins can change or delete global vaults.
 {% endhint %}
 
 ### Custom roles <a href="#custom-roles" id="custom-roles"></a>
@@ -327,6 +325,8 @@ Using external secrets in your own credentials, as a project editor or admin wit
 In versions before n8n 2.13.0 (or when **Enable external secrets for project roles** is off), only instance owners and admins can resolve secrets at runtime. If an owner or admin updates another user's credential with a secrets expression, it may appear to work in preview but fail in production.
 
 In this case, only use external secrets in credentials owned by an instance owner or admin.
+
+See [Manage credentials](README.md) for other ways to secure and share credentials.
 
 [^1]: In n8n, credentials store authentication information to connect with specific apps and services. After creating credentials with your authentication information (username and password, API key, OAuth secrets, etc.), you can use the associated app node to interact with the service.
 [^2]: In n8n, expressions allow you to populate node parameters dynamically by executing JavaScript code. Instead of providing a static value, you can use the n8n expression syntax to define the value using data from previous nodes, other workflows, or your n8n environment.

--- a/docs/administer/manage-credentials/use-external-secret-stores.md
+++ b/docs/administer/manage-credentials/use-external-secret-stores.md
@@ -1,5 +1,5 @@
 ---
-title: Use external secret stores
+title: External secrets
 description: Use an external secrets vault with n8n.
 contentType: howto
 nodeTitle: Use external secret stores
@@ -11,7 +11,7 @@ layout:
     visible: false
 ---
 
-# Use external secret stores <a href="#external-secrets" id="external-secrets"></a>
+# External secrets <a href="#external-secrets" id="external-secrets"></a>
 
 {% hint style="info" %}
 **Feature availability**
@@ -24,7 +24,8 @@ External secrets are available on:
 
 n8n supports the following secret providers: 1Password (using [Connect Server](https://developer.1password.com/docs/connect/get-started/)), AWS Secrets Manager, Azure Key Vault, GCP Secrets Manager, HashiCorp Vault, and Infisical. n8n doesn't support [HashiCorp Vault Secrets](https://developer.hashicorp.com/hcp/docs/vault-secrets).
 
-From n8n 2.10.0 you can connect multiple vaults per secret provider. Older versions only support one vault per provider.
+* From n8n 2.10.0 you can connect multiple vaults per secret provider. Older versions only support one vault per provider.
+* From n8n 2.13.0, if enabled, project editors can use external secrets within their projects, and project admins can also manage project vaults.
 
 Credentials stored in an external secrets store only resolve in credential fields, not in any other fields supporting expressions.
 

--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -1,4 +1,5 @@
 ---
+description: Build workflows in n8n, from first draft to production.
 layout:
   width: default
   title:
@@ -51,7 +52,7 @@ Reference, transform, structure, and test the data moving through workflows.
 
 [**Code in n8n**](code-in-n8n/README.md)
 
-Use expressions, the Code node, and developer tools when low-code is not enough.
+Use expressions, the Code node, and developer tools when low-code isn't enough.
 
 <a href="code-in-n8n/" class="button secondary">Open</a>
 {% endcolumn %}

--- a/docs/build/integrate-ai/README.md
+++ b/docs/build/integrate-ai/README.md
@@ -1,4 +1,5 @@
 ---
+description: Build AI-powered workflows in n8n with LLM providers, agents, tools, memory, and MCP servers.
 layout:
   description:
     visible: false
@@ -6,6 +7,10 @@ layout:
 # Integrate AI <a href="#integrate-ai" id="integrate-ai"></a>
 
 n8n lets you build AI workflows that connect different LLM providers such as OpenAI, Anthropic, and Google, add tools and memory, and combine several models in one workflow.
+
+{% content-ref url="mcp-servers.md" %}
+[mcp-servers.md](mcp-servers.md)
+{% endcontent-ref %}
 
 {% content-ref url="understand-ai-components/README.md" %}
 [understand-ai-components/README.md](understand-ai-components/README.md)
@@ -22,3 +27,5 @@ n8n lets you build AI workflows that connect different LLM providers such as Ope
 {% content-ref url="ai-examples.md" %}
 [ai-examples.md](ai-examples.md)
 {% endcontent-ref %}
+
+See [Build](../README.md) for other workflow-building topics.

--- a/docs/build/understand-workflows/README.md
+++ b/docs/build/understand-workflows/README.md
@@ -10,7 +10,7 @@ layout:
     visible: false
 ---
 
-# Understand workflows <a href="#workflows" id="workflows"></a>
+# Workflows <a href="#workflows" id="workflows"></a>
 
 A workflow[^1] is a collection of nodes connected together to automate a process.
 
@@ -21,6 +21,6 @@ A workflow[^1] is a collection of nodes connected together to automate a process
 * Debug using the [Executions](understand-executions/README.md) list.
 * [Share](../manage-workflows/share-with-others.md) workflows between users.
 
-If it's your first time building a workflow, you may want to use the [quickstart guides](https://app.gitbook.com/s/CxSeOtVxqqhfxMSac0AV/build-your-first-workflow) to try out n8n features.
+If it's your first time building a workflow, you may want to use the [quickstart guide](https://app.gitbook.com/s/CxSeOtVxqqhfxMSac0AV/build-your-first-workflow) to quickly try out n8n features.
 
 [^1]: An n8n workflow is a collection of nodes that automate a process. Workflows begin execution when a trigger condition occurs and execute sequentially to achieve complex tasks.

--- a/docs/build/understand-workflows/README.md
+++ b/docs/build/understand-workflows/README.md
@@ -1,5 +1,5 @@
 ---
-description: Learn about the key components of automation in n8n.
+description: Learn about the key components of a workflow in n8n.
 contentType: overview
 nodeTitle: Understand workflows
 originalFilePath: workflows/index.md
@@ -10,17 +10,17 @@ layout:
     visible: false
 ---
 
-# Workflows <a href="#workflows" id="workflows"></a>
+# Understand workflows <a href="#workflows" id="workflows"></a>
 
 A workflow[^1] is a collection of nodes connected together to automate a process.
 
 
 * [Create](create-and-run-workflows.md) a workflow.
 * Use [Workflow templates](../ways-of-building-workflows/use-templates.md) to help you get started.
-* Learn about the key [components](workflow-components/README.md) of an automation in n8n.
+* Learn about the key [components](workflow-components/README.md) of a workflow in n8n.
 * Debug using the [Executions](understand-executions/README.md) list.
 * [Share](../manage-workflows/share-with-others.md) workflows between users.
 
-If it's your first time building a workflow, you may want to use the [quickstart guides](https://app.gitbook.com/s/CxSeOtVxqqhfxMSac0AV/build-your-first-workflow) to quickly try out n8n features.
+If it's your first time building a workflow, you may want to use the [quickstart guides](https://app.gitbook.com/s/CxSeOtVxqqhfxMSac0AV/build-your-first-workflow) to try out n8n features.
 
 [^1]: An n8n workflow is a collection of nodes that automate a process. Workflows begin execution when a trigger condition occurs and execute sequentially to achieve complex tasks.

--- a/docs/build/understand-workflows/workflow-components/add-notes-and-documentation.md
+++ b/docs/build/understand-workflows/workflow-components/add-notes-and-documentation.md
@@ -28,56 +28,56 @@ layout:
 
 # Add notes and documentation
 
-Sticky Notes allow you to annotate and comment on your workflows.
+Sticky notes let you annotate and comment on your workflows.
 
-n8n recommends using Sticky Notes heavily, especially on [template workflows](#user-content-fn-1)[^1], to help other users understand your workflow.
+n8n recommends using sticky notes on template workflows[^1] to help other users understand your workflow.
 
 ![A basic workflow with a sticky note attached](../../.gitbook/assets/example-sticky-note.png)
 
-## Create a Sticky Note <a href="#create-a-sticky-note" id="create-a-sticky-note"></a>
+## Create a sticky note <a href="#create-a-sticky-note" id="create-a-sticky-note"></a>
 
-Sticky Notes are a core node. To add a new Sticky Note:
+Sticky notes are a core node. To add a new sticky note:
 
 1. Open the nodes panel.
 2. Search for `note`.
-3. Click the **Sticky Note** node. n8n adds a new Sticky Note to the canvas.
+3. Click the **Sticky Note** node. n8n adds a new sticky note to the canvas.
 
-## Edit a Sticky Note <a href="#edit-a-sticky-note" id="edit-a-sticky-note"></a>
+## Edit a sticky note <a href="#edit-a-sticky-note" id="edit-a-sticky-note"></a>
 
-1. Double click the Sticky Note you want to edit.
+1. Double-click the sticky note you want to edit.
 2. Write your note. [This guide](https://commonmark.org/help/) explains how to format your text with Markdown. n8n uses [markdown-it](https://github.com/markdown-it/markdown-it), which implements the CommonMark specification.
 3. Click away from the note, or press `Esc`, to stop editing.
 
 ## Change the color <a href="#change-the-color" id="change-the-color"></a>
 
-To change the Sticky Note color:
+To change the sticky note color:
 
-1. Hover over the Sticky Note
-2. Select **Change color** <img src="../../.gitbook/assets/change-color.png" alt="Change Sticky Note color icon" data-size="line">
-3. Choose from seven preset colors, or click the rainbow gradient button to select a custom color
+1. Hover over the sticky note.
+2. Select **Change color** <img src="../../.gitbook/assets/change-color.png" alt="Change Sticky Note color icon" data-size="line">.
+3. Choose from seven preset colors, or click the rainbow gradient button to select a custom color.
 
 ![Color selector showing preset colors and custom color button](../../.gitbook/assets/color-picker-popover.png)
 
 ### Custom colors <a href="#custom-colors" id="custom-colors"></a>
 
-In addition to the seven preset colors, you can select any custom color for your sticky notes:
+Besides the seven preset colors, you can select any custom color for your sticky notes:
 
-1. Click the button with the rainbow gradient and plus icon
-2. Use the color picker to select your desired color, or enter a hex color code (for example, `#FF5733`)
-3. Click **Apply** to set the color
+1. Click the button with the rainbow gradient and plus icon.
+2. Use the color picker to select your desired color, or enter a hex color code (for example, `#FF5733`).
+3. Click **Apply** to set the color.
 
-Your recently used custom colors (up to 8) are automatically saved and displayed in the color picker for quick access.
+n8n automatically saves your last-used custom colors (up to eight) and displays them in the color picker for quick access.
 
 Custom colors feature theme-aware borders that automatically adjust for optimal visibility in both light and dark modes.
 
-## Sticky Note positioning <a href="#sticky-note-positioning" id="sticky-note-positioning"></a>
+## Sticky note positioning <a href="#sticky-note-positioning" id="sticky-note-positioning"></a>
 
 You can:
 
-* Drag a Sticky Note anywhere on the canvas.
-* Drag Sticky Notes behind nodes. You can use this to visually group nodes.
-* Resize Sticky Notes by hovering over the edge of the note and dragging to resize.
-* Change the color: select **Options** <img src="../../.gitbook/assets/three-dot-options-menu (1).png" alt="Options icon" data-size="line"> to open the color selector.
+* Drag a sticky note anywhere on the canvas.
+* Drag sticky notes behind nodes. You can use this to visually group nodes.
+* Resize sticky notes by hovering over the edge of the note and dragging to resize.
+* Change the color: select the **Options** menu <img src="../../.gitbook/assets/three-dot-options-menu (1).png" alt="Options icon" data-size="line"> to open the color selector.
 
 ## Writing in Markdown <a href="#writing-in-markdown" id="writing-in-markdown"></a>
 
@@ -128,5 +128,7 @@ For example:
 ```
 
 To embed your own video, copy the above syntax, replacing `ZCuL2e4zC_4` with your video ID. The YouTube video ID is the string that follows `v=` in the YouTube URL.
+
+See [Workflow components](README.md) for other elements you can add to a workflow.
 
 [^1]: n8n templates are pre-built workflows designed by n8n and community members that you can import into your n8n instance. When using templates, you may need to fill in credentials and adjust the configuration to suit your needs.

--- a/docs/build/ways-of-building-workflows/ai-assistant.md
+++ b/docs/build/ways-of-building-workflows/ai-assistant.md
@@ -50,7 +50,7 @@ You can ask the AI Assistant to:
 - **Test and troubleshoot workflows:** ask it to run checks, inspect relevant errors, and suggest fixes.
 - **Help with credentials:** prompt you to select an existing credential or create a new one, without pasting secrets into chat.
 - **Use n8n resources:** create or update supporting resources such as [Data Tables](../work-with-data/data-tables.md) when needed.
-- **Research approved websites:** when you enable web access, the AI Assistant asks for permission before accessing a domain.
+- **Research approved websites:** when web access is enabled, the AI Assistant asks for permission before accessing a domain.
 
 ## Before you start
 
@@ -128,7 +128,7 @@ If you create a new credential, you enter the secret in the standard n8n credent
 
 ## Web access
 
-When you enable web research, the AI Assistant asks for permission before accessing an external domain.
+When you enable web access, the AI Assistant asks for permission before accessing an external domain.
 
 Review the requested domain before you approve access.
 
@@ -154,7 +154,7 @@ Depending on the task, this can include:
 - workflow structure and node configuration,
 - selected execution and error details used for troubleshooting,
 - credential names, credential types, or connection status,
-- approved web pages or domains, when you enable web research.
+- approved web pages or domains, when you enable web access.
 
 The AI Assistant doesn't require you to paste secrets into chat. Enter API keys, passwords, and tokens through the standard n8n credential screens.
 

--- a/docs/build/ways-of-building-workflows/ai-assistant.md
+++ b/docs/build/ways-of-building-workflows/ai-assistant.md
@@ -23,7 +23,10 @@ The result is a normal n8n workflow. You can open it, inspect it, edit it, test 
 {% hint style="info" %}
 **Feature availability**
 
-The AI Assistant is available on **n8n Cloud** and **self-hosted**. 
+The AI Assistant is available on:
+
+- **n8n Cloud:** Starter, Pro
+- **Self-hosted:** Community, Registered Community, Business
 
 It isn't ready for n8n Cloud Enterprise or self-hosted Enterprise yet. If you're an Enterprise customer, contact your Customer Success Manager about preview access.
 {% endhint %}
@@ -47,11 +50,11 @@ You can ask the AI Assistant to:
 - **Test and troubleshoot workflows:** ask it to run checks, inspect relevant errors, and suggest fixes.
 - **Help with credentials:** prompt you to select an existing credential or create a new one, without pasting secrets into chat.
 - **Use n8n resources:** create or update supporting resources such as [Data Tables](../work-with-data/data-tables.md) when needed.
-- **Research approved websites:** when web access is enabled, the AI Assistant asks for permission before accessing a domain.
+- **Research approved websites:** when you enable web access, the AI Assistant asks for permission before accessing a domain.
 
 ## Before you start
 
-To use the AI Assistant, you need access to an n8n instance where the feature is enabled.
+To use the AI Assistant, you need access to an n8n instance with the feature enabled.
 
 Make sure that:
 
@@ -125,7 +128,7 @@ If you create a new credential, you enter the secret in the standard n8n credent
 
 ## Web access
 
-When web research is enabled, the AI Assistant asks for permission before accessing an external domain.
+When you enable web research, the AI Assistant asks for permission before accessing an external domain.
 
 Review the requested domain before you approve access.
 
@@ -151,7 +154,7 @@ Depending on the task, this can include:
 - workflow structure and node configuration,
 - selected execution and error details used for troubleshooting,
 - credential names, credential types, or connection status,
-- approved web pages or domains, when web research is enabled.
+- approved web pages or domains, when you enable web research.
 
 The AI Assistant doesn't require you to paste secrets into chat. Enter API keys, passwords, and tokens through the standard n8n credential screens.
 
@@ -174,4 +177,6 @@ To reduce unnecessary usage:
 
 To get more credits during Preview, upgrade your plan. More ways to top up are coming.
 
-For current plan details, see [n8n Plans and Pricing](https://n8n.io/pricing/).
+For current plan details, see [n8n plans and pricing](https://n8n.io/pricing/).
+
+See [Ways of building workflows](README.md) for other approaches.

--- a/docs/build/work-with-data/expressions-versus-data-nodes.md
+++ b/docs/build/work-with-data/expressions-versus-data-nodes.md
@@ -1,4 +1,5 @@
 ---
+description: Compare expressions, the Code node, the AI Transform node, and data transformation nodes for working with data in n8n.
 contentType: howto
 nodeTitle: Expressions versus data nodes
 originalFilePath: data/expressions.md
@@ -13,7 +14,7 @@ layout:
 
 n8n provides multiple ways to work with and transform data. Understanding when to use each approach helps you build efficient workflows.
 
-| Approach	| Use when you need to... | Examples | Available on |
+| Approach	| When to use | Examples | Available on |
 |---|---|---|---|
 | Expressions | Set a single parameter value using existing data | Pull `{{$json.city}}`, format dates, simple math | Cloud and Self-hosted |
 | Code node	| Write full JavaScript/Python for complex transformations | Restructure data, loop through items, use external libraries | Cloud and Self-hosted |
@@ -38,21 +39,21 @@ Expressions have the advantage of providing an immediate preview of the computed
 
 ### Code node <a href="#code-node" id="code-node"></a>
 
-The [Code node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.code) is a dedicated node where you write JavaScript or Python that runs as a workflow step. It gives you access to incoming data from previous nodes, which you can manipulate by adding, removing, or updating items. You can create any custom function you need and use n8n's built‑in methods and variables through `$` syntax.
+The [Code node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.code) is a dedicated node where you write JavaScript or Python that runs as a workflow step. It gives you access to incoming data from previous nodes, which you can manipulate by adding, removing, or updating items. You can create any custom function you need and use n8n's built-in methods and variables through `$` syntax.
 
 **When to use the Code node:**
 
 * You need more complex logic or data transformation than an expression can provide, such as restructuring arrays and objects, aggregating or splitting items, and custom algorithms.
-* You want to transform many items at once.
-* You want to use promises, `console.log`, or, in the case of self‑hosted setups, external npm modules.
+* You want to transform a batch of items at once.
+* You want to use promises, `console.log`, or, for self-hosted setups, external npm modules.
 
 ### AI Transform node <a href="#ai-transform-node" id="ai-transform-node"></a>
 
-This node generates code snippets based on a short natural‑language prompt. It's context‑aware and understands your workflow's nodes and data types. The generated code is read‑only in the node; you can copy it into a Code node to edit.
+This node generates code snippets based on a short natural-language prompt. It's context-aware and understands your workflow's nodes and data types. The generated code is read-only in the node. You can copy it into a Code node to edit.
 
 **When to use the AI Transform node:**
 
-* You know what transformation you want but don't want to hand‑write the code.
+* You know what transformation you want but don't want to hand-write the code.
 * You want AI to draft the transformation logic and then run it directly in the node, or copy into a Code node for further customization.
 
 ### Other data transformation nodes <a href="#other-data-transformation-nodes" id="other-data-transformation-nodes"></a>
@@ -64,11 +65,13 @@ n8n provides a collection of nodes to transform data:
 * [Remove Duplicates](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.removeduplicates): identify and delete items that are identical across all fields or a subset of fields.
 * [Sort](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.sort): organize lists in a desired ordering, or generate a random selection.
 * [Split Out](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.splitout): separate a single data item containing a list into multiple items.
-* [Summarize](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.summarize): aggregate items together, in a manner similar to Excel pivot tables. 
+* [Summarize](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-nodes/n8n-nodes-base.summarize): aggregate items together, like Excel pivot tables.
 
 **When to use data transformation nodes:**
 
 * The operation you need matches a specific transformation node's purpose.
 * You want a no-code solution with a guided UI.
 * You prefer visual workflow building over writing expressions or code.
+
+See [Work with data](README.md) for other ways to reference, transform, and structure data.
 

--- a/docs/build/work-with-data/expressions-versus-data-nodes.md
+++ b/docs/build/work-with-data/expressions-versus-data-nodes.md
@@ -14,7 +14,7 @@ layout:
 
 n8n provides multiple ways to work with and transform data. Understanding when to use each approach helps you build efficient workflows.
 
-| Approach	| When to use | Examples | Available on |
+| Approach	| Use when you need to... | Examples | Available on |
 |---|---|---|---|
 | Expressions | Set a single parameter value using existing data | Pull `{{$json.city}}`, format dates, simple math | Cloud and Self-hosted |
 | Code node	| Write full JavaScript/Python for complex transformations | Restructure data, loop through items, use external libraries | Cloud and Self-hosted |
@@ -44,7 +44,7 @@ The [Code node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/builtin/core-node
 **When to use the Code node:**
 
 * You need more complex logic or data transformation than an expression can provide, such as restructuring arrays and objects, aggregating or splitting items, and custom algorithms.
-* You want to transform a batch of items at once.
+* You want to transform many items at once.
 * You want to use promises, `console.log`, or, for self-hosted setups, external npm modules.
 
 ### AI Transform node <a href="#ai-transform-node" id="ai-transform-node"></a>

--- a/docs/connect/README.md
+++ b/docs/connect/README.md
@@ -1,7 +1,6 @@
 ---
 contentType: guide
-status: beta
-nodeTitle: Connect
+nodeTitle: n8n CLI
 originalFilePath: api/n8n-cli/index.md
 originalUrl: https://docs.n8n.io/api/n8n-cli
 url: https://docs.n8n.io/connect/

--- a/docs/connect/README.md
+++ b/docs/connect/README.md
@@ -1,7 +1,7 @@
 ---
 contentType: guide
 status: beta
-nodeTitle: n8n CLI
+nodeTitle: Connect
 originalFilePath: api/n8n-cli/index.md
 originalUrl: https://docs.n8n.io/api/n8n-cli
 url: https://docs.n8n.io/connect/
@@ -75,3 +75,5 @@ Best for:
 Start with [Connect to n8n MCP server](connect-to-n8n-mcp-server.md).
 {% endtab %}
 {% endtabs %}
+
+You can also connect an MCP client to [the n8n docs MCP server](connect-to-n8n-docs-mcp-server.md) so AI tools can search the docs, or [create your own node](create-nodes/README.md) to add a custom integration to n8n.

--- a/docs/connect/connect-to-n8n-docs-mcp-server.md
+++ b/docs/connect/connect-to-n8n-docs-mcp-server.md
@@ -51,7 +51,7 @@ Use the endpoint for the server you want:
 The steps differ by tool, but each one needs a server URL from above. The following examples set up both servers. To connect only one, keep the entry you want and remove the other.
 
 {% hint style="info" %}
-The Kapa.ai server requires authentication. Your AI tool opens a browser-based sign-in flow when you first connect to it, or the first time you use it. Follow the prompts to authorize the connection.
+The Kapa.ai server requires authentication. Your AI tool opens a browser-based sign-in flow when you first connect to it, or the first time you use it. Follow the prompts to approve the connection.
 {% endhint %}
 
 ### Claude Code
@@ -113,3 +113,5 @@ After you connect, your tool can search n8n's knowledge as you work.
 {% hint style="info" %}
 The exact configuration steps and file locations vary between tools and versions. Check your tool's documentation for how it adds a remote MCP server. For more on the Kapa.ai server, see the [Kapa.ai MCP documentation](https://docs.kapa.ai/overview/build-with-ai).
 {% endhint %}
+
+See [Connect](README.md) for other ways to connect to n8n.

--- a/docs/connect/connect-to-n8n-mcp-server.md
+++ b/docs/connect/connect-to-n8n-mcp-server.md
@@ -63,7 +63,7 @@ The settings layout described below (**Connection details**, **Access**, **Conne
 1. Navigate to **Settings > Instance-level MCP**.
 2. Select **Enable MCP access** (requires instance owner or admin permissions).
 
-![The Instance-level MCP page before MCP is enabled, showing the Enable MCP access button](.gitbook/assets/mcp-enable-screen.png)
+![The Instance-level MCP page before you enable MCP access, showing the Enable MCP access button](.gitbook/assets/mcp-enable-screen.png)
 
 Once enabled, the page groups settings into three sections:
 
@@ -71,7 +71,7 @@ Once enabled, the page groups settings into three sections:
 * **Access**: shows how many workflows (and, if your instance has the agents feature, agents) are exposed to MCP clients, see [Exposing workflows to MCP clients](#exposing-workflows-to-mcp-clients) and [Exposing agents to MCP clients](#exposing-agents-to-mcp-clients). Instance owners and admins also see **Allowed callback URLs** here, see [Restricting OAuth callback URLs](#restricting-oauth-callback-urls).
 * **Connected clients**: shows how many clients currently have access, each with its own granted permissions. Select **View all** to review or revoke access for individual clients, see [Reviewing and revoking client access](#revoking-client-access).
 
-![The Instance-level MCP page after MCP is enabled, showing Connection details, Access, and Connected clients](.gitbook/assets/mcp-enabled-screen.png)
+![The Instance-level MCP page after you enable MCP access, showing Connection details, Access, and Connected clients](.gitbook/assets/mcp-enabled-screen.png)
 
 **To disable:** In **Connection details**, select the **MCP status** control and choose **Disable**. n8n asks you to confirm, since disabling disconnects every connected client and revokes its access. You can turn MCP access back on later.
 
@@ -103,7 +103,7 @@ In **Connection details**, select **Connect** to open the **Connect a client** d
 
 1. Navigate to **Settings > Instance-level MCP**.
 2. In **Connection details**, select **Connect** to open the **Connect a client** dialog.
-3. Make sure the **OAuth (recommended)** tab is selected.
+3. Confirm you're on the **OAuth (recommended)** tab.
 4. In the **Your client** dropdown, pick your AI assistant, IDE, or CLI. n8n groups clients into **CLI** (Claude Code, Codex, Gemini CLI), **Web** (Claude.ai, ChatGPT), and **IDE** (Cursor, VS Code, Windsurf), and shows setup steps tailored to your choice.
 5. Follow the steps shown for your client type:
    * **Web clients**: select **One-click setup** to add n8n to the client directly, or copy the **Server URL** and paste it into the client's own connector settings yourself.
@@ -125,7 +125,7 @@ Each connected client only has the permissions you granted it when it connected,
 1. Navigate to **Settings > Instance-level MCP**.
 2. In **Connection details**, select **Connect** to open the **Connect a client** dialog.
 3. Switch to the **API key** tab. n8n automatically generates a personal access token tied to your user account the first time you open it.
-4. Copy what you need: the **Configuration JSON** block, already filled in with your server URL and an `Authorization: Bearer` header carrying your token, or the individual **Server URL** and access token values if your client doesn't use that JSON format (for example, Codex's TOML config). Once you leave this tab, n8n only shows a redacted token value, and you won't be able to copy it again unless you [rotate it](#rotating-your-token).
+4. Copy what you need: the **Configuration JSON** block, already filled in with your server URL and an `Authorization: Bearer` header carrying your token, or the individual **Server URL** and access token values if your client doesn't use that JSON format (for example, Codex's TOML configuration). Once you leave this tab, n8n only shows a redacted token value, and you won't be able to copy it again unless you [rotate it](#rotating-your-token).
 5. Paste what you copied into your MCP client's configuration: drop the **Configuration JSON** straight in for clients that accept an `mcpServers` JSON snippet, or use the individual **Server URL** and token for clients that need a different format. This tab isn't client-specific, so the same values work no matter which client you're setting up (see [MCP client connection examples](connect-to-n8n-mcp-server/mcp-client-examples.md) for client-specific formats).
 
 #### Rotating your access token <a href="#rotating-your-token" id="rotating-your-token"></a>
@@ -142,12 +142,12 @@ If you lose your token or need to rotate it:
 
 ## Exposing workflows to MCP clients <a href="#exposing-workflows-to-mcp-clients" id="exposing-workflows-to-mcp-clients"></a>
 
-MCP clients can discover previews of all workflows the current user has access to using `search_workflows`. However, clients can't access full workflow data, nor execute or modify a workflow unless you explicitly enable MCP access for that workflow.
+MCP clients can discover previews of all workflows the current user has access to using `search_workflows`. Clients can't access full workflow data, execute, or change a workflow unless you explicitly enable MCP access for that workflow.
 
 {% hint style="info" %}
 **Workflow eligibility** <a href="#workflow-eligibility" id="workflow-eligibility"></a>
 
-Only workflows that are published, and that contain a webhook, form, schedule, or chat trigger node, can be enabled for MCP access.
+You can only enable MCP access for published workflows that contain a webhook, form, schedule, or chat trigger node.
 {% endhint %}
 
 ### Enabling access for individual workflows <a href="#enabling-access-for-individual-workflows" id="enabling-access-for-individual-workflows"></a>
@@ -164,7 +164,7 @@ From the **Workflows exposed** page (available from n8n 2.2.0), you can enable a
 #### Option 2: From the workflow editor <a href="#option-2-from-the-workflow-editor" id="option-2-from-the-workflow-editor"></a>
 
 1. Open the workflow.
-2. Click the main workflow menu (`...`) in the top-right corner.
+2. Click the main **Workflow menu** (`...`) in the top-right corner.
 3. Select **Settings**.
 4. Toggle **Available in MCP**.
 
@@ -201,7 +201,7 @@ This will toggle MCP access for all workflows that are **currently** in the sele
 {% hint style="info" %}
 **Feature availability**
 
-Auto-exposing new workflows is rolling out gradually from n8n 2.36.0. The setting may not be immediately visible on every instance.
+Auto-exposing new workflows is rolling out gradually from n8n 2.36.0. The setting may not be visible on every instance yet.
 {% endhint %}
 
 Instead of enabling MCP access for each workflow individually, you can expose every newly created workflow automatically:
@@ -209,9 +209,9 @@ Instead of enabling MCP access for each workflow individually, you can expose ev
 1. Navigate to **Settings > Instance-level MCP**.
 2. Turn on **Auto-expose new workflows**.
 
-This setting is off by default. Turning it on only affects workflows created afterwards. Workflows that already exist keep their current setting, so use [Enabling access for individual workflows](#enabling-access-for-individual-workflows) or [Enabling access for projects/folders](#enabling-access-for-projectsfolders) to expose those.
+This setting is off by default. Turning it on only affects workflows created afterward. Workflows that already exist keep their current setting, so use [Enabling access for individual workflows](#enabling-access-for-individual-workflows) or [Enabling access for projects/folders](#enabling-access-for-projectsfolders) to expose those.
 
-Only instance owners and admins can change this setting. It's read-only on instances where MCP access is managed through environment variables.
+Only instance owners and admins can change this setting. It's read-only on instances that manage MCP access through environment variables.
 
 {% hint style="info" %}
 **Note**
@@ -236,11 +236,11 @@ To help MCP clients identify workflows, you can add free-text descriptions as fo
    1. Navigate to **Settings > Instance-level MCP**.
    2. Select **Workflows exposed**.
    3. Use the action menu in the desired workflow's row and select the **Edit description** action.
-   4. Alternatively, click the description text directly to open the edit dialog.
+   4. Or click the description text directly to open the edit dialog.
 2.  Option 2: From the workflow editor
 
     1. Open the workflow.
-    2. Click the main workflow menu (`...`) in the top-right corner.
+    2. Click the main **Workflow menu** (`...`) in the top-right corner.
     3. Select **Edit description**.
 
     ![Workflow's main menu open, with Edit description highlighted](<.gitbook/assets/mcp_workflow_description (1).png>)
@@ -250,7 +250,7 @@ To help MCP clients identify workflows, you can add free-text descriptions as fo
 {% hint style="info" %}
 **Feature availability**
 
-Agents are available from n8n 2.34.0 and are a separate feature from workflows. See [Build and manage agents](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/build-and-manage-agents) for details. This section only applies if agents are enabled on your instance.
+Agents are available from n8n 2.34.0 and are a separate feature from workflows. See [Build and manage agents](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/build-and-manage-agents) for details. This section only applies if you've enabled agents on your instance.
 {% endhint %}
 
 {% hint style="info" %}
@@ -282,7 +282,7 @@ If your instance has the agents feature, the **Access** section also shows **Age
 The **Agents exposed** page shows every agent enabled for MCP clients to access, with its name and its project or folder location. From this list you can:
 
 * Open an agent or its project directly.
-* Remove access for a single agent from its row, or select multiple agents and remove access for all of them at once.
+* Remove access for a single agent from its row, or select multiple agents and remove access for all at once.
 * Enable access for more agents using the **Enable agents** button.
 
 ## Restricting OAuth callback URLs <a href="#restricting-oauth-callback-urls" id="restricting-oauth-callback-urls"></a>
@@ -299,7 +299,7 @@ Instance owners and admins can restrict which URLs an OAuth client can redirect 
 ## Tools and resources <a href="#tools-and-resources" id="tools-and-resources"></a>
 
 {% hint style="info" %}
-Consider using coding agents (such as Claude Code or Google ADK agents) instead of chat clients as your MCP clients. Coding agents are optimized for generating and validating TypeScript code, making them ideal for building workflows programmatically.
+Consider using coding agents (such as Claude Code or Google ADK agents) instead of chat clients as your MCP clients. Coding agents specialize in generating and validating TypeScript code, making them ideal for building workflows programmatically.
 {% endhint %}
 
 The n8n MCP server exposes tools for workflow management, workflow building, agent management, and data tables. For a complete list of available tools and their parameters, refer to the [MCP server tools reference](connect-to-n8n-mcp-server/mcp-server-tools-reference.md).
@@ -324,7 +324,7 @@ Skills load guidance at the moment the agent needs it, rather than relying on th
 * Avoid common mistakes, such as incorrect expression syntax or missing error handling.
 * Produce workflows that need less back-and-forth to fix.
 
-The skills are plain Markdown, so you can read, fork, and modify them for your own conventions.
+The skills are plain Markdown, so you can read, fork, and change them for your own conventions.
 
 ### Installing skills <a href="#installing-skills" id="installing-skills"></a>
 
@@ -340,8 +340,8 @@ If you encounter issues connecting MCP clients to your n8n instance, consider th
 
 * Ensure that your n8n instance is publicly accessible if you are using cloud-based MCP clients.
 * Verify that the MCP access is enabled in n8n settings.
-* Check that the workflows you want to execute or modify are marked as **Available in MCP**.
-* Confirm that the authentication method (OAuth or API key) is configured correctly in your MCP client.
+* Check that the workflows you want to execute or change are marked as **Available in MCP**.
+* Confirm that the authentication method (OAuth or API key) is configured in your MCP client.
 * If your instance runs behind a reverse proxy, load balancer, or web application firewall, make sure it doesn't strip the MCP request headers. See [MCP request headers](#mcp-request-headers).
 * Review n8n server logs for any error messages related to MCP connections.
 

--- a/docs/connect/connect-to-n8n-mcp-server.md
+++ b/docs/connect/connect-to-n8n-mcp-server.md
@@ -141,7 +141,7 @@ If you lose your token or need to rotate it:
 
 ## Exposing workflows to MCP clients <a href="#exposing-workflows-to-mcp-clients" id="exposing-workflows-to-mcp-clients"></a>
 
-MCP clients can discover previews of all workflows the current user has access to using `search_workflows`. Clients can't access full workflow data, execute, or change a workflow unless you explicitly enable MCP access for that workflow.
+MCP clients can discover previews of all workflows the current user has access to using `search_workflows`. Clients can't access full workflow data, execute, or modify a workflow unless you explicitly enable MCP access for that workflow.
 
 {% hint style="info" %}
 **Workflow eligibility** <a href="#workflow-eligibility" id="workflow-eligibility"></a>

--- a/docs/connect/connect-to-n8n-mcp-server.md
+++ b/docs/connect/connect-to-n8n-mcp-server.md
@@ -1,6 +1,5 @@
 ---
 title: Set up and use n8n MCP server
-status: beta
 nodeTitle: Connect to n8n MCP server
 originalFilePath: advanced-ai/mcp/accessing-n8n-mcp-server.md
 originalUrl: https://docs.n8n.io/advanced-ai/mcp/accessing-n8n-mcp-server
@@ -236,7 +235,7 @@ To help MCP clients identify workflows, you can add free-text descriptions as fo
    1. Navigate to **Settings > Instance-level MCP**.
    2. Select **Workflows exposed**.
    3. Use the action menu in the desired workflow's row and select the **Edit description** action.
-   4. Or click the description text directly to open the edit dialog.
+   4. Alternatively, click the description text directly to open the edit dialog.
 2.  Option 2: From the workflow editor
 
     1. Open the workflow.
@@ -324,7 +323,7 @@ Skills load guidance at the moment the agent needs it, rather than relying on th
 * Avoid common mistakes, such as incorrect expression syntax or missing error handling.
 * Produce workflows that need less back-and-forth to fix.
 
-The skills are plain Markdown, so you can read, fork, and change them for your own conventions.
+The skills are plain Markdown, so you can read, fork, and modify them for your own conventions.
 
 ### Installing skills <a href="#installing-skills" id="installing-skills"></a>
 
@@ -340,8 +339,8 @@ If you encounter issues connecting MCP clients to your n8n instance, consider th
 
 * Ensure that your n8n instance is publicly accessible if you are using cloud-based MCP clients.
 * Verify that the MCP access is enabled in n8n settings.
-* Check that the workflows you want to execute or change are marked as **Available in MCP**.
-* Confirm that the authentication method (OAuth or API key) is configured in your MCP client.
+* Check that the workflows you want to execute or modify are marked as **Available in MCP**.
+* Confirm that the authentication method (OAuth or API key) is configured correctly in your MCP client.
 * If your instance runs behind a reverse proxy, load balancer, or web application firewall, make sure it doesn't strip the MCP request headers. See [MCP request headers](#mcp-request-headers).
 * Review n8n server logs for any error messages related to MCP connections.
 

--- a/docs/connect/connect-to-n8n-mcp-server/mcp-client-examples.md
+++ b/docs/connect/connect-to-n8n-mcp-server/mcp-client-examples.md
@@ -25,7 +25,7 @@ The examples below are useful if interactive steps aren't shown in n8n for your 
    * Navigate to your workspace **Settings > Integrations**.
    * In the **MCP Servers** section, find **n8n** and click **Connect**.
    * Enter your n8n server URL: the **Server URL** value shown in the **Connect a client** dialog.
-   * Save the connection. If successful, n8n redirects you to authorize Lovable.
+   * Save the connection. If successful, n8n redirects you to approve access for Lovable.
 2. Verify connectivity.
    * Once connected, Lovable can query for workflows with MCP access enabled.
    * **Example:** Asking Lovable to build a workflow UI that lists users and allows deleting them.
@@ -40,7 +40,7 @@ The examples below are useful if interactive steps aren't shown in n8n for your 
    * **Name:** n8n MCP
    * **Remote MCP Server URL**: the **Server URL** value shown in the **Connect a client** dialog
 4. Save the connector.
-5. When prompted, authorize Claude Desktop to access your n8n instance.
+5. When prompted, approve access for Claude Desktop.
 
 **Using API key**
 
@@ -68,7 +68,7 @@ Here, replace:
 
 ## Connecting Claude Code to n8n MCP server <a href="#connecting-claude-code-to-n8n-mcp-server" id="connecting-claude-code-to-n8n-mcp-server"></a>
 
-**OPTION 1: Authenticate using OAuth (recommended)**
+**Option 1: Authenticate using OAuth (recommended)**
 
 Use the following CLI command:
 
@@ -76,7 +76,7 @@ Use the following CLI command:
 claude mcp add --transport http n8n https://<your-n8n-domain>/mcp-server/http
 ```
 
-Alternatively, add the following entry to your `claude.json` file:
+Or add the following entry to your `claude.json` file:
 
 ```json
 {
@@ -95,7 +95,7 @@ Here, replace:
 
 Run `/mcp` in Claude Code and select **n8n** to complete the OAuth authorization.
 
-**OPTION 2: Authenticate using API key**
+**Option 2: Authenticate using API key**
 
 Use the following CLI command:
 
@@ -104,7 +104,7 @@ claude mcp add --transport http n8n-mcp https://<your-n8n-domain>/mcp-server/htt
   --header "Authorization: Bearer <YOUR_N8N_MCP_TOKEN>"
 ```
 
-Alternatively, add the following entry to your `claude.json` file:
+Or add the following entry to your `claude.json` file:
 
 ```json
 {
@@ -127,7 +127,7 @@ Here, replace:
 
 ## Connecting Codex CLI to n8n MCP server <a href="#connecting-codex-cli-to-n8n-mcp-server" id="connecting-codex-cli-to-n8n-mcp-server"></a>
 
-**OPTION 1: Authenticate using OAuth (recommended)**
+**Option 1: Authenticate using OAuth (recommended)**
 
 Use the following CLI command:
 
@@ -135,7 +135,7 @@ Use the following CLI command:
 codex mcp add n8n --url "https://<your-n8n-domain>/mcp-server/http"
 ```
 
-Alternatively, add the following entry to your `~/.codex/config.toml` file:
+Or add the following entry to your `~/.codex/config.toml` file:
 
 ```toml
 [features]
@@ -155,7 +155,7 @@ Here, replace:
 
 Run `codex mcp login n8n` to complete the OAuth authorization.
 
-**OPTION 2: Authenticate using API key**
+**Option 2: Authenticate using API key**
 
 Add the following entry to your `~/.codex/config.toml` file:
 
@@ -181,7 +181,7 @@ Use the following CLI command:
 gemini mcp add --transport http n8n https://<your-n8n-domain>/mcp-server/http
 ```
 
-Alternatively, add the following entry to your `~/.gemini/settings.json` file:
+Or add the following entry to your `~/.gemini/settings.json` file:
 
 ```json
 {
@@ -203,7 +203,7 @@ Run `/mcp` in Gemini CLI and select **n8n** to complete the OAuth authorization.
 
 In the **Connect a client** dialog, select **Cursor** from **Your client**, then select **One-click setup** to open Cursor and add the n8n server automatically. Approve access when Cursor redirects you back to n8n.
 
-Alternatively, add the following entry to your `~/.cursor/mcp.json` file (or the project's `.cursor/mcp.json`):
+Or add the following entry to your `~/.cursor/mcp.json` file (or the project's `.cursor/mcp.json`):
 
 ```json
 {
@@ -224,7 +224,7 @@ Here, replace:
 
 In the **Connect a client** dialog, select **VS Code** from **Your client**, then select **One-click setup** to open VS Code and add the n8n server automatically. Approve access when VS Code redirects you back to n8n.
 
-Alternatively, add the following entry to your workspace's `.vscode/mcp.json` file:
+Or add the following entry to your workspace's `.vscode/mcp.json` file:
 
 ```json
 {

--- a/docs/connect/create-nodes/README.md
+++ b/docs/connect/create-nodes/README.md
@@ -1,4 +1,5 @@
 ---
+description: Plan, build, test, and deploy a custom n8n node.
 layout:
   description:
     visible: false
@@ -24,3 +25,5 @@ layout:
 {% content-ref url="deploy-your-node/README.md" %}
 [deploy-your-node/README.md](deploy-your-node/README.md)
 {% endcontent-ref %}
+
+See [Connect](../README.md) for other ways to connect to n8n.

--- a/docs/connect/n8n-api/README.md
+++ b/docs/connect/n8n-api/README.md
@@ -1,9 +1,8 @@
 ---
-title: n8n public REST API Documentation and Guides
+title: n8n API
 description: >-
-  Access n8n public REST API documentation and guides. Find comprehensive
-  resources to programmatically perform tasks with the public API instead of the
-  GUI.
+  Use n8n's public REST API to perform tasks programmatically instead of
+  through the GUI.
 contentType: overview
 search:
   boost: 5
@@ -19,7 +18,7 @@ layout:
     visible: false
 ---
 
-# n8n public REST API <a href="#n8n-public-rest-api" id="n8n-public-rest-api"></a>
+# n8n API <a href="#n8n-public-rest-api" id="n8n-public-rest-api"></a>
 
 {% hint style="info" %}
 **Feature availability**
@@ -27,7 +26,7 @@ layout:
 The n8n API isn't available during the free trial. Please upgrade to access this feature.
 {% endhint %}
 
-Using n8n's public API[^1], you can programmatically perform many of the same tasks as you can in the GUI. This section introduces n8n's REST API, including:
+Using n8n's public API[^1], you can programmatically perform most of the same tasks as you can in the GUI. This section introduces n8n's REST API, including:
 
 * How to [authenticate](authentication.md)
 * [Paginating](pagination.md) results
@@ -38,18 +37,18 @@ n8n provides an [n8n API node](https://app.gitbook.com/s/BKcbOzIWja8NfqKDcqHc/bu
 
 ## Choose your interaction method <a href="#choose-your-interaction-method" id="choose-your-interaction-method"></a>
 
-### REST API (This section) <a href="#rest-api-this-section" id="rest-api-this-section"></a>
+### REST API (this section) <a href="#rest-api-this-section" id="rest-api-this-section"></a>
 Interact with n8n directly using HTTP requests. Ideal for:
-- Custom integrations and applications
-- Language-agnostic HTTP calls
-- Direct REST API usage in workflows
+* Custom integrations and applications
+* Language-agnostic HTTP calls
+* Direct REST API usage in workflows
 
-### n8n CLI (Recommended for developers) <a href="#n8n-cli-recommended-for-developers" id="n8n-cli-recommended-for-developers"></a>
-Use [n8n CLI](../README.md) for a command-line experience. It wraps the public API and is optimized for:
-- Command-line automation and scripting
-- CI/CD pipeline integration
-- AI agent integration (Claude Code, Cursor, etc.)
-- Developers who prefer CLI tools
+### n8n CLI (recommended for developers) <a href="#n8n-cli-recommended-for-developers" id="n8n-cli-recommended-for-developers"></a>
+Use [n8n CLI](../n8n-cli.md) for a command-line experience. It wraps the public API and is a good fit for:
+* Command-line automation and scripting
+* CI/CD pipeline integration
+* AI agent integration (Claude Code, Cursor, etc.)
+* Developers who prefer CLI tools
 
 ## Learn about REST APIs <a href="#learn-about-rest-apis" id="learn-about-rest-apis"></a>
 
@@ -63,7 +62,7 @@ The API documentation assumes you are familiar with REST APIs. If you're not, th
 {% hint style="info" %}
 **Use the API playground**
 
-Trying out the API in the [playground](use-an-api-playground.md) can help you understand how APIs work. If you're worried about changing live data, consider setting up a test workflow, or test n8n instance, to explore safely.
+Trying out the API in the [playground](use-an-api-playground.md) can help you understand how APIs work. If you're worried about changing live data, consider setting up a test workflow, or test n8n instance, to explore.
 {% endhint %}
 
 [^1]: APIs, or application programming interfaces, offer programmatic access to a service's data and functionality. APIs make it easier for software to interact with external systems. They're often offered as an alternative to traditional user-focused interfaces accessed through web browsers or UI.

--- a/docs/connect/n8n-api/README.md
+++ b/docs/connect/n8n-api/README.md
@@ -1,5 +1,5 @@
 ---
-title: n8n API
+title: n8n public REST API Documentation and Guides
 description: >-
   Use n8n's public REST API to perform tasks programmatically instead of
   through the GUI.
@@ -18,7 +18,7 @@ layout:
     visible: false
 ---
 
-# n8n API <a href="#n8n-public-rest-api" id="n8n-public-rest-api"></a>
+# n8n public REST API <a href="#n8n-public-rest-api" id="n8n-public-rest-api"></a>
 
 {% hint style="info" %}
 **Feature availability**
@@ -26,7 +26,7 @@ layout:
 The n8n API isn't available during the free trial. Please upgrade to access this feature.
 {% endhint %}
 
-Using n8n's public API[^1], you can programmatically perform most of the same tasks as you can in the GUI. This section introduces n8n's REST API, including:
+Using n8n's public API[^1], you can programmatically perform many of the same tasks as you can in the GUI. This section introduces n8n's REST API, including:
 
 * How to [authenticate](authentication.md)
 * [Paginating](pagination.md) results
@@ -62,7 +62,7 @@ The API documentation assumes you are familiar with REST APIs. If you're not, th
 {% hint style="info" %}
 **Use the API playground**
 
-Trying out the API in the [playground](use-an-api-playground.md) can help you understand how APIs work. If you're worried about changing live data, consider setting up a test workflow, or test n8n instance, to explore.
+Trying out the API in the [playground](use-an-api-playground.md) can help you understand how APIs work. If you're worried about changing live data, consider setting up a test workflow, or test n8n instance, to explore safely.
 {% endhint %}
 
 [^1]: APIs, or application programming interfaces, offer programmatic access to a service's data and functionality. APIs make it easier for software to interact with external systems. They're often offered as an alternative to traditional user-focused interfaces accessed through web browsers or UI.


### PR DESCRIPTION
## Summary

Third branch of the top-50 (now top-58) style/terminology rollout, covering the `connect`, `build`, and `administer` spaces — the "Branch A" grouping (workflow-building, connecting, and administering n8n; deliberately separated from the node/credential reference content in `integrations`, which follows different templates). Depends on #5289 and #5293 for the underlying Vale rule changes (already merged).

14 of 15 pages in scope are complete. `mcp-server-tools-reference.md` is explicitly deferred — see below.

## Content changes

Per-page Vale fixes (terminology, contractions, passive voice, wordiness, weasel words) plus the manual pass against style-guide items Vale can't check (terminology not in the word list, frontmatter, cross-linking, title consistency, page structure)

## Test plan

- [x] `vale` on all 14 completed pages — 0 errors/warnings aside from documented deliberate exceptions (real technical-term spelling false positives, checklist-style declarative assertions, literal UI-label text, standard adjectives like "read-only" that trip regex-based passive-voice detection)
- [x] Manual checklist pass on every completed page: terminology not in Vale's word list, frontmatter, cross-linking, title consistency, page structure
- [x] CI (Vale, Lexi, internal-links, lychee) on this PR
