### PR TITLE
docs: Use "repository" consistently for the source control push/pull endpoints

### DIFF
--- a/docs/administer/use-source-control-and-environments/use-environments-via-api.md
+++ b/docs/administer/use-source-control-and-environments/use-environments-via-api.md
@@ -28,8 +28,8 @@ The public API exposes three source control operations:
 | Endpoint | Method | What it does |
 |----------|--------|--------------|
 | `/source-control/status` | `GET` | Previews the pending changes between your instance and Git, in either direction. |
-| `/source-control/push` | `POST` | Commits and pushes local changes to the connected Git branch. |
-| `/source-control/pull` | `POST` | Fetches changes from the connected Git branch into the instance. |
+| `/source-control/push` | `POST` | Commits and pushes local changes to the connected Git repository. |
+| `/source-control/pull` | `POST` | Fetches changes from the connected Git repository into the instance. |
 
 `push` and `pull` are the same actions as the **Push** and **Pull** buttons in the source control menu. `status` matches the file list the UI shows in the push and pull modals before you confirm. The API exposes it as its own endpoint so a script can do the same review the UI does inline.
 


### PR DESCRIPTION
## Summary

Small follow-up to [n8n-docs#5086](https://github.com/n8n-io/n8n-docs/pull/5086), related to [API-279](https://linear.app/n8n/issue/API-279/reconcile-environments-via-api-docs-with-the-shipped-statuspush).

The endpoints table on *Use environments programmatically with the public API* described `push` and `pull` as acting on "the connected Git branch," while `status` describes itself as acting on "the connected Git repository."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

