### PR TITLE
ci: Update cla-check and opt out of labeling

### DIFF
--- a/.github/workflows/ci-cla-check.yml
+++ b/.github/workflows/ci-cla-check.yml
@@ -65,8 +65,9 @@ jobs:
     steps:
       # Defaults for the CLA endpoints, status context, comment marker and label
       # are already n8n's production values.
-      - uses: n8n-io/github-actions/cla-check@931777df53ace1bdb31d2bf5c63c9f2d27451c35 # cla-check/v1.0.0
+      - uses: n8n-io/github-actions/cla-check@ac16f4c5d147eaa226b9b5fd0effb137007d1bf1 # v1.0.1
         with:
           app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
           private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+          apply-label: false
 


### PR DESCRIPTION
# Summary

Updates the cla-check job to 1.0.1, which introduces opting out of cla-check labels and opts out of them.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

