### PR TITLE
docs(core): Document scheduled job owner reconciliation

### DIFF
--- a/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/scheduler.md
+++ b/docs/deploy/host-n8n/configure-n8n/basic-configuration/use-environment-variables/scheduler.md
@@ -93,6 +93,25 @@ Controls how long the scheduler keeps finished runs as history and how often it 
 | `N8N_SCHEDULER_RETENTION_INTERVAL` | Number | `3600` | How often, in seconds, the scheduler deletes finished runs older than the retention windows. Defaults to one hour. Must be greater than 0. |
 | `N8N_SCHEDULER_RETENTION_TIMEOUT` | Number | `300` | How long, in seconds, a single cleanup pass may run before it's abandoned and retried on the next interval. Defaults to five minutes. Must be greater than 0. |
 
+## Owner reconciliation
+
+Controls the sweep that retires schedules whose owner no longer exists, such as a workflow that's no longer published. The sweep stops them right away and deletes them after a grace period. See [How the durable scheduler works](../../durable-scheduler.md#how-it-works).
+
+{% hint style="info" %}
+**Feature availability**
+
+Owner reconciliation is available from n8n 2.39.0.
+{% endhint %}
+
+| Variable | Type | Default | Description |
+| :------- | :--- | :------ | :---------- |
+| `N8N_SCHEDULER_OWNER_RECONCILIATION_ENABLED` | Boolean | `true` | Whether the scheduler periodically checks that every schedule's owner still exists and retires the schedules whose owner is missing. Turning it off leaves those schedules in place. |
+| `N8N_SCHEDULER_OWNER_RECONCILIATION_INTERVAL` | Number | `900` | How often, in seconds, the sweep runs. Defaults to 15 minutes. It's a safety net rather than the usual cleanup path, so a long interval is fine. Must be greater than 0. |
+| `N8N_SCHEDULER_OWNER_RECONCILIATION_TIMEOUT` | Number | `300` | How long, in seconds, a single sweep may run before it's abandoned and retried on the next interval. Defaults to five minutes. Must be greater than 0. |
+| `N8N_SCHEDULER_OWNER_RECONCILIATION_BATCH_SIZE` | Number | `500` | How many owners the sweep checks per database query. Larger batches finish a sweep in fewer queries; smaller ones keep each query light. Must be between 1 and 1000. |
+| `N8N_SCHEDULER_OWNER_QUARANTINE_GRACE` | Number | `86400` | How long, in seconds, the sweep keeps a stopped schedule before deleting it. Defaults to one day. The schedule stops firing as soon as the sweep finds it, so this only delays the delete. Must be greater than 0. |
+| `N8N_SCHEDULER_OWNER_SETTLE_PERIOD` | Number | `300` | How old, in seconds, a schedule must be before the sweep considers it. Defaults to five minutes. n8n can write a schedule a moment before its owner, so this stops the sweep from mistaking a brand-new schedule for an abandoned one. Must be greater than 0. |
+
 ## Coordination across instances <a href="#coordination-vars" id="coordination-vars"></a>
 
 Controls how the scheduler overlaps its background passes and spreads database load across instances.

--- a/docs/deploy/host-n8n/configure-n8n/durable-scheduler.md
+++ b/docs/deploy/host-n8n/configure-n8n/durable-scheduler.md
@@ -57,14 +57,15 @@ These terms make the environment variables easier to reason about:
 - **Schedule**: a recurring rule, such as a Schedule Trigger node's "every 15 minutes" setting. The scheduler stores each schedule in the database.
 - **Run**: a single firing of a schedule at a specific time. The scheduler records upcoming runs ahead of time as individual rows.
 
-The scheduler moves each run through four stages, and each stage has its own [environment variables](basic-configuration/use-environment-variables/scheduler.md):
+The scheduler runs five stages, and each stage has its own [environment variables](basic-configuration/use-environment-variables/scheduler.md):
 
 1. **Materialization.** The scheduler scans your active schedules and records the runs coming up soon (within the *materialization window*). This commits runs to the database before they're due. If a run is already past its [misfire grace](#misfire-policy) when materialization catches it, the schedule's misfire policy handles it instead of the scheduler recording it as-is.
 2. **Execution.** The scheduler claims each recorded run up to one check interval before its time, so no other instance takes it, and starts the workflow at the scheduled instant.
 3. **Recovery.** If an instance claims a run but stops before finishing (for example after a crash), the *reaper* releases the run so another instance can pick it up.
 4. **Retention.** The scheduler keeps finished runs for a while as recent history, then deletes them to keep its tables small.
+5. **Owner reconciliation.** Every schedule has an owner, such as the workflow that created it. The scheduler periodically checks that each owner still exists and retires the schedules whose owner no longer exists. See the [owner reconciliation environment variables](basic-configuration/use-environment-variables/scheduler.md#owner-reconciliation).
 
-Across multiple instances, every main runs all four stages. Claiming keeps this safe: because only one instance claims each run, running the loops everywhere shares the load rather than duplicating work.
+Across multiple instances, every main runs all five stages. Claiming keeps this safe: because only one instance claims each run, running the loops everywhere shares the load rather than duplicating work.
 
 ## Misfire policy <a href="#misfire-policy" id="misfire-policy"></a>
 
@@ -171,7 +172,7 @@ Counters and the histogram record each main's own work, so sum them across your 
 
 ### Background passes
 
-These counters cover the [four stages](#how-it-works) that keep the queue moving. They're most useful when a stage stops doing its job.
+These counters cover the [five stages](#how-it-works) that keep the queue moving. They're most useful when a stage stops doing its job.
 
 | Metric | Type | What it tells you |
 | :----- | :--- | :---------------- |
@@ -181,6 +182,9 @@ These counters cover the [four stages](#how-it-works) that keep the queue moving
 | `n8n_scheduler_occurrences_retired_total` | Counter | How many recorded runs the scheduler dropped because a catch-up run superseded them. |
 | `n8n_scheduler_occurrences_missed_total` | Counter | How many recorded runs went past their deadline unclaimed and the reaper marked missed. |
 | `n8n_scheduler_tasks_pruned_total` | Counter | How many finished runs retention deleted. If it never rises, the scheduler tables keep growing. |
+| `n8n_scheduler_jobs_quarantined_total` | Counter | How many schedules owner reconciliation stopped because their owner no longer exists. Available from n8n 2.39.0. |
+| `n8n_scheduler_orphaned_jobs_deleted_total` | Counter | How many stopped schedules owner reconciliation deleted after their owner stayed missing past the quarantine grace. Available from n8n 2.39.0. |
+| `n8n_scheduler_jobs_revived_total` | Counter | How many stopped schedules owner reconciliation resumed because their owner turned out to exist after all. Available from n8n 2.39.0. |
 
 ### Poll trigger metrics
 


### PR DESCRIPTION
## Summary

Documents the owner reconciliation sweep shipped by the CAT-4226 stack.

- `durable-scheduler.md`: 
   - owner reconciliation as the fifth stage
   - the three new counters (`n8n_scheduler_jobs_quarantined_total`, `n8n_scheduler_orphaned_jobs_deleted_total`, `n8n_scheduler_jobs_revived_total`)
- `use-environment-variables/scheduler.md`: new "Owner reconciliation" table

## Related

- Linear: https://linear.app/n8n/issue/CAT-4350 (point 4)
- Source: https://github.com/n8n-io/n8n/pull/37685

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

