### PR TITLE
docs: Document API key authentication for Metabase credentials

### DIFF
--- a/docs/integrations/builtin/credentials/metabase.md
+++ b/docs/integrations/builtin/credentials/metabase.md
@@ -23,11 +23,13 @@ You can use these credentials to authenticate the following nodes:
 
 ## Prerequisites <a href="#prerequisites" id="prerequisites"></a>
 
-Create a [Metabase](https://www.metabase.com/) account with access to a Metabase instance.
+- Create a [Metabase](https://www.metabase.com/) account with access to a Metabase instance.
+- For API key authentication, a Metabase admin must create an API key in **Admin settings > Settings > Authentication > API keys > Manage**. Refer to [Metabase API keys](https://www.metabase.com/docs/latest/people-and-groups/api-keys) for more information.
 
 ## Supported authentication methods <a href="#supported-authentication-methods" id="supported-authentication-methods"></a>
 
 - Basic auth
+- API key: Use this method if your Metabase instance uses SSO, or if you don't want to store a user password in n8n.
 
 ## Related resources <a href="#related-resources" id="related-resources"></a>
 
@@ -40,3 +42,10 @@ To configure this credential, you'll need:
 - A **URL**: Enter the base URL of your Metabase instance. If you're using a custom domain, use that URL.
 - A **Username**: Enter your Metabase username.
 - A **Password**: Enter your Metabase password.
+
+## Using API key <a href="#using-api-key" id="using-api-key"></a>
+
+To configure this credential, you'll need:
+
+- A **URL**: Enter the base URL of your Metabase instance. If you're using a custom domain, use that URL.
+- An **API Key**: Enter a Metabase API key. To create one, go to **Admin settings > Settings > Authentication > API keys > Manage** and select **Create API Key**. Enter a name and select a **Group** for the key. The key gets the permissions of that group. Copy the key when Metabase displays it, as Metabase can't show it again.


### PR DESCRIPTION
## Summary

Documents the new **API key** authentication method for the Metabase credentials page, added in n8n-io/n8n#37931.

Changes to `docs/integrations/builtin/credentials/metabase.md`:

- Add API key to the supported authentication methods, with a note on when to use it (SSO, or to avoid storing a user password in n8n).
- Add a prerequisite for creating the key in Metabase, with a link to the Metabase API keys docs.
- Add a **Using API key** section with the fields (URL, API Key) and the steps to create a key in Metabase, following the structure of the Zammad and Odoo credential pages.

Depends on n8n-io/n8n#37931 being merged. Please hold review until then.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

