### PR TITLE
ci: Python GitBook syntax check for headings glued to {% endhint %}

### DIFF
--- a/.github/scripts/check_gitbook_syntax.py
+++ b/.github/scripts/check_gitbook_syntax.py
@@ -39,9 +39,10 @@ from typing import Iterable
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCS_ROOT = REPO_ROOT / "docs"
 
-# A real ATX heading: 1-6 `#` followed by a space or end of line. (`#foo` with
-# no space is not a heading in CommonMark, so it isn't matched.)
-ATX_RE = re.compile(r"^#{1,6}(?:\s|$)")
+# A real ATX heading: up to 3 leading spaces (CommonMark allows 0-3; 4+ is an
+# indented code block), then 1-6 `#` followed by a space or end of line. (`#foo`
+# with no space is not a heading in CommonMark, so it isn't matched.)
+ATX_RE = re.compile(r"^ {0,3}#{1,6}(?:\s|$)")
 # The whole (trimmed) line is exactly the endhint tag, tolerant of inner spaces.
 ENDHINT_RE = re.compile(r"^\{%\s*endhint\s*%\}$")
 # Opening of a fenced code block: 3+ backticks or 3+ tildes.

--- a/.github/scripts/check_gitbook_syntax.py
+++ b/.github/scripts/check_gitbook_syntax.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Check GitBook block syntax in the n8n docs that silently breaks rendering.
+
+GitBook's `{% ... %}` blocks have a few authoring gotchas that pass a normal
+Markdown review but render wrong (or not at all) on the live site. Vale and the
+Markdown linters don't know about them, so this script encodes them as CI rules.
+
+Each entry in RULES scans the Markdown files changed in a PR (or all of docs/
+when run with no arguments) and reports a finding. The rules are line-based and
+stdlib-only; there is no Markdown dependency in CI.
+
+Rules enforced:
+  1. heading-after-endhint
+     A heading placed on the line immediately after `{% endhint %}`, with no
+     blank line between them, fails to render on the live site -- the raw `##`
+     leaks through as literal text. This is scoped to `{% endhint %}` ONLY, on
+     purpose. The opening tags `{% hint %}`, `{% step %}`, and `{% column %}`
+     treat a glued heading as the block's styled title and render it correctly
+     (the style guide documents the hint-title pattern), so those must not be
+     flagged. Headings inside fenced code blocks (e.g. the style guide's own
+     examples of this exact syntax) are excluded via the code-fence mask.
+
+Usage:
+    python3 .github/scripts/check_gitbook_syntax.py [files...]
+
+With no arguments it scans every docs/**/*.md file. Pass specific files (e.g.
+the changed files in a PR) to check only those. Exits 1 if any finding is found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+# Repo root = two levels up from .github/scripts/
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_ROOT = REPO_ROOT / "docs"
+
+# A real ATX heading: 1-6 `#` followed by a space or end of line. (`#foo` with
+# no space is not a heading in CommonMark, so it isn't matched.)
+ATX_RE = re.compile(r"^#{1,6}(?:\s|$)")
+# The whole (trimmed) line is exactly the endhint tag, tolerant of inner spaces.
+ENDHINT_RE = re.compile(r"^\{%\s*endhint\s*%\}$")
+# Opening of a fenced code block: 3+ backticks or 3+ tildes.
+FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
+
+
+def code_line_mask(lines: list[str]) -> list[bool]:
+    """Return a per-line mask where True means the line is a fenced code block
+    delimiter or sits inside one.
+
+    A fence opens on 3+ backticks/tildes and closes only on a delimiter of the
+    same character that is at least as long and carries no info string -- so a
+    longer outer fence can wrap an inner ```` ``` ```` example without the inner
+    delimiter ending the outer block. This mirrors how GitBook (and CommonMark)
+    parse nested fences, so illustrative examples don't get misread as headings.
+    """
+    mask = [False] * len(lines)
+    fence: tuple[str, int] | None = None  # (char, length) of the open fence
+    for i, line in enumerate(lines):
+        stripped = line.lstrip()
+        m = FENCE_RE.match(stripped)
+        if m:
+            run = m.group(1)
+            char, length = run[0], len(run)
+            rest = stripped[length:].strip()
+            if fence is None:
+                fence = (char, length)
+                mask[i] = True
+                continue
+            # A closing fence matches the char, is at least as long, and has no
+            # trailing info string.
+            if char == fence[0] and length >= fence[1] and not rest:
+                fence = None
+                mask[i] = True
+                continue
+        if fence is not None:
+            mask[i] = True
+    return mask
+
+
+def rule_heading_after_endhint(
+    rel: str, lines: list[str], in_code: list[bool]
+) -> Iterable[tuple[int, str, str]]:
+    """Flag a heading glued directly below `{% endhint %}` (rule 1)."""
+    name = "heading-after-endhint"
+    for i, line in enumerate(lines):
+        if i == 0 or in_code[i]:
+            continue
+        if ATX_RE.match(line) and ENDHINT_RE.match(lines[i - 1].strip()):
+            yield (
+                i + 1,
+                name,
+                "heading is glued to the preceding {% endhint %}; add a blank "
+                "line above it or it won't render on the live site",
+            )
+
+
+# Registry of GitBook-syntax rules. Add the next rule here.
+RULES = [rule_heading_after_endhint]
+
+
+def discover_files() -> list[Path]:
+    return sorted(DOCS_ROOT.rglob("*.md"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("files", nargs="*", help="Markdown files to check (default: all docs)")
+    args = ap.parse_args()
+
+    if args.files:
+        files = [Path(f).resolve() for f in args.files]
+    else:
+        files = discover_files()
+
+    findings: list[str] = []
+
+    for md_file in files:
+        if not md_file.exists() or md_file.suffix != ".md":
+            continue
+        try:
+            rel = md_file.relative_to(REPO_ROOT).as_posix()
+        except ValueError:
+            continue
+
+        lines = md_file.read_text(encoding="utf-8", errors="replace").split("\n")
+        in_code = code_line_mask(lines)
+        for rule in RULES:
+            for line, name, message in rule(rel, lines, in_code):
+                findings.append(f"{rel}:{line}  [{name}]  {message}")
+
+    if findings:
+        print(f"❌ {len(findings)} GitBook syntax issue(s):\n")
+        for f in sorted(findings):
+            print(f"  {f}")
+        print(
+            "\nRun locally with python3 .github/scripts/check_gitbook_syntax.py <file>"
+        )
+        return 1
+
+    print(f"✅ No GitBook syntax issues found ({len(files)} file(s) scanned).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_check_gitbook_syntax.py
+++ b/.github/scripts/tests/test_check_gitbook_syntax.py
@@ -66,6 +66,27 @@ def main():
     )
     check("glued heading inside a nested code fence is not flagged", endhint_findings(nested) == [])
 
+    # Tilde fences get the same masking as backtick fences.
+    tilde = (
+        "Example of the bug:\n\n"
+        "~~~md\n"
+        "{% endhint %}\n"
+        "## Heading\n"
+        "~~~\n"
+    )
+    check("glued heading inside a tilde code fence is not flagged", endhint_findings(tilde) == [])
+
+    # A backtick run inside a tilde fence doesn't close it (different char).
+    tilde_nested = (
+        "~~~md\n"
+        "```\n"
+        "{% endhint %}\n"
+        "## Heading\n"
+        "```\n"
+        "~~~\n"
+    )
+    check("glued heading inside a tilde fence wrapping backticks is not flagged", endhint_findings(tilde_nested) == [])
+
     # --- Guards ---------------------------------------------------------------
     # A heading glued to a `{% hint %}` OPENING tag renders as the hint title.
     hint_title = "{% hint style=\"info\" %}\n## This is the hint title\nBody.\n{% endhint %}\n"

--- a/.github/scripts/tests/test_check_gitbook_syntax.py
+++ b/.github/scripts/tests/test_check_gitbook_syntax.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Network-free tests for check_gitbook_syntax.py.
+
+Drives each rule with in-memory Markdown strings (no fixture tree needed for a
+line-based rule) and locks in the behaviour that matters: the endhint-glued
+heading is flagged, a properly spaced heading isn't, a heading glued to a
+`{% hint %}` opening tag isn't (endhint-only scope), and the style guide's own
+fenced examples of this syntax don't false-positive.
+
+Run: python3 .github/scripts/tests/test_check_gitbook_syntax.py
+"""
+import importlib.util
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "check_gitbook_syntax.py"
+
+spec = importlib.util.spec_from_file_location("cgs", SCRIPT)
+cgs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cgs)
+
+checks = []
+
+
+def check(name, cond):
+    checks.append((name, bool(cond)))
+
+
+def endhint_findings(text):
+    """Run the endhint rule over a Markdown string; return (line, name, msg) list."""
+    lines = text.split("\n")
+    in_code = cgs.code_line_mask(lines)
+    return list(cgs.rule_heading_after_endhint("test.md", lines, in_code))
+
+
+def main():
+    # --- Passing: blank line between endhint and heading ----------------------
+    ok = "{% hint style=\"info\" %}\nNote.\n{% endhint %}\n\n## Heading\n"
+    check("spaced heading after endhint is not flagged", endhint_findings(ok) == [])
+
+    # --- Failing: heading glued directly below endhint ------------------------
+    bad = "{% hint style=\"info\" %}\nNote.\n{% endhint %}\n## Heading\n"
+    bad_findings = endhint_findings(bad)
+    check("glued heading after endhint is flagged", len(bad_findings) == 1)
+    check("finding points at the heading line", bad_findings and bad_findings[0][0] == 4)
+    check("finding uses the rule name", bad_findings and bad_findings[0][1] == "heading-after-endhint")
+
+    # --- Inside a code fence: illustrative example must not fire --------------
+    fenced = (
+        "Example of the bug:\n\n"
+        "```md\n"
+        "{% endhint %}\n"
+        "## Heading\n"
+        "```\n"
+    )
+    check("glued heading inside a code fence is not flagged", endhint_findings(fenced) == [])
+
+    # A longer outer fence wrapping an inner ``` example still counts as code.
+    nested = (
+        "````md\n"
+        "```\n"
+        "{% endhint %}\n"
+        "## Heading\n"
+        "```\n"
+        "````\n"
+    )
+    check("glued heading inside a nested code fence is not flagged", endhint_findings(nested) == [])
+
+    # --- Guards ---------------------------------------------------------------
+    # A heading glued to a `{% hint %}` OPENING tag renders as the hint title.
+    hint_title = "{% hint style=\"info\" %}\n## This is the hint title\nBody.\n{% endhint %}\n"
+    check("heading glued to a hint opening tag is not flagged", endhint_findings(hint_title) == [])
+
+    # A heading on line 1 has no line above it.
+    check("heading on line 1 is not flagged", endhint_findings("## Heading\n") == [])
+
+    # Inner whitespace variants of the tag are still matched.
+    spaced_tag = "{%  endhint  %}\n## Heading\n"
+    check("endhint tag with extra inner spaces is matched", len(endhint_findings(spaced_tag)) == 1)
+
+    failed = [n for n, ok in checks if not ok]
+    for n, ok in checks:
+        print(f"  {'PASS' if ok else 'FAIL'}  {n}")
+    if failed:
+        print(f"\n{len(failed)} FAILED")
+        return 1
+    print(f"\nAll {len(checks)} checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/gitbook-syntax.yml
+++ b/.github/workflows/gitbook-syntax.yml
@@ -1,0 +1,31 @@
+name: GitBook syntax check
+# Catches GitBook block-syntax mistakes that pass a normal Markdown review but
+# break rendering on the live site (e.g. a heading glued directly below
+# `{% endhint %}`). Scans the Markdown files changed in the PR and fails if any
+# of them trip a rule. See .github/scripts/check_gitbook_syntax.py.
+on:
+  pull_request:
+    branches:
+      - main
+permissions:
+  contents: read
+jobs:
+  gitbook-syntax:
+    name: runner / gitbook-syntax
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Get changed markdown files
+        id: changed
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1 # v45.0.1
+        with:
+          files: |
+            docs/**/*.md
+      - name: Check GitBook syntax
+        if: steps.changed.outputs.any_changed == 'true'
+        run: |
+          python3 .github/scripts/check_gitbook_syntax.py ${{ steps.changed.outputs.all_changed_files }}
+      - name: Report status
+        if: failure()
+        run: echo "❌ GitBook syntax issues detected. See the log above; run locally with python3 .github/scripts/check_gitbook_syntax.py <file>"

--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -29,6 +29,15 @@ jobs:
       - name: Run check_internal_links tests
         run: python3 .github/scripts/tests/test_check_internal_links.py
 
+  check-gitbook-syntax:
+    name: runner / check-gitbook-syntax
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Run check_gitbook_syntax tests
+        run: python3 .github/scripts/tests/test_check_gitbook_syntax.py
+
   check-version-snippet:
     name: runner / check-version-snippet
     runs-on: ubuntu-latest


### PR DESCRIPTION
Python port of #5330. Same protection Benny built, reimplemented in our existing CI idiom.

Credit to @bennycode for spotting the bug and writing the original check. Fixes DOC-2296.

## Why this instead of #5330

#5330 caught a real GitBook bug: a heading placed on the line right after `{% endhint %}`, with no blank line between, fails to render on the live site (the raw `##` leaks through as text). It used a Node/markdownlint toolchain.

We have no Node in CI. All our docs checks are stdlib-only Python scripts in `.github/scripts/` with tests in `.github/scripts/tests/`, run on the PR's changed files (`internal-links.yml` is the model). Benny agreed a Python rule fits better and handed the port over. This is that port, no Node added.

## What this adds

- `.github/scripts/check_gitbook_syntax.py`: a stdlib-only checker. It holds the `{% endhint %}`-glued-heading rule as its first rule, in a `RULES` list so the next GitBook-syntax gotcha we find is a few lines added, not another workflow.
- `.github/scripts/tests/test_check_gitbook_syntax.py`: network-free tests (pass case, glued-heading fail case, one inside a code fence, plus hint-opening and line-1 guards).
- `.github/workflows/gitbook-syntax.yml`: runs the check on changed `docs/**/*.md` in a PR (`runner / gitbook-syntax`), modelled on `internal-links.yml` with actions pinned to SHAs.
- `.github/workflows/script-tests.yml`: adds a `runner / check-gitbook-syntax` unit-test job.

## Scope and safety

- Scoped to `{% endhint %}` only, on purpose. Opening tags (`{% hint %}`, `{% step %}`, `{% column %}`) render a glued heading correctly as the block's title, so they're not flagged.
- Excludes fenced code blocks (tracking fence char + length, so nested example fences work), so illustrative examples like the style guide's own don't false-positive.
- The content fix (blank lines in 18 docs) already landed via #5329, so this is CI-only and reports zero violations on current `main`.

## Verification

- `python3 .github/scripts/tests/test_check_gitbook_syntax.py` -> all checks pass.
- `python3 .github/scripts/check_gitbook_syntax.py` (all docs) -> 0 issues on current `main`.
- Deleting the blank line after an `{% endhint %}` in a file and re-running flags exactly that line.

Supersedes #5330, which I'll close once this is up.
