### PR TITLE
docs(versioning): fix Light versioning heading rendering

### DIFF
--- a/docs/connect/create-nodes/build-your-node/reference/versioning.md
+++ b/docs/connect/create-nodes/build-your-node/reference/versioning.md
@@ -24,6 +24,7 @@ Be aware of how n8n decides which node version to load:
 
 If you build a node using the declarative style, you can't use full versioning.
 {% endhint %}
+
 ## Light versioning <a href="#light-versioning" id="light-versioning"></a>
 
 This is available for all node types.


### PR DESCRIPTION
## Summary

On [Node versioning](https://docs.n8n.io/connect/create-nodes/build-your-node/reference/versioning), the **Light versioning** heading rendered as plain text because there was no blank line between the preceding `{% endhint %}` block and the `##` heading.

Added the missing blank line.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

