### PR TITLE
docs: Replace Pyodide-era Python examples in the code docs

### DIFF
--- a/docs/build/code-in-n8n/cookbook/code-node/output-to-the-browser-console.md
+++ b/docs/build/code-in-n8n/cookbook/code-node/output-to-the-browser-console.md
@@ -39,30 +39,19 @@ a = "apple"
 print(a)
 ```
 
-### Handling an output of `[object Object]` <a href="#handling-an-output-of-object-object" id="handling-an-output-of-object-object"></a>
+### Printing node data <a href="#printing-node-data" id="printing-node-data"></a>
 
-If the console displays `[object Object]` when you print, check the data type, then convert it as needed.
-
-To check the data type:
+`_items` and `_item` are standard Python objects, so you can print them directly:
 
 ```python
-print(type(myData))
+print(_items)
 ```
 
-#### JsProxy <a href="#jsproxy" id="jsproxy"></a>
+{% hint style="info" %}
+**`type()` isn't available**
 
-If `type()` outputs `<class 'pyodide.ffi.JsProxy'>`, you need to convert the JsProxy to a native Python object using `to_py()`. This occurs when working with data in the n8n node data structure, such as node inputs and outputs. For example, if you want to print the data from a previous node in the workflow:
-
-```python
-previousNodeData = _("<node-name>").all();
-for item in previousNodeData:
-	# item is of type <class 'pyodide.ffi.JsProxy'>
-	# You need to convert it to a Dict
-	itemDict = item.json.to_py()
-	print(itemDict)
-```
-
-Refer to the Pyodide documentation on [JsProxy](https://pyodide.org/en/stable/usage/api/python-api/ffi.html#pyodide.ffi.JsProxy) for more information on this class.
+The Python Code node denies some built-in functions by default, including `type()`. Refer to [task runners environment variables](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/basic-configuration/use-environment-variables/task-runners) for the full list and how to change it when self-hosting.
+{% endhint %}
 
 
 

--- a/docs/build/code-in-n8n/use-built-in-shortcuts/jmespath.md
+++ b/docs/build/code-in-n8n/use-built-in-shortcuts/jmespath.md
@@ -17,20 +17,11 @@ layout:
 This is an n8n-provided method for working with the [JMESPath](../../work-with-data/handle-special-data-types/query-json-data.md) library.
 
 {% hint style="info" %}
-**Python support**
+**JavaScript only**
 
-You can use Python in the Code node. It isn't available in expressions.
+The Python Code node doesn't provide this method. To query JSON in Python, use standard Python instead. Refer to [Query JSON with JMESPath](../../work-with-data/handle-special-data-types/query-json-data.md) for a Python version of each example.
 {% endhint %}
-{% tabs %}
-{% tab title="JavaScript" %}
+
 | Method | Description | Available in Code node? |
 | ------ | ----------- | :-------------------------: |
 | `$jmespath()` | Perform a search on a JSON object using JMESPath. | ✅ |
-{% endtab %}
-
-{% tab title="Python" %}
-| Method | Description | 
-| ------ | ----------- | 
-| `_jmespath()` | Perform a search on a JSON object using JMESPath. | 
-{% endtab %}
-{% endtabs %}

--- a/docs/build/code-in-n8n/use-built-in-shortcuts/n8n-metadata.md
+++ b/docs/build/code-in-n8n/use-built-in-shortcuts/n8n-metadata.md
@@ -58,6 +58,7 @@ You can use Python in the Code node. It isn't available in expressions.
 | ------ | ----------- |
 | `_items` | Contains incoming items in "Run once for all items" mode. |
 | `_item` | Contains the item being iterated on in "Run once for each item" mode. |
+| `_query` | In the Code Tool, contains the input string the AI Agent passes when it calls the tool. Available in "Run once for all items" mode. |
 
 ## Python (Pyodide, deprecated)
 

--- a/docs/build/work-with-data/handle-special-data-types/query-json-data.md
+++ b/docs/build/work-with-data/handle-special-data-types/query-json-data.md
@@ -25,19 +25,15 @@ n8n provides a custom method, `jmespath()`. Use this method to perform a search 
 
 The basic syntax is: 
 
-{% tabs %}
-{% tab title="JavaScript" %}
 ```js
 $jmespath(object, searchString)
 ```
-{% endtab %}
 
-{% tab title="Python" %}
-```python
-_jmespath(object, searchString)
-```
-{% endtab %}
-{% endtabs %}
+{% hint style="info" %}
+**JavaScript only**
+
+The Python Code node doesn't provide `$jmespath()`. To get the same results in Python, use standard Python instead. Each example below includes a Python version.
+{% endhint %}
 
 To help understand what the method does, here is the equivalent longer JavaScript:
 
@@ -155,8 +151,9 @@ return {firstNames};
 
 {% tab title="Code node (Python)" %}
 ```python
