### PR TITLE
fix(docs): correct plan availability for workflow diffs and named versions

### DIFF
--- a/docs/administer/use-source-control-and-environments/compare-versions.md
+++ b/docs/administer/use-source-control-and-environments/compare-versions.md
@@ -22,7 +22,7 @@ Workflow diffs allow you to visually compare changes between the workflow you ha
 Workflow diffs are available on:
 
 - **n8n Cloud:** Enterprise
-- **Self-hosted:** Enterprise
+- **Self-hosted:** Business, Enterprise
 
 Workflow diffs are only available when you [enable the environments features](set-up-source-control.md) on an instance.
 {% endhint %}

--- a/docs/build/manage-workflows/view-change-history.md
+++ b/docs/build/manage-workflows/view-change-history.md
@@ -78,4 +78,4 @@ You can restore a previous workflow version, or make a copy of it:
    * **Clone to new workflow**: create a new workflow based on the selected version.
    * **Open version in new tab**: open a second tab displaying the selected version. Use this to compare versions.
    * **Download**: download the version as JSON.
-   * **Name version**: give the version a name and description. n8n never prunes named versions automatically. Refer to [Naming versions](../understand-workflows/save-and-publish-workflows.md#naming-versions) for more details. Named versions are available on n8n Cloud Enterprise, and self-hosted Business and Enterprise.
+   * **Name version**: give the version a name and description. n8n never prunes named versions automatically. Refer to [Naming versions](../understand-workflows/save-and-publish-workflows.md#naming-versions) for more details. Named versions are available on n8n Cloud Pro and Enterprise, and self-hosted Business and Enterprise.

--- a/docs/build/manage-workflows/view-change-history.md
+++ b/docs/build/manage-workflows/view-change-history.md
@@ -78,4 +78,4 @@ You can restore a previous workflow version, or make a copy of it:
    * **Clone to new workflow**: create a new workflow based on the selected version.
    * **Open version in new tab**: open a second tab displaying the selected version. Use this to compare versions.
    * **Download**: download the version as JSON.
-   * **Name version**: give the version a name and description. Named versions are protected from automatic pruning. Refer to [Naming versions](../understand-workflows/save-and-publish-workflows.md#naming-versions) for more details. Named versions are available on n8n Cloud Pro, Enterprise, and self-hosted Enterprise.
+   * **Name version**: give the version a name and description. n8n never prunes named versions automatically. Refer to [Naming versions](../understand-workflows/save-and-publish-workflows.md#naming-versions) for more details. Named versions are available on n8n Cloud Enterprise, and self-hosted Business and Enterprise.

--- a/docs/build/understand-workflows/save-and-publish-workflows.md
+++ b/docs/build/understand-workflows/save-and-publish-workflows.md
@@ -106,7 +106,7 @@ If workflow reviews are enabled for your instance, you can submit a version for 
 
 Named versions are available on:
 
-- **n8n Cloud:** Enterprise
+- **n8n Cloud:** Pro, Enterprise
 - **Self-hosted:** Business, Enterprise
 {% endhint %}
 

--- a/docs/build/understand-workflows/save-and-publish-workflows.md
+++ b/docs/build/understand-workflows/save-and-publish-workflows.md
@@ -106,8 +106,8 @@ If workflow reviews are enabled for your instance, you can submit a version for 
 
 Named versions are available on:
 
-- **n8n Cloud:** Pro, Enterprise
-- **Self-hosted:** Enterprise
+- **n8n Cloud:** Enterprise
+- **Self-hosted:** Business, Enterprise
 {% endhint %}
 
 Named versions let you give a meaningful name and description to any workflow version. This helps you identify important milestones in your workflow's development. Named versions are also protected from automatic [version history pruning](../manage-workflows/view-change-history.md), so they persist indefinitely.


### PR DESCRIPTION
Part of DOC-2257. Second batch from the plan-availability audit. **Purely additive — this PR adds self-hosted Business in three places and removes nothing.**

## Workflow diffs — add self-hosted Business

`compare-versions.md` said self-hosted Enterprise only. LIGO-988 enabled `feat:workflowDiffs` for Business on 14 Aug (`license-management-setup#250`), and that ticket's own scope said to "check that the plan comparison and pricing material list the feature under Business so the entitlement and the public messaging agree". Nobody updated the docs.

**Cloud stays Enterprise only, and this is now verified.** My first audit run said this page also omitted Cloud Pro, because I'd mapped it to `feat:workflowDiffs` alone. Wrong: this page documents diffs in *source control push/pull*, which its own hint says need environments enabled. That needs `feat:workflowDiffs` **and** `feat:sourceControl`. A live Cloud Pro instance returns `sourceControl: false`, confirming Pro can't use these. Version-history diffs are a separate experience — LIGO-988 explicitly out-of-scoped source control diffs.

## Named versions — add self-hosted Business only

`save-and-publish-workflows.md` and an inline sentence on `view-change-history.md` both said self-hosted Enterprise. `feat:namedVersions` is granted to Business, so both now say Business, Enterprise.

**I nearly removed Cloud Pro here and it would have been wrong.** `cloud_pro.yml` has `feat:namedVersions: false`, so the audit flagged the docs as over-claiming. Before changing it we checked a real Cloud Pro instance (`planName: "Pro 1"`, n8n 2.35.4) via `/rest/settings`:

```
"namedVersions": true
```

The docs were right and the yaml is wrong. Every *other* flag on that instance matched `cloud_pro.yml` exactly — `sourceControl`, `binaryDataS3`, `externalSecrets`, `logStreaming`, `customRoles`, `dataRedaction`, `workflowReviews`, `projects.team.limit: 3` — so this is a genuine one-off divergence, not a stale snapshot. Cloud Pro stays in the docs.

Worth raising separately with Lifecycle & Governance: either `cloud_pro.yml` is missing the entitlement, or an instance-level override is granting it. Recorded in the audit's `flag-map.json` so nobody "fixes" the docs from the yaml before that's answered.

## Also

Reworded "Named versions are protected from automatic pruning" to "n8n never prunes named versions automatically", on the same line I was already editing. The passive-voice warning pre-existed on `main`, but Vale's reviewdog filter only reports changed lines, so touching the line would have failed the check.

Vale is clean on every changed line.