### PR TITLE
docs: remove stale OAuth2 mention from MCP servers page description

### DIFF
--- a/docs/build/integrate-ai/mcp-servers.md
+++ b/docs/build/integrate-ai/mcp-servers.md
@@ -1,7 +1,5 @@
 ---
-description: >-
-  Connect an AI agent to an MCP registry server directly from the node panel,
-  with OAuth2 sign-in and no manual credential setup.
+description: Connect an AI agent to an MCP registry server in one click.
 layout:
   description:
     visible: false


### PR DESCRIPTION
The page description still says "with OAuth2 sign-in and no manual credential setup". We removed that phrasing from the body in #5271 but the frontmatter was never updated.

It's currently live in Google snippets and Slack unfurls. Spotted via a link preview in Slack.

Single line edit , no visible change to the page.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

