### PR TITLE
ci: pin the remaining floating action versions (DOC-2286)

### DIFF
--- a/.github/workflows/lexi.yml
+++ b/.github/workflows/lexi.yml
@@ -9,10 +9,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repo with history
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                   fetch-depth: 0
-            - uses: Rebilly/lexi@v2
+            - uses: Rebilly/lexi@5a517542b048ca8cb46e43f27736fed84dfb0e84 # v2.3.6
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   glob: '**/*.md'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,8 @@ jobs:
     name: runner / vale
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: errata-ai/vale-action@reviewdog
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # Pinned to the commit the `reviewdog` branch points at (same as v3.0.0).
+      - uses: errata-ai/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff # v3.0.0
         with:
           files: '["docs"]'

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run Lychee Link Checker
-        uses: lycheeverse/lychee-action@f796c8b7d468feb9b8c0a46da3fac0af6874d374
+        uses: lycheeverse/lychee-action@f796c8b7d468feb9b8c0a46da3fac0af6874d374 # v2.2.0
         with:
           args: --config lychee.toml ./docs
 

--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -11,7 +11,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/support-requests@47d5ea12f6c9e4a081637de9626b7319b415a3bf
+      - uses: dessant/support-requests@47d5ea12f6c9e4a081637de9626b7319b415a3bf # v4.0.0
         with:
           github-token: ${{ github.token }}
           support-label: 'issue:support'


### PR DESCRIPTION
Closes DOC-2286: https://linear.app/n8n/issue/DOC-2286

Most of this repo's CI is SHA-pinned already. Five references were still floating, so a compromised upstream release would start running in our CI on the next job with no change on our side. This pins them.

Severity is low, which is why it is a small standalone PR rather than urgent: all three affected workflows run on `pull_request`, where a fork PR gets a read-only token and no secrets, so there is nothing to exfiltrate. The exposure is our runner and our trust in third-party code.

## Pinned

| file | was | now |
| --- | --- | --- |
| `lint.yml` | `actions/checkout@v4` | `11bd7190` (v4.2.2) |
| `lint.yml` | `errata-ai/vale-action@reviewdog` (mutable **branch**) | `518a9136` (v3.0.0) |
| `lexi.yml` | `actions/checkout@v4` | `11bd7190` (v4.2.2) |
| `lexi.yml` | `Rebilly/lexi@v2` | `5a517542` (v2.3.6) |
| `lychee.yml` | `actions/checkout@v4` | `11bd7190` (v4.2.2) |

**No behaviour change.** Each SHA is what the floating ref resolves to right now: the `reviewdog` branch head and the `v3.0.0` tag are the same commit (`518a9136`), and `Rebilly/lexi`'s `v2` peels to the same commit as `v2.3.6` (`5a517542`). Verified every pin in the repo against upstream tags after the change.

Also labelled two refs that were already pinned but had no version comment, so the files read consistently: `lychee-action f796c8b7` is v2.2.0 and `support-requests 47d5ea12` is v4.0.0.

## A live example of why this matters

While verifying, two *pre-existing* pins turned out to no longer match the tag in their comment: `lychee-action a99389ae # v2.3.0` is exactly 1 commit behind what `v2.3.0` points to today, and `actions-comment-pull-request e4a76dd2 # v3.0.1` likewise. Upstream moved those tags after we pinned. The pins held, which is the entire point. I left both alone: they are safe, the comments are just stale labels, and bumping them is a separate decision that deserves its own behaviour check.

## Follow-up, not in this PR

Pins do not update themselves. The usual companion is `.github/dependabot.yml` with a `github-actions` entry opening a monthly bump PR. This repo has no dependabot config today and adding one changes repo-wide PR behaviour, so it is worth agreeing with the repo maintainers first. Noted on the ticket.

## Checks

All workflow files still parse, and every `uses:` in `.github/workflows/` is now a 40-character SHA. Vale, lexi and lychee run on this PR, so their own pinned versions get exercised here.