### PR TITLE
docs: update n8n MCP server docs for n8n#34975

### DIFF
--- a/docs/connect/connect-to-n8n-mcp-server/mcp-server-tools-reference.md
+++ b/docs/connect/connect-to-n8n-mcp-server/mcp-server-tools-reference.md
@@ -919,8 +919,10 @@ Create a workflow in n8n from validated SDK code. Parses the code into a workflo
 | `targetProject.id` | `string` | The ID of the project |
 | `targetProject.name` | `string` | The display name of the project |
 | `targetProject.type` | `"personal" \| "team"` | Whether the workflow was created in a personal or team project |
-| `note` | `string` | Additional notes about workflow creation, for example nodes skipped during credential auto-assignment or a description that was shortened to 255 characters |
+| `targetFolder` | `object` | The folder holding the workflow, with `id` and `name`. Omitted when the workflow sits at the project root |
+| `note` | `string` | Additional notes about workflow creation, for example nodes skipped during credential auto-assignment, a description that was shortened to 255 characters, or a post-save step that failed after n8n saved the workflow |
 | `hint` | `string` | Actionable recovery hint, if available after an error |
+| `errorCode` | `string` | Machine-readable error code. Present only on failure |
 
 #### Notes <a href="#notes" id="notes"></a>
 
@@ -933,6 +935,8 @@ Create a workflow in n8n from validated SDK code. Parses the code into a workflo
 - If the user names a target project, call `search_projects` first and pass the resolved `projectId`; don't guess.
 - After creation, tell the user which project the workflow was created in using the `targetProject` field.
 - From n8n 2.27.0, a `description` longer than 255 characters is truncated (not rejected); the response `note` mentions when this happens.
+- If n8n saves the workflow but a later step fails, the tool confirms the saved workflow and explains the failed step in `note`, instead of reporting the call as an error.
+- `errorCode` holds `HTTP_` plus the HTTP status code when the error carries one, the error's own error code when it has one, or `UNKNOWN_ERROR`.
 
 ---
 
@@ -1001,6 +1005,7 @@ Update an existing workflow in n8n by applying an ordered batch of targeted part
 | `validationWarnings[].nodeName` | `string` | Optional node associated with the warning |
 | `note` | `string` | Additional notes about the workflow update, for example HTTP Request nodes skipped during credential auto-assignment |
 | `error` | `string` | Error message if the update failed |
+| `errorCode` | `string` | Machine-readable error code |
 
 #### Notes <a href="#notes" id="notes"></a>
 
@@ -1010,6 +1015,7 @@ Update an existing workflow in n8n by applying an ordered batch of targeted part
 - HTTP Request nodes are skipped during credential auto-assignment and must be configured manually.
 - The resulting workflow is validated before saving. Validation warnings are returned in `validationWarnings`.
 - Marks the workflow with `aiBuilderAssisted` metadata and `builderVariant: mcp`.
+- `errorCode` holds `HTTP_` plus the HTTP status code when the error carries one, the error's own error code when it has one, or `UNKNOWN_ERROR`.
 
 ---
 


### PR DESCRIPTION
Automated draft. The n8n MCP docs need an update because n8n-io/n8n PR #34975 was approved and is about to ship.

**Source PR:** https://github.com/n8n-io/n8n/pull/34975 - fix(core): Eliminate false-negative 500s in workflow builder tools
**Source PR author:** sinehypernova-0718
**Pages updated:** Tools reference

**MCP files changed in the source PR:**
- `packages/cli/src/modules/mcp/mcp-post-save-metrics.service.ts` (added)
- `packages/cli/src/modules/mcp/mcp.service.ts` (modified)
- `packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts` (modified)
- `packages/cli/src/modules/mcp/tools/workflow-builder/error-code.utils.ts` (added)
- `packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts` (modified)

> Drafted automatically by the *MCP Docs Automation v2* n8n workflow. The source PR is approved but **not merged yet** - confirm it landed unchanged before merging this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the MCP workflow builder tools reference to match the behavior changes in n8n#34975. The docs now cover the new `errorCode` response field, the new `targetFolder` field in `create_workflow` responses, and clarify that post-save failures return a successful response with details in `note` instead of a false 500 error.

<sup>Written for commit 30da26d6ce3750c4d3418c381d7cc4e62be6fc19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

