### PR TITLE
Changelog: error workflow executions no longer count towards your quota (2.28)

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -223,6 +223,18 @@ Learn more in the [insights retention documentation](https://app.gitbook.com/s/w
 **Availability:** Pro, Business, and Enterprise.
 {% endhint %}
 
+## Error workflow executions no longer count towards your quota
+
+**Released:** 2026-06-23 in [n8n 2.28](release-notes.md#n8n228)
+
+Runs of your error workflows are now excluded from your execution quota, on every plan. An error workflow is the one n8n runs when another workflow fails. It receives the details of the failure, which workflow, which node, what went wrong, and does something useful with them: post to a Slack channel, send an email, open a ticket, or retry the run.
+
+Until now each of those runs counted like any other execution. Handling a failure cost you an execution on top of the failure itself, and some people left error workflows out to protect their quota. Every production workflow should have one, so we stopped counting them.
+
+There is nothing to configure. Attach an error workflow to a workflow in its **Workflow Settings** and its runs are excluded from the count. One error workflow can serve as many workflows as you like. Past counts stay as they are; the change applies to executions from the upgrade onwards, so the same workflows might register fewer executions per month than before.
+
+On Cloud the change is already live. On self-hosted it applies from 2.28.0, or 1.123.60 if you're still on v1. If some of your workflows still run without an error workflow, refer to [Handle errors gracefully](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/flow-logic/handle-errors-gracefully) to set one up.
+
 ## Organize large workflows with Canvas Groups
 
 **Released:** 2026-06-23 in [n8n 2.28](release-notes.md#n8n228)


### PR DESCRIPTION
Adds a changelog entry for the 2.28 change that excludes error workflow runs from the execution quota, on every plan.

- Placed with the other 2.28 entries (Released 2026-06-23, anchor `release-notes.md#n8n228` checked).
- Links to the Handle errors gracefully page via its GitBook space URL.
- Follows the format in the PMM "How to changelog" Notion page: H2 headline, Released line, no availability hint since it applies to every plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)