### PR TITLE
docs: Add the Microsoft Teams channel message get and reply operations

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftteams.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftteams.md
@@ -50,7 +50,9 @@ If you're using a government cloud tenant (US Government, US Government DOD, or 
     * Update
 * Channel Message
     * Create
+    * Get
     * Get Many
+    * Reply
 * Chat Message
 	* Create
 	* Get
@@ -62,6 +64,12 @@ If you're using a government cloud tenant (US Government, US Government DOD, or 
     * Get
     * Get Many
     * Update
+
+{% hint style="info" %}
+**Channel messages with Service Principal credentials**
+
+The **Create** and **Reply** operations for channel messages are not available with the Microsoft Entra Service Principal credentials. App-only Microsoft Graph supports only migration import for channel messages. Use an OAuth2 credential to send channel messages.
+{% endhint %}
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/c0Jp2CWNEFSR2IfIVdlL/" %}
 

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftteams.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftteams.md
@@ -71,7 +71,7 @@ If you're using a government cloud tenant (US Government, US Government DOD, or 
 
 The **Create** and **Reply** operations for channel messages are not available with the Microsoft Entra Service Principal credentials. App-only Microsoft Graph supports only migration import for channel messages. Use an OAuth2 credential to send channel messages.
 
-The read operations stay available with the Service Principal credentials: **Get**, **Get Many** and **Get Many Replies**.
+The read operations stay available with the Service Principal credentials: **Get**, **Get Many**, and **Get Many Replies**.
 {% endhint %}
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/c0Jp2CWNEFSR2IfIVdlL/" %}

--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftteams.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftteams.md
@@ -52,6 +52,7 @@ If you're using a government cloud tenant (US Government, US Government DOD, or 
     * Create
     * Get
     * Get Many
+    * Get Many Replies
     * Reply
 * Chat Message
 	* Create
@@ -69,6 +70,8 @@ If you're using a government cloud tenant (US Government, US Government DOD, or 
 **Channel messages with Service Principal credentials**
 
 The **Create** and **Reply** operations for channel messages are not available with the Microsoft Entra Service Principal credentials. App-only Microsoft Graph supports only migration import for channel messages. Use an OAuth2 credential to send channel messages.
+
+The read operations stay available with the Service Principal credentials: **Get**, **Get Many** and **Get Many Replies**.
 {% endhint %}
 
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/c0Jp2CWNEFSR2IfIVdlL/" %}


### PR DESCRIPTION
## Summary

The Microsoft Teams node adds two operations to the Channel Message resource:

- **Get**: fetch one channel message by ID.
- **Reply**: post a reply into an existing message thread.

This PR lists the two operations on the node page. It also adds a note that the Create and Reply operations do not work with the Microsoft Entra Service Principal credentials. App-only Microsoft Graph supports only migration import for channel messages. The node shows the same note in the editor.

## Related

Code PR: https://github.com/n8n-io/n8n/pull/37542
Linear: https://linear.app/n8n/issue/ENT-321

Merge this after the code PR ships.

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