-firstNames = _jmespath(_json.body.people, "[*].first" )
-return {"firstNames":firstNames}
+people = _item["json"]["body"]["people"]
+first_names = [person["first"] for person in people]
+return {"firstNames": first_names}
 """
 Returns:
 [
@@ -203,8 +200,9 @@ return {firstTwoNames};
 
 {% tab title="Code node (Python)" %}
 ```python
-firstTwoNames = _jmespath(_json.body.people, "[:2].first" )
-return {"firstTwoNames":firstTwoNames}
+people = _item["json"]["body"]["people"]
+first_two_names = [person["first"] for person in people[:2]]
+return {"firstTwoNames": first_two_names}
 """
 Returns:
 [
@@ -249,8 +247,9 @@ return {dogsAges};
 
 {% tab title="Code node (Python)" %}
 ```python
-dogsAges = _jmespath(_json.body.dogs, "*.age")
-return {"dogsAges": dogsAges}
+dogs = _item["json"]["body"]["dogs"]
+dogs_ages = [dog["age"] for dog in dogs.values()]
+return {"dogsAges": dogs_ages}
 """
 Returns:
 [
@@ -353,8 +352,9 @@ return {newList};
 
 {% tab title="Code node (Python)" %}
 ```python
-newList = _jmespath(_json.body.people, "[].[first, last]")
-return {"newList":newList}
+people = _item["json"]["body"]["people"]
+new_list = [[person["first"], person["last"]] for person in people]
+return {"newList": new_list}
 """
 Returns:
 [


### PR DESCRIPTION
Closes DOC-2287

## Why

The Python Code node runs native Python now. That runtime provides only `_items`, `_item`, `_query` and `print` — the `globals` dict passed to `exec()` in `packages/@n8n/task-runner-python/src/task_executor.py`. Our Python examples still used Pyodide-only names like `_json` and `_jmespath`, so a user copying them got a `NameError`.

Pyodide is gone from the Code node's language selector (only `javaScript | pythonNative` remain), so these examples can't work for anyone today.

Our [Code node page](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.code) already documents this correctly — `docs/reusable-content/.gitbook/includes/integrations/builtin/core-nodes/code-node.md` says "Native Python supports only `_items` in all-items mode and `_item` in per-item mode." These pages just never got the update.

## What

**`query-json-data.md`** — the four `$jmespath(_json…)` Python examples become plain Python list comprehensions returning the same values. Per-item mode and `_item`, matching the page's own instruction to use **Run Once for Each Item**. The "Returns" blocks are unchanged because the output is identical.

**`jmespath.md`** — dropped the Python tab. `$jmespath()` has no Python equivalent at all (no library imports on Cloud), so the honest answer is to point at the Python examples on the JMESPath page.

**`output-to-the-browser-console.md`** — dropped the `[object Object]` / JsProxy section. `JsProxy`, `to_py()` and `_("<node>").all()` are Pyodide-only, and `print(type(myData))` fails too because `type` is in `N8N_RUNNERS_BUILTINS_DENY` by default. Replaced with `print(_items)` and a note about the denied built-ins.

**`n8n-metadata.md`** — added the missing `_query` row.

## Verified, not assumed

Every new Python snippet was pasted into a Code node on docs-prod and run before it landed here: https://docs-prod.app.n8n.cloud/workflow/k6fYGyWzoLBvlLIH (execution 26595/26596, all green).

| Snippet | Output |
| -- | -- |
| List projection | `["James","Jacob","Jayden"]` |
| Slice projection | `["James","Jacob"]` |
| Object projection | `[7,5]` |
| Multiselect | `[["James","Green"],["Jacob","Jones"],["Jayden","Smith"]]` |
| `print(_items)` | ran clean |
| `type` | `NameError: name 'type' is not defined` |

Each matches the values the docs already claim, so no "Returns" block needed changing.

## Notes

- The decision not to wait for the built-ins to return is backed by Slack: cutting the Python `_` helpers was deliberate (Iván, 2025-07-14), and native Python went to 100% of Cloud out of beta on 2025-12-04.
- Related: NODE-5919, where the Code node's Python field tip still suggests `_today` and `_jmespath` while the notice right below it correctly says they don't work.
- Not touched: `N8N_RUNNERS_BUILTINS_DENY`'s documented default in the task-runners env var page is missing `license,help,credits,copyright` versus the current source default. That's env-var docs, so I left it for whoever owns that page.

## Checks

Vale clean on all added lines. Please confirm the four Python tabs and the two new callouts render correctly on the GitBook preview.