### PR TITLE
docs: Add tunnel setup video to n8n with tunnel section

### DIFF
--- a/docs/reusable-content/.gitbook/includes/self-hosting/installation/tunnel.md
+++ b/docs/reusable-content/.gitbook/includes/self-hosting/installation/tunnel.md
@@ -13,6 +13,10 @@ Use this for local development and testing. It isn't safe to use it in productio
 The tunnel feature is a convenience tool for local development. The underlying implementation may change between n8n versions.
 {% endhint %}
 
+Watch a video guide to setting up the tunnel using Cloudflare or ngrok:
+
+{% embed url="https://www.youtube.com/embed/O9dpO81dEQ0" %}
+
 To use webhooks for trigger nodes of external services like GitHub, n8n has to be reachable from the web. n8n provides a tunnel service using [cloudflared](https://github.com/cloudflare/cloudflared) that redirects requests from the web to your local n8n instance. Docker must be installed for the tunnel to work.
 
 There are two ways to use the tunnel, depending on how you run n8n:


### PR DESCRIPTION
## Summary

Embeds a tutorial video by @digitalchild in the "n8n with tunnel" section, beneath the warning callouts and above the intro text. Uses the same embed pattern as the video on the credential overwrites page (#5189).

The section lives in the shared `tunnel.md` reusable include, so the video shows up in both the Docker and npm installation pages.

---
AI assisted with this PR