### PR TITLE
Document grant type selection for Zendesk OAuth2 credentials

### DIFF
--- a/docs/integrations/builtin/credentials/zendesk.md
+++ b/docs/integrations/builtin/credentials/zendesk.md
@@ -48,6 +48,10 @@ To configure this credential, you'll need:
 
 To configure this credential, you'll need:
 
+- A **Grant Type**: Select the OAuth2 flow that matches your OAuth client's kind:
+  - **Authorization Code**: The default flow. Use it for OAuth clients marked as **Confidential**.
+  - **Client Credentials**: Authenticates without a user sign-in. Zendesk supports this flow for OAuth clients marked as **Confidential** only.
+  - **PKCE**: The authorization code flow with Proof Key for Code Exchange. Zendesk requires PKCE for OAuth clients marked as **Public**.
 - A **Client ID**: Generated when you create a new OAuth client.
 - A **Client Secret**: Generated when you create a new OAuth client.
 - Your **Subdomain**: Your Zendesk subdomain is the portion of the URL between `https://` and `.zendesk.com`. For example, if the Zendesk URL is `https://n8n-example.zendesk.com/agent/dashboard`, the subdomain is `n8n-example`.


### PR DESCRIPTION
## Summary

n8n-io/n8n#37736 makes the grant type selectable in the Zendesk OAuth2 credential. Users can select Authorization Code, Client Credentials, or PKCE.

This change documents the new **Grant Type** field on the Zendesk credentials page. It explains which flow matches each Zendesk OAuth client kind: Zendesk requires PKCE for clients marked as **Public**, and supports the client credentials flow for clients marked as **Confidential** only.

This PR should merge together with n8n-io/n8n#37736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

