### PR TITLE
docs: update graphql node docs to add support for predefined credentials

### DIFF
--- a/docs/integrations/builtin/core-nodes/n8n-nodes-base.graphql.md
+++ b/docs/integrations/builtin/core-nodes/n8n-nodes-base.graphql.md
@@ -26,9 +26,11 @@ layout:
 
 ### Authentication <a href="#authentication" id="authentication"></a>
 
-Select the type of authentication to use.
+Select the type of authentication to use. n8n recommends using **Predefined Credential Type** when it's available for the service you want to connect to. It offers an easier way to set up and manage credentials, compared to configuring generic credentials manually.
 
-If you select anything other than **None**, the **Credential for <selected-auth-type>** parameter appears for you to select an existing or create a new authentication credential for that authentication type.
+If you select **Predefined Credential Type**, a **Credential Type** parameter appears. Select the app or service you want to use, then select an existing credential for it or create a new one. Refer to [Custom API operations](../custom-api-actions-for-existing-nodes.md) for more information.
+
+If you select any other authentication method except **None**, a **Credential for <selected-auth-type>** parameter appears for you to select an existing or create a new authentication credential for that authentication type.
 
 ### HTTP Request Method <a href="#http-request-method" id="http-request-method"></a>
 

--- a/docs/integrations/builtin/custom-api-actions-for-existing-nodes.md
+++ b/docs/integrations/builtin/custom-api-actions-for-existing-nodes.md
@@ -15,7 +15,7 @@ layout:
 
 ## Predefined credential types <a href="#predefined-credential-types" id="predefined-credential-types"></a>
 
-A predefined credential type is a credential that already exists in n8n. You can use predefined credential types instead of generic credentials in the HTTP Request node.
+A predefined credential type is a credential that already exists in n8n. You can use predefined credential types instead of generic credentials in the HTTP Request and GraphQL nodes.
 
 For example: you create an Asana credential, for use with the Asana node. Later, you want to perform an operation that isn't supported by the Asana node, using Asana's API. You can use your existing Asana credential in the HTTP Request node to perform the operation, without additional authentication setup.
 

--- a/docs/reusable-content/.gitbook/includes/integrations/predefined-credential-type-how-to.md
+++ b/docs/reusable-content/.gitbook/includes/integrations/predefined-credential-type-how-to.md
@@ -3,7 +3,7 @@ title: predefined-credential-type-how-to
 ---
 To use a predefined credential type:
 
-1. Open your HTTP Request node, or add a new one to your workflow.
+1. Open your HTTP Request or GraphQL node, or add a new one to your workflow.
 2. In **Authentication**, select **Predefined Credential Type**.
 3. In **Credential Type**, select the API you want to use. 
 4. In **Credential for `<API name>`**, you can:


### PR DESCRIPTION
This PR updates the documentation to reflect the addition of predenfined credentials for the graphQL node that was implemented as part of this [PR](https://github.com/n8n-io/n8n/pull/37671). 