### PR TITLE
docs(create-nodes): clarify that trigger nodes must be programmatic

### DIFF
--- a/docs/connect/create-nodes/build-your-node/reference/verification-guidelines.md
+++ b/docs/connect/create-nodes/build-your-node/reference/verification-guidelines.md
@@ -39,7 +39,7 @@ All verified community node authors should use the [`n8n-node` tool](../using-th
 
 * The node **MUST** not be an existing node, If your node is an iteration on an existing node create a pull request instead.
 * n8n isn't accepting Logic or Flow control nodes at the moment.
-* Each package should integrate exactly one third-party service. A trigger node for the same service may be included alongside the main node. Packages that wrap multiple unrelated APIs or act as a proxy layer for several services generally don't qualify for verification. Submit each service as its own separate package.
+* Each package should integrate exactly one third-party service. A trigger node for the same service may be included alongside the main node. Build the trigger node in the programmatic style, because the [declarative style](../../plan-your-node/choose-a-node-building-style.md) doesn't support triggers. A package can mix styles, so a declarative-style action node and a programmatic-style trigger node can live in the same package. Packages that wrap multiple unrelated APIs or act as a proxy layer for several services generally don't qualify for verification. Submit each service as its own separate package.
 
 ## Package source verification <a href="#package-source-verification" id="package-source-verification"></a>
 

--- a/docs/connect/create-nodes/build-your-node/reference/verification-guidelines.md
+++ b/docs/connect/create-nodes/build-your-node/reference/verification-guidelines.md
@@ -39,7 +39,8 @@ All verified community node authors should use the [`n8n-node` tool](../using-th
 
 * The node **MUST** not be an existing node, If your node is an iteration on an existing node create a pull request instead.
 * n8n isn't accepting Logic or Flow control nodes at the moment.
-* Each package should integrate exactly one third-party service. A trigger node for the same service may be included alongside the main node. Build the trigger node in the programmatic style, because the [declarative style](../../plan-your-node/choose-a-node-building-style.md) doesn't support triggers. A package can mix styles, so a declarative-style action node and a programmatic-style trigger node can live in the same package. Packages that wrap multiple unrelated APIs or act as a proxy layer for several services generally don't qualify for verification. Submit each service as its own separate package.
+* Each package should integrate one third-party service. Most packages that wrap multiple unrelated APIs or act as a proxy layer for several services don't qualify for verification. Submit each service as its own separate package.
+* You can include a trigger node for the same service alongside the main node. Build the trigger node in the programmatic style, because the [declarative style](../../plan-your-node/choose-a-node-building-style.md) doesn't support triggers. A package can mix styles, so a declarative-style action node and a programmatic-style trigger node can live in the same package.
 
 ## Package source verification <a href="#package-source-verification" id="package-source-verification"></a>
 

--- a/docs/connect/create-nodes/build-your-node/using-the-n8n-node-tool.md
+++ b/docs/connect/create-nodes/build-your-node/using-the-n8n-node-tool.md
@@ -115,7 +115,7 @@ This will start an interactive prompt where you can define the details of your p
     * `@<YOUR_ORG>/n8n-nodes-<YOUR_NODE_NAME>`
 * **What kind of node are you building?** The [node type](../plan-your-node/choose-a-node-building-style.md) you want to build:
     * **HTTP API**: A low-code, declarative node structure that's designed for faster approval for n8n Cloud.
-    * **Other**: A programmatic style node with full flexibility.
+    * **Other**: A programmatic style node with full flexibility. Choose this for trigger nodes: the declarative style doesn't support triggers. To add a trigger node to a package that already has a declarative-style node, write the trigger node in the programmatic style in the same package.
 * **What template do you want to use?** When using the HTTP API, you can choose the template to start from:
     * **GitHub Issues API**: A demo node that includes multiple operations and credentials. This can help you get familiar with the node structure and conventions.
     * **Start from scratch**: A blank template that will guide you through your custom setup with some further prompts.

--- a/docs/connect/create-nodes/plan-your-node/choose-a-node-building-style.md
+++ b/docs/connect/create-nodes/plan-your-node/choose-a-node-building-style.md
@@ -27,6 +27,14 @@ The programmatic style is more verbose. You must use the programmatic style for:
 * Any node that needs to transform incoming data.
 * Full versioning. Refer to [Node versioning](../build-your-node/reference/versioning.md) for more information on types of versioning.
 
+{% hint style="info" %}
+**Trigger nodes must use the programmatic style**
+
+The declarative style doesn't support trigger nodes. Build every trigger node in the programmatic style, even when the action node for the same service is declarative.
+
+You can mix both styles in one node package. For example, a package submitted for [verification](../build-your-node/reference/verification-guidelines.md) can contain a declarative-style action node and a programmatic-style trigger node for the same service.
+{% endhint %}
+
 ## Data handling differences <a href="#data-handling-differences" id="data-handling-differences"></a>
 
 The main difference between the declarative and programmatic styles is how they handle incoming data and build API requests. The programmatic style requires an `execute()` method, which reads incoming data and parameters, then builds a request. The declarative style handles this using the `routing` key in the `operations` object. Refer to [Node base file](../build-your-node/reference/base-files/README.md) for more information on node parameters and the `execute()` method.


### PR DESCRIPTION
## Summary

Node builders using the declarative style are often confused when they find that trigger nodes don't support it. The docs said "you must use the programmatic style for trigger nodes" in a bullet list, but never said that a single package can mix both styles.

This makes it explicit at the three points where authors hit the question:

- **Choose your node building approach**: a hint stating the declarative style doesn't support triggers, and that one package can contain a declarative-style action node plus a programmatic-style trigger node.
- **Community node verification guidelines**: the existing "a trigger node for the same service may be included" bullet now says the trigger must be programmatic and that a mixed-style package is fine for verification.
- **Using the n8n-node tool**: the **Other** template option now says to pick it for trigger nodes, including when adding one to a package that already has a declarative node.

No behavior or product change, wording only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

