### PR TITLE
docs: Document what n8n Assistant knows about your instance

### DIFF
--- a/docs/build/ways-of-building-workflows/n8n-assistant.md
+++ b/docs/build/ways-of-building-workflows/n8n-assistant.md
@@ -51,6 +51,49 @@ You can ask n8n Assistant to:
 - **Help with credentials:** prompt you to select an existing credential or create a new one, without pasting secrets into chat.
 - **Use n8n resources:** create or update supporting resources such as [Data Tables](../work-with-data/data-tables.md) when needed.
 - **Research approved websites:** when web access is enabled, n8n Assistant asks for permission before accessing a domain.
+- **Pick up recent work:** ask about a workflow you built earlier or an execution that failed, and n8n Assistant can find it without you naming it.
+
+## What n8n Assistant knows about your instance
+
+At the start of a conversation, n8n Assistant receives instance context: a short summary of the project you opened it in. This is why a brief prompt such as "what should I look at?" or "carry on" often works without you naming a workflow.
+
+Instance context draws on three sources:
+
+| What instance context reports | Source |
+| :---------------------------- | :----- |
+| Which workflows exist in the project, and which are published | Your workflows |
+| What changed recently, and who changed it | The instance activity log |
+| Which workflows ran, how many failed, and the last failure | Your execution history |
+
+n8n Assistant gets the full picture with your first message in a conversation. After that, each message carries only what changed since then. Start a new conversation for unrelated work, and n8n Assistant reads the project again from the start.
+
+Instance context is off by default on self-hosted instances. An instance admin turns it on. See [Enable instance context](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-n8n-assistant#enable-instance-context).
+
+### What n8n Assistant can look up from instance context
+
+Instance context holds pointers, not contents. From it, n8n Assistant can:
+
+- **Read further back through recent changes.** Instance context covers a recent window. n8n Assistant can list older entries, filter to workflow or credential changes, or open one entry to see a single workflow's recent change history.
+- **Open the live record.** Every line carries an ID, so n8n Assistant can fetch the workflow, execution, or credential it points to.
+
+Change entries are pruned as they age, and executions stay only as long as your [execution data retention](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/scaling/manage-execution-data) allows. An entry n8n Assistant can no longer open is a normal outcome, not an error, and it carries on without that entry.
+
+### How n8n Assistant learns which nodes you use
+
+Node type counting is a separate setting from instance context, and an instance admin turns it on separately. See [Enable node type counting](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-n8n-assistant#enable-node-type-counting).
+
+With it on, n8n Assistant can ask how many workflows in a project use each node type, instead of reading every workflow to work out your conventions. It reports counts of node types, never parameter values, so it can tell that 10 of your 10 workflows use the **Slack** node, never how you configured any of them. To follow a convention rather than just name it, n8n Assistant reads one workflow in full.
+
+### What instance context doesn't include
+
+The activity log records that a change happened, not what the change contained. To answer anything about how a workflow is built, n8n Assistant reads the workflow itself.
+
+Instance context doesn't include:
+
+- **Parameter values.** A change entry names the node types you added or removed, and which settings you changed. It never records the values you set.
+- **Individual nodes.** Adding a second **Slack** node looks the same as having one. Entries track which node types are in use, not how many nodes of each type.
+- **Every node type in a large change.** When one save adds many node types, the entry lists some of them and reports the total.
+- **Work in projects you didn't open.** See [Instance context stays inside one project](#instance-context-stays-inside-one-project).
 
 ## Before you start
 
@@ -154,13 +197,24 @@ Depending on the task, this can include:
 - workflow structure and node configuration,
 - selected execution and error details used for troubleshooting,
 - credential names, credential types, or connection status,
-- approved web pages or domains, when you enable web access.
+- approved web pages or domains, when you enable web access,
+- the names of the workflows in the project you opened it in,
+- a record of recent workflow and credential changes in that project,
+- which of those workflows ran, and which executions failed.
 
 n8n Assistant doesn't require you to paste secrets into chat. Enter API keys, passwords, and tokens through the standard n8n credential screens.
 
 {% hint style="warning" %}
 Don't paste sensitive data into chat unless it's necessary for the task. AI-generated outputs can be incorrect, so review workflows and configurations before using them in production.
 {% endhint %}
+
+### Instance context stays inside one project
+
+A conversation is bound to the project you opened it in, and n8n Assistant reads instance context from that project only. It doesn't read your other projects, even ones you can open yourself, so work in one project never reaches a conversation in another.
+
+n8n Assistant reads instance context with your own permissions, and n8n checks them on every message rather than once at the start. If you lose access to the project, n8n Assistant stops reading it.
+
+An ID from outside the conversation's project gives the same answer as one that no longer exists. Neither can be used to find out whether something exists elsewhere in the instance.
 
 ## Credit usage
 

--- a/docs/build/ways-of-building-workflows/n8n-assistant.md
+++ b/docs/build/ways-of-building-workflows/n8n-assistant.md
@@ -60,14 +60,14 @@ At the start of a conversation, n8n Assistant receives instance context: a short
 Instance context draws on three sources:
 
 | What instance context reports | Source |
-| :---------------------------- | :----- |
+| --- | --- |
 | Which workflows exist in the project, and which are published | Your workflows |
 | What changed recently, and who changed it | The instance activity log |
 | Which workflows ran, how many failed, and the last failure | Your execution history |
 
 n8n Assistant gets the full picture with your first message in a conversation. After that, each message carries only what changed since then. Start a new conversation for unrelated work, and n8n Assistant reads the project again from the start.
 
-Instance context is off by default on self-hosted instances. An instance admin turns it on. See [Enable instance context](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-n8n-assistant#enable-instance-context).
+On n8n Cloud, n8n manages instance context for you. On self-hosted instances it's off by default, and an instance admin turns it on. See [Enable instance context](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/set-up-n8n-assistant#enable-instance-context).
 
 ### What n8n Assistant can look up from instance context
 
@@ -91,7 +91,7 @@ The activity log records that a change happened, not what the change contained. 
 Instance context doesn't include:
 
 - **Parameter values.** A change entry names the node types you added or removed, and which settings you changed. It never records the values you set.
-- **Individual nodes.** Adding a second **Slack** node looks the same as having one. Entries track which node types are in use, not how many nodes of each type.
+- **Individual nodes.** Adding a second **Slack** node looks the same as adding the first. A change entry names the node types that changed, not how many nodes of each type you have.
 - **Every node type in a large change.** When one save adds many node types, the entry lists some of them and reports the total.
 - **Work in projects you didn't open.** See [Instance context stays inside one project](#instance-context-stays-inside-one-project).
 

--- a/docs/deploy/host-n8n/configure-n8n/set-up-n8n-assistant.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-n8n-assistant.md
@@ -305,9 +305,9 @@ N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED=true
 | `N8N_ACTIVITY_LOG_ENABLED` | `false` | Set to `true` to record workflow and credential changes in the instance activity log. |
 | `N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED` | `false` | Set to `true` to let n8n Assistant read instance context. |
 
-Set both. With only `N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED`, n8n Assistant still reports which workflows exist and what has run, because neither of those comes from the activity log. The recent-changes part stays empty, because nothing wrote an entry.
+Set both. With only `N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED`, n8n Assistant still reports which workflows exist and what has run, because neither of those comes from the activity log. The recent-changes part stays empty, because nothing wrote an entry. With only `N8N_ACTIVITY_LOG_ENABLED`, n8n records the changes but n8n Assistant reads none of them.
 
-The activity log records that a change happened and which node types moved. It never records parameter values, so it can tell n8n Assistant which nodes a project uses, never how they're configured.
+The activity log records that a change happened and which node types you added or removed in it. It never records parameter values. It reports what changed in a save, not what the project uses now, which is what node type counting below answers.
 
 Turning `N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED` off removes instance context and the tool that reads the activity log. n8n Assistant then reads no instance context.
 
@@ -417,5 +417,11 @@ If n8n Assistant doesn't appear or doesn't work, check for these issues.
 * If only `N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED` is set, n8n Assistant reports which workflows exist and which ran, but no recent changes. Set the activity log variable too.
 * Nothing changed in the project yet. The activity log only records changes made after you enabled it.
 * The project is empty, and nothing has run in it. n8n Assistant reports nothing rather than an empty summary.
+
+**Node type counting**
+
+* `N8N_INSTANCE_AI_NODE_USAGE_ENABLED` is set to `true`.
+* Setting it to `false` doesn't force the feature off. It falls back to the managed rollout, which may not have reached your instance.
+* It's independent of instance context. Turning instance context on doesn't turn node type counting on.
 
 See [Configure n8n](./) for other configuration topics.

--- a/docs/deploy/host-n8n/configure-n8n/set-up-n8n-assistant.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-n8n-assistant.md
@@ -286,6 +286,47 @@ If you configure both, Brave Search takes priority over SearXNG. Free or unauthe
 
 If an instance admin selects a Brave Search or SearXNG credential in the AI settings UI, n8n uses that credential instead of these environment variables.
 
+## Enable instance context
+
+Instance context gives n8n Assistant a short summary of the project a conversation is opened in: which workflows exist, what changed recently, and what has run or failed. It's optional, and the rest of n8n Assistant works without it. See [What n8n Assistant knows about your instance](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/ways-of-building-workflows/n8n-assistant#what-n8n-assistant-knows-about-your-instance).
+
+It needs two variables. One records the changes, and the other lets n8n Assistant read them:
+
+```bash
+# Record workflow and credential changes in the activity log
+N8N_ACTIVITY_LOG_ENABLED=true
+
+# Let n8n Assistant read instance context
+N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED=true
+```
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `N8N_ACTIVITY_LOG_ENABLED` | `false` | Set to `true` to record workflow and credential changes in the instance activity log. |
+| `N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED` | `false` | Set to `true` to let n8n Assistant read instance context. |
+
+Set both. With only `N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED`, n8n Assistant still reports which workflows exist and what has run, because neither of those comes from the activity log. The recent-changes part stays empty, because nothing wrote an entry.
+
+The activity log records that a change happened and which node types moved. It never records parameter values, so it can tell n8n Assistant which nodes a project uses, never how they're configured.
+
+Turning `N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED` off removes instance context and the tool that reads the activity log. n8n Assistant then reads no instance context.
+
+## Enable node type counting
+
+Node type counting lets n8n Assistant ask how many workflows in a project use each node type, so it can follow your conventions without reading every workflow. It's separate from instance context and needs its own variable:
+
+```bash
+N8N_INSTANCE_AI_NODE_USAGE_ENABLED=true
+```
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `N8N_INSTANCE_AI_NODE_USAGE_ENABLED` | `false` | Set to `true` to let n8n Assistant count the node types a project uses. |
+
+Setting it to `false` doesn't force the feature off. It falls back to the managed rollout, which decides whether your instance gets it.
+
+Node type counting reports counts of node types, never parameter values.
+
 ## Enable agents
 
 Agents run on the same self-hosted stack as n8n Assistant. Once n8n Assistant works, add the `agents` module to [build and run agents on your instance](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/build-and-manage-agents). Agents are in Preview and available from n8n 2.32.3.
@@ -369,5 +410,12 @@ If n8n Assistant doesn't appear or doesn't work, check for these issues.
 
 * `INSTANCE_AI_BRAVE_SEARCH_API_KEY` is set, or `N8N_INSTANCE_AI_SEARXNG_URL` is set.
 * If nothing is set, this is expected. Web search is optional and the rest of n8n Assistant still works.
+
+**Instance context**
+
+* Both `N8N_ACTIVITY_LOG_ENABLED` and `N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED` are set to `true`.
+* If only `N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED` is set, n8n Assistant reports which workflows exist and which ran, but no recent changes. Set the activity log variable too.
+* Nothing changed in the project yet. The activity log only records changes made after you enabled it.
+* The project is empty, and nothing has run in it. n8n Assistant reports nothing rather than an empty summary.
 
 See [Configure n8n](./) for other configuration topics.

--- a/docs/deploy/host-n8n/configure-n8n/set-up-n8n-assistant.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-n8n-assistant.md
@@ -307,7 +307,7 @@ N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED=true
 
 Set both. With only `N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED`, n8n Assistant still reports which workflows exist and what has run, because neither of those comes from the activity log. The recent-changes part stays empty, because nothing wrote an entry. With only `N8N_ACTIVITY_LOG_ENABLED`, n8n records the changes but n8n Assistant reads none of them.
 
-The activity log records that a change happened and which node types you added or removed in it. It never records parameter values. It reports what changed in a save, not what the project uses now, which is what node type counting below answers.
+The activity log records that a change happened and which node types you added or removed in it. It never records parameter values. It reports what changed in a save, not what the project uses now. Node type counting reports current usage, and it needs its own variable.
 
 Turning `N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED` off removes instance context and the tool that reads the activity log. n8n Assistant then reads no instance context.
 

--- a/docs/deploy/host-n8n/configure-n8n/set-up-n8n-assistant.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-n8n-assistant.md
@@ -307,7 +307,7 @@ N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED=true
 
 Set both. With only `N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED`, n8n Assistant still reports which workflows exist and what has run, because neither of those comes from the activity log. The recent-changes part stays empty, because nothing wrote an entry. With only `N8N_ACTIVITY_LOG_ENABLED`, n8n records the changes but n8n Assistant reads none of them.
 
-The activity log records that a change happened and which node types you added or removed in it. It never records parameter values. It reports what changed in a save, not what the project uses now. Node type counting reports current usage, and it needs its own variable.
+The activity log records that a change happened and which node types you added or removed in it. It never records parameter values. It reports what changed in a save, not what the project uses now. Node type counting reports current usage. It needs its own variable.
 
 Turning `N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED` off removes instance context and the tool that reads the activity log. n8n Assistant then reads no instance context.
 
@@ -421,7 +421,7 @@ If n8n Assistant doesn't appear or doesn't work, check for these issues.
 **Node type counting**
 
 * `N8N_INSTANCE_AI_NODE_USAGE_ENABLED` is set to `true`.
-* The variable only turns the feature on. If it's unset and node type counting still doesn't work, the managed rollout hasn't reached your instance yet.
+* The variable only turns the feature on. If it isn't set to `true` and node type counting still doesn't work, the managed rollout hasn't reached your instance yet.
 * It's independent of instance context. Turning instance context on doesn't turn node type counting on.
 
 See [Configure n8n](./) for other configuration topics.

--- a/docs/deploy/host-n8n/configure-n8n/set-up-n8n-assistant.md
+++ b/docs/deploy/host-n8n/configure-n8n/set-up-n8n-assistant.md
@@ -323,7 +323,7 @@ N8N_INSTANCE_AI_NODE_USAGE_ENABLED=true
 | --- | --- | --- |
 | `N8N_INSTANCE_AI_NODE_USAGE_ENABLED` | `false` | Set to `true` to let n8n Assistant count the node types a project uses. |
 
-Setting it to `false` doesn't force the feature off. It falls back to the managed rollout, which decides whether your instance gets it.
+This variable only turns node type counting on. Setting it to `false`, or leaving it out, hands the decision back to the managed rollout, so it isn't a way to keep the feature off.
 
 Node type counting reports counts of node types, never parameter values.
 
@@ -421,7 +421,7 @@ If n8n Assistant doesn't appear or doesn't work, check for these issues.
 **Node type counting**
 
 * `N8N_INSTANCE_AI_NODE_USAGE_ENABLED` is set to `true`.
-* Setting it to `false` doesn't force the feature off. It falls back to the managed rollout, which may not have reached your instance.
+* The variable only turns the feature on. If it's unset and node type counting still doesn't work, the managed rollout hasn't reached your instance yet.
 * It's independent of instance context. Turning instance context on doesn't turn node type counting on.
 
 See [Configure n8n](./) for other configuration topics.


### PR DESCRIPTION
## Summary

**Do not merge yet.** These pages describe behavior that no instance shows. Instance context is off by default and has not been tested internally behind its flag. This PR exists for review only.

n8n Assistant now receives instance context at the start of a conversation. Instance context is a short summary of the project a conversation is opened in. It reports which workflows exist, what changed recently, and which workflows ran or failed.

This PR documents the feature on two pages.

**`build/ways-of-building-workflows/n8n-assistant.md`** gets a new section, *What n8n Assistant knows about your instance*. The section covers:

- What instance context reports, and the source of each part.
- The cadence. n8n Assistant gets the full picture with the first message. Later messages carry only what changed.
- What n8n Assistant can look up from it. It can read further back through recent changes, and it can open the live record from an ID.
- Node type counting, in its own sub-section. This is a separate setting, so it is documented separately.
- What instance context does not include. This is the load-bearing part. A change entry names the node types you added or removed. It never records parameter values and never records individual nodes. Anything about how a workflow is built needs a workflow read.

The same page gets one new capability bullet, and a new *Instance context stays inside one project* sub-section under *Data and privacy*. A conversation reads only the project it was opened in. n8n checks your permissions on every message. An ID from outside that project answers the same way as one that no longer exists.

**`deploy/host-n8n/configure-n8n/set-up-n8n-assistant.md`** gets two enablement sections and matching troubleshooting entries:

- *Enable instance context*, for `N8N_ACTIVITY_LOG_ENABLED` and `N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED`. The section explains that you must set both, and what happens if you set only one.
- *Enable node type counting*, for `N8N_INSTANCE_AI_NODE_USAGE_ENABLED`.

### Why node type counting is documented separately

Node type counting has its own flag and no dependency on instance context. An admin who followed a combined enablement section would get everything the pages promise except node type counting. The two capabilities are therefore described apart, and each names its own variable.

### One gap before this can publish

The pages carry no version number, so there is no **Feature availability** hint. Add one when the release is known.

### The MCP half is not here

Docs for the MCP surface are outlined but not written. Two decisions on https://linear.app/n8n/issue/CONTEXT-109 still control what those pages would say: the project scope an MCP client gets, and whether the reader honors `availableInMCP`. Both decide the privacy and scoping sentences, so the prose waits.

## How to test

Instance context is off by default. To see the documented behavior on a local instance, set both variables:

```bash
N8N_ACTIVITY_LOG_ENABLED=true \
N8N_INSTANCE_AI_INSTANCE_CONTEXT_ENABLED=true \
pnpm dev:be
```

Then build a workflow, publish it, and run it so that it fails. Open a **new** chat and ask "what should I look at?". n8n Assistant should name that workflow and its failure.

To review the pages themselves:

1. Read the GitBook preview for both changed pages.
2. Confirm the three cross-space links resolve. Two point from the assistant page to the deploy space. One points from the deploy page back to the assistant page.
3. Confirm the same-page link to *Instance context stays inside one project* resolves.

Both repository checks pass on the changed files:

```bash
python3 .github/scripts/check_gitbook_syntax.py docs/build/ways-of-building-workflows/n8n-assistant.md docs/deploy/host-n8n/configure-n8n/set-up-n8n-assistant.md
python3 .github/scripts/check_internal_links.py docs/build/ways-of-building-workflows/n8n-assistant.md docs/deploy/host-n8n/configure-n8n/set-up-n8n-assistant.md
```

Vale is not installed locally, and Lexi runs only on a pull request. Readability is therefore unverified by tooling.

## Related tickets and issues

- https://linear.app/n8n/issue/CONTEXT-107
- Documents the feature added in n8n-io/n8n#37867 and n8n-io/n8n#37539
- Parent: https://linear.app/n8n/issue/CONTEXT-84
- MCP half blocked by https://linear.app/n8n/issue/CONTEXT-109

## Review checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] Title and summary are descriptive.
- [ ] A **Feature availability** hint is added with a version, before merge.
- [ ] `N8N_INSTANCE_AI_NODE_USAGE_ENABLED` still exists, before merge. https://linear.app/n8n/issue/CONTEXT-112 proposes removing it as redundant, which would make the Enable node type counting section wrong.
- [ ] The read flag is tested internally, before merge.

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->