### PR TITLE
fix(docops): post GitBook preview links on fork PRs (DOC-2284)

### DIFF
--- a/.github/workflows/gitbook-preview-links.yml
+++ b/.github/workflows/gitbook-preview-links.yml
@@ -40,12 +40,28 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           SHA: ${{ github.event.sha || github.event.inputs.sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
         run: |
           set -euo pipefail
-          PR=$(gh api "repos/$GH_REPO/commits/$SHA/pulls" \
-                --jq '[.[] | select(.state=="open")][0].number // empty')
+          # Match the sha against open PRs' heads rather than asking
+          # `commits/$SHA/pulls`: that endpoint only indexes commits on the base
+          # repo's own branches, so it returns [] for a fork PR head (reachable
+          # only via refs/pull/N/head) and the job silently skipped every
+          # external contributor's PR. `pulls` carries `head.sha` verbatim, fork
+          # or not.
+          gh api "repos/$GH_REPO/pulls?state=open&per_page=100" --paginate --slurp > /tmp/open_prs.json
+          PR=$(jq -r --arg sha "$SHA" '[.[][] | select(.head.sha==$sha)][0].number // empty' /tmp/open_prs.json)
           if [ -z "$PR" ]; then
-            echo "No open PR for $SHA; nothing to do."
+            # A build for a commit already on the default branch (a merged PR,
+            # or a change request GitBook pushed straight to it) has no open PR
+            # to comment on — expected, stay quiet. Anything else is a preview
+            # we failed to map to its PR: warn, so the next regression here is
+            # visible instead of a green no-op.
+            CMP=$(gh api "repos/$GH_REPO/compare/$DEFAULT_BRANCH...$SHA" --jq '.status' 2>/dev/null) || CMP=unknown
+            case "$CMP" in
+              identical|behind) echo "No open PR for $SHA (already on $DEFAULT_BRANCH); nothing to do." ;;
+              *) echo "::warning::GitBook built a preview for $SHA but no open PR has that head sha; no preview links posted." ;;
+            esac
             exit 0
           fi
           echo "pr=$PR" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/gitbook-preview-links.yml
+++ b/.github/workflows/gitbook-preview-links.yml
@@ -54,9 +54,9 @@ jobs:
           if [ -z "$PR" ]; then
             # A build for a commit already on the default branch (a merged PR,
             # or a change request GitBook pushed straight to it) has no open PR
-            # to comment on — expected, stay quiet. Anything else is a preview
-            # we failed to map to its PR: warn, so the next regression here is
-            # visible instead of a green no-op.
+            # to comment on. That is expected, so stay quiet. Anything else is
+            # a preview we failed to map to its PR, so warn: the next
+            # regression here should be visible, not a green no-op.
             CMP=$(gh api "repos/$GH_REPO/compare/$DEFAULT_BRANCH...$SHA" --jq '.status' 2>/dev/null) || CMP=unknown
             case "$CMP" in
               identical|behind) echo "No open PR for $SHA (already on $DEFAULT_BRANCH); nothing to do." ;;


### PR DESCRIPTION
Closes DOC-2284: https://linear.app/n8n/issue/DOC-2284

The `GitBook preview links` workflow has never posted a comment on a pull request opened from a fork, so external contributors never got the deep links to the pages they changed. It only worked for branches pushed to this repo.

## Cause

The resolve step used `GET /repos/{repo}/commits/{sha}/pulls`. That endpoint only associates commits living on the base repo's own branches. A fork PR head is reachable through `refs/pull/N/head` but is not in that index, so the call returned `[]`, the step printed "No open PR" and exited 0 - a green run that did nothing.

Run [34089098224](https://github.com/n8n-io/n8n-docs/actions/runs/34089098224) for #5338 (fork), after GitBook reported success:

```
SHA: ee43d67e8c267201a9c16b27a44cd69dd12a36ea
No open PR for ee43d67e...; nothing to do.
```

Same endpoint, queried directly:

| head sha | PR | fork | `commits/{sha}/pulls` |
| --- | --- | --- | --- |
| `ee43d67e` | #5338 | yes | `[]` |
| `fbd069a3` | #5335 | yes | `[]` |
| `73e5f29f` | #5327 | yes | `[]` |
| `974af898` | #5329 | no | `[{5329, open}]` |
| `fdcb48bc` | #5328 | no | `[{5328, open}]` |

GitBook posts its statuses on fork commits just fine, so the trigger was never the problem - only the PR lookup was.

## Change

- Resolve the PR by scanning open PRs for a matching `head.sha`. `pulls` carries the head sha verbatim, fork or not.
- Warn when a preview built but no open PR matches it, so a future regression here is visible instead of a silent green no-op. Commits already on the default branch (merged PRs, and change requests GitBook pushes straight to `main`) are the expected no-PR case and stay quiet - that is what the `compare` call distinguishes.

Unchanged: the security model. The job still checks out the trusted default branch and overlays only the PR's changed file *contents*. `contents/<path>?ref=<fork-sha>` already resolves against this repo (verified on the #5338 head), so the overlay needed no fork-specific handling.

## Verification

Resolve logic replayed against real shas before pushing:

| sha | result |
| --- | --- |
| `ee43d67e` (#5338, fork) | PR 5338 |
| `fdcb48bc` (#5328, same repo) | PR 5328 |
| `3317373c` (on `main`) | no PR, `compare=behind` -> quiet |

End-to-end dry run from this branch to follow in a comment below.