### PR TITLE
docs: Document private CA support for source control HTTPS connections

### DIFF
--- a/docs/administer/use-source-control-and-environments/set-up-source-control.md
+++ b/docs/administer/use-source-control-and-environments/set-up-source-control.md
@@ -69,6 +69,18 @@ Required permissions for your token:
 - Contents read/write (for GitHub)
 - Source code pull/push (for GitLab)
 
+#### Git hosts with a private certificate authority
+
+{% hint style="info" %}
+**Feature availability**
+
+Private certificate authorities for Git connections are available from n8n 2.40.0.
+{% endhint %}
+
+If your Git host uses a certificate from a private certificate authority (CA), set the `GIT_SSL_CAINFO` environment variable on the n8n instance to the path of a PEM file that contains the CA certificate. Git uses its own trust store, so the [custom certificate authority](https://app.gitbook.com/s/jm0ZYRpZIPWge2ZSiDYO/host-n8n/configure-n8n/basic-configuration/configuration-examples/configure-custom-ssl-certificate-authorities) configuration for n8n doesn't apply to Git connections. If you keep the certificates in a directory indexed with `c_rehash`, set `GIT_SSL_CAPATH` to the directory instead.
+
+The file or directory replaces the default trust store for Git. If the instance also connects to public Git hosts, include their root certificates.
+
 ## Step 4: Connect n8n and configure your instance <a href="#step-4-connect-n8n-and-configure-your-instance" id="step-4-connect-n8n-and-configure-your-instance"></a>
 
 1. In **Settings** > **Environments** in n8n, select **Connect**. n8n connects to your Git repository.


### PR DESCRIPTION
## Summary

Adds a short section to the source control setup page for Git hosts signed by a private CA. It names `GIT_SSL_CAINFO` as the variable to set, points out that the n8n custom certificate authority configuration does not apply to Git, and notes that the file replaces Git's default trust store.

Companion to https://github.com/n8n-io/n8n/pull/38258, which makes n8n pass the variable to Git. The version in the availability hint assumes that PR ships in 2.40.0. Adjust it if the release or a backport changes that.

## Related

https://linear.app/n8n/issue/LIGO-1022

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

