### PR TITLE
docs: Document the Output Dimensionality option of the Embeddings Google Gemini node

### DIFF
--- a/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsgooglegemini.md
+++ b/docs/integrations/builtin/cluster-nodes/sub-nodes/n8n-nodes-langchain.embeddingsgooglegemini.md
@@ -35,9 +35,15 @@ You can find authentication information for this node [here](../../credentials/g
 
 ## Node parameters <a href="#node-parameters" id="node-parameters"></a>
 
-* **Model**: Select the model to use to generate the embedding.
+* **Model**: Select the model to use to generate the embedding. The default model, `gemini-embedding-001`, returns 3072-dimensional embeddings unless you set the **Output Dimensionality** option.
 
 Learn more about available models in [Google Gemini's models documentation](https://ai.google.dev/models/gemini).
+
+## Node options <a href="#node-options" id="node-options"></a>
+
+* **Output Dimensionality**: Enter the number of dimensions the returned embeddings should have. Google recommends `768`, `1536`, or `3072` for `gemini-embedding-001`. Leave the option unset to use the model default. Make sure your vector store is configured for the same dimensionality.
+
+Refer to [Google's embeddings documentation](https://ai.google.dev/gemini-api/docs/embeddings) for the dimensions each model supports.
 
 ## Templates and examples <a href="#templates-and-examples" id="templates-and-examples"></a>
 


### PR DESCRIPTION
## Summary

Documents the new **Output Dimensionality** option of the Embeddings Google Gemini node and corrects the implicit assumption that the default model returns 768-dimensional embeddings. Since the default model became `gemini-embedding-001`, the node returns 3072 dimensions unless the option is set.

Companion to n8n-io/n8n#38127, which adds the option and fixes the in-node notice. The page can be merged once that PR ships.

## Changes

- Note the default dimensionality of `gemini-embedding-001` under the **Model** parameter.
- Add a **Node options** section describing **Output Dimensionality**, with the sizes Google recommends and a link to Google's embeddings documentation.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

