### PR TITLE
fix(build): variables and workflow sharing are on self-hosted Business too

### DIFF
--- a/docs/build/code-in-n8n/cookbook/built-in-methods-and-variables-examples/vars.md
+++ b/docs/build/code-in-n8n/cookbook/built-in-methods-and-variables-examples/vars.md
@@ -19,7 +19,7 @@ layout:
 `vars` is available on:
 
 - **n8n Cloud:** Pro, Enterprise
-- **Self-hosted:** Enterprise
+- **Self-hosted:** Business, Enterprise
 
 You need access to the n8n instance owner account to create variables.
 {% endhint %}

--- a/docs/build/code-in-n8n/define-custom-variables.md
+++ b/docs/build/code-in-n8n/define-custom-variables.md
@@ -19,7 +19,7 @@ layout:
 Custom variables are available on:
 
 - **n8n Cloud:** Pro, Enterprise
-- **Self-hosted:** Enterprise
+- **Self-hosted:** Business, Enterprise
 
 Only instance owners and admins can create variables.
 {% endhint %}

--- a/docs/build/manage-workflows/share-with-others.md
+++ b/docs/build/manage-workflows/share-with-others.md
@@ -18,7 +18,7 @@ layout:
 Workflow sharing is available on:
 
 - **n8n Cloud:** All plans
-- **Self-hosted:** Enterprise
+- **Self-hosted:** Business, Enterprise
 {% endhint %}
 
 Workflow sharing allows you to share workflows between users of the same n8n instance.


### PR DESCRIPTION
Part of DOC-2257. First batch from the plan-availability audit.

## Problem

Three pages say these features are self-hosted **Enterprise** only. The licence config grants them to **Business** as well:

| Page | Flag | Business | Enterprise |
|---|---|---|---|
| `vars.md` | `feat:variables` | Yes | Yes |
| `define-custom-variables.md` | `feat:variables` | Yes | Yes |
| `share-with-others.md` | `feat:sharing` | Yes | Yes |

Source is `license-management-setup/entities/product/production_business.yml`, read via the auto-generated [License Feature Matrix](https://app.notion.com/p/2855b6e0c94f804c991df2da03c200f6).

This is the same failure as DOC-2255 (external storage): the pages predate the self-hosted Business plan and were never revisited. A Business customer reading these is told to upgrade for something they already have.

## Changes

Only the `Self-hosted:` bullet, `Enterprise` becomes `Business, Enterprise`. The `n8n Cloud:` bullets were already correct and are untouched, as is all surrounding prose.

## How this was found

DOC-2257 has a checker that extracts every `Feature availability` hint and joins it against the per-plan licence flags. It found 7 mismatches across the docs; these are the 3 with no open questions. The rest need either an SME answer on the flag mapping or a decision about quota-gated features, so they're in later batches.

## Checks

Vale is clean on every changed line. I confirmed there's no inline prose elsewhere making the same claim for these features — `community-edition-features.md` and `choose-how-to-use-n8n.md` only list them as "not in Community", which stays true.