### PR TITLE
docs: Add the Microsoft Teams online meeting and chat member operations

### DIFF
--- a/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftteams.md
+++ b/docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftteams.md
@@ -20,14 +20,22 @@ layout:
 
 # Microsoft Teams node <a href="#microsoft-teams-node" id="microsoft-teams-node"></a>
 
-Use the Microsoft Teams node to automate work in Microsoft Teams, and integrate Microsoft Teams with other applications. n8n has built-in support for a wide range of Microsoft Teams features, including creating and deleting, channels, messages, and tasks. 
+Use the Microsoft Teams node to automate work in Microsoft Teams, and integrate Microsoft Teams with other applications. n8n has built-in support for a wide range of Microsoft Teams features, including channels, channel and chat messages, chat members, online meetings, and tasks.
 
 On this page, you'll find a list of operations the Microsoft Teams node supports and links to more resources.
 
 {% hint style="info" %}
 **Credentials**
 
-Refer to [Microsoft credentials](../credentials/microsoft.md) for guidance on setting up authentication. From version 2 of the node, this node also supports the [Microsoft Entra Service Principal credentials](../credentials/microsoftentraserviceprincipal.md) for app-only access with no signed-in user: select **Service Principal (App-Only)** in the **Authentication** dropdown.
+From version 2 of the node, the **Authentication** dropdown offers three options:
+
+- **Teams OAuth2**: the Microsoft Teams-specific OAuth2 credential (default). Its default scopes cover every resource on this page, including `Chat.ReadWrite` for chat members and chat messages and, from n8n 2.39.0, `OnlineMeetings.ReadWrite` for online meetings.
+- **Microsoft OAuth2 (Graph)**: a generic Microsoft Graph credential that you can reuse across other Microsoft nodes. When you select this option, grant the credential the scopes this node needs. Refer to [Default scopes for Microsoft Teams](../credentials/microsoft.md#default-scopes-for-microsoft-teams) for the full list.
+- **Service Principal (App-Only)**: app-only access through a Microsoft Entra app registration, with no signed-in user. Some resources need a signed-in user and aren't available with this credential. Refer to [Service Principal credential support](#service-principal-credential-support) on this page, and to [Microsoft Entra Service Principal credentials](../credentials/microsoftentraserviceprincipal.md) for setup and the required application permissions.
+
+If you connected a Teams OAuth2 credential before n8n 2.39.0, reconnect it so it picks up `OnlineMeetings.ReadWrite`. If the credential uses **Custom Scopes**, add the scope to **Enabled Scopes** instead.
+
+Refer to [Microsoft credentials](../credentials/microsoft.md) for guidance on setting up authentication.
 {% endhint %}
 
 {% hint style="info" %}
@@ -42,6 +50,12 @@ If you're using a government cloud tenant (US Government, US Government DOD, or 
 
 ## Operations <a href="#operations" id="operations"></a>
 
+{% hint style="info" %}
+**Feature availability**
+
+The Chat Member and Online Meeting resources are available from n8n 2.39.0, together with the Channel Message **Get**, **Get Many Replies**, and **Reply** operations. The Chat Member **Add** operation and the Online Meeting **Create or Get**, **Delete**, and **Update** operations are available from n8n 2.40.0.
+{% endhint %}
+
 * Channel
     * Create
     * Delete
@@ -54,11 +68,20 @@ If you're using a government cloud tenant (US Government, US Government DOD, or 
     * Get Many
     * Get Many Replies
     * Reply
+* Chat Member
+    * Add
+    * Get Many
 * Chat Message
 	* Create
 	* Get
 	* Get Many
 	* Send and Wait for Response
+* Online Meeting
+    * Create
+    * Create or Get
+    * Delete
+    * Get
+    * Update
 * Task
     * Create
     * Delete
@@ -66,15 +89,20 @@ If you're using a government cloud tenant (US Government, US Government DOD, or 
     * Get Many
     * Update
 
-{% hint style="info" %}
-**Channel messages with Service Principal credentials**
-
-The **Create** and **Reply** operations for channel messages are not available with the Microsoft Entra Service Principal credentials. App-only Microsoft Graph supports only migration import for channel messages. Use an OAuth2 credential to send channel messages.
-
-The read operations stay available with the Service Principal credentials: **Get**, **Get Many**, and **Get Many Replies**.
-{% endhint %}
-
 {% include "https://app.gitbook.com/s/GixZThfitWP21x2gQFpD/~/reusable/c0Jp2CWNEFSR2IfIVdlL/" %}
+
+## Service Principal credential support
+
+The **Service Principal (App-Only)** credential has no signed-in user, so the Microsoft Teams node can't run operations that act as one. The list below states what's available for each resource. For the unavailable resources and operations, the node hides their fields and shows a notice when you select this credential. A workflow that still uses one of them fails with an error before the node sends any request.
+
+- **Channel**: all operations.
+- **Channel Message**: Get, Get Many, and Get Many Replies. Create and Reply aren't available, because app-only Microsoft Graph only supports migration import for channel messages. Use an OAuth2 credential to send channel messages.
+- **Chat Member**: not available. The node's chat picker lists the signed-in user's chats, which app-only access can't do, so the node blocks the whole resource, including chats given by ID.
+- **Chat Message**: not available. The node sends and reads chat messages as the signed-in user.
+- **Online Meeting**: not available. The node creates and manages online meetings as the signed-in user.
+- **Task**: all operations. Get Many always lists the tasks of a plan: the node hides the **Tasks For** option, so **Group Member** isn't available. The node also hides the **Team** picker, and the **Plan**, **Bucket**, and **Assigned To** fields accept an ID only.
+
+Refer to [Microsoft Entra Service Principal credentials](../credentials/microsoftentraserviceprincipal.md) for the application permissions each operation needs.
 
 ## Templates and examples <a href="#templates-and-examples" id="templates-and-examples"></a>
 

--- a/docs/integrations/builtin/credentials/microsoft.md
+++ b/docs/integrations/builtin/credentials/microsoft.md
@@ -224,6 +224,18 @@ Microsoft OneDrive credentials use the following scopes by default:
 * `offline_access`
 * `Files.ReadWrite.All`
 
+#### Default scopes for Microsoft Teams
+
+Microsoft Teams credentials use the following scopes by default:
+
+* `openid`
+* `offline_access`
+* `User.Read.All`
+* `Group.ReadWrite.All`
+* `Chat.ReadWrite`
+* `ChannelMessage.Read.All`
+* `OnlineMeetings.ReadWrite` (available from n8n 2.39.0)
+
 ### Service-specific settings <a href="#service-specific-settings" id="service-specific-settings"></a>
 
 The following services require extra information for OAuth2:

--- a/docs/integrations/builtin/credentials/microsoftentraserviceprincipal.md
+++ b/docs/integrations/builtin/credentials/microsoftentraserviceprincipal.md
@@ -58,7 +58,7 @@ Refer to Microsoft's documentation for more information:
 
 With the OAuth2 Microsoft credentials, nodes act as the user who signed in. With the Service Principal credential, there's no signed-in user, which changes how you use the nodes:
 
-- **You choose who or what to act on.** Each node shows an extra required parameter when you select this credential: **Access As** (a user or drive) in Microsoft OneDrive, Microsoft OneDrive Trigger, and Microsoft Excel (OneDrive), **Mailbox** in Microsoft Outlook and Microsoft Outlook Trigger, and **User** in Microsoft To Do. Enter a user principal name (UPN), for example `jane@contoso.com`, or a user object ID. In the **Access As** field you can instead select **Drive** and enter a drive ID. There's no list picker for these fields: paste the value directly. In the Microsoft Teams nodes, the **Authentication** option is labelled **Service Principal (App-Only)**, and the **Task** operations replace the group, plan, bucket, and member pickers with plain ID fields.
+- **You choose who or what to act on.** Each node shows an extra required parameter when you select this credential: **Access As** (a user or drive) in Microsoft OneDrive, Microsoft OneDrive Trigger, and Microsoft Excel (OneDrive), **Mailbox** in Microsoft Outlook and Microsoft Outlook Trigger, and **User** in Microsoft To Do. Enter a user principal name (UPN), for example `jane@contoso.com`, or a user object ID. In the **Access As** field you can instead select **Drive** and enter a drive ID. There's no list picker for these fields: paste the value directly. In the Microsoft Teams nodes, the **Authentication** option is labelled **Service Principal (App-Only)**, and the **Task** operations hide the **Team** picker and replace the **Plan**, **Bucket**, and **Assigned To** pickers with plain ID fields.
 - **Permissions apply tenant-wide.** Application permissions aren't scoped to one user. For example, the `Mail.Send` application permission lets the app send as any mailbox in the tenant unless you restrict it with an [Exchange Online application access policy](https://learn.microsoft.com/en-us/graph/auth-limit-mailbox-access). n8n recommends scoping tenant-wide mail permissions with an application access policy.
 - **Pickers see the whole tenant.** For example, the Microsoft Teams **Team** picker lists every team in the organization, not just teams the app has joined.
 - **Some operations aren't available.** The nodes hide anything that only exists for a signed-in user, such as drive search or Teams chats, or block it with an explanatory error. Refer to [Operations not available with app-only access](#operations-not-available-with-app-only-access).
@@ -139,19 +139,13 @@ The Microsoft Teams node needs `Team.ReadBasic.All` to list teams, plus a permis
 | Channel: Create | `Channel.Create` |
 | Channel: Update | `ChannelSettings.ReadWrite.All` |
 | Channel: Delete | `Channel.Delete.All` |
-| Channel Message: Get Many | `ChannelMessage.Read.All` |
+| Channel Message: Get, Get Many, Get Many Replies | `ChannelMessage.Read.All` |
 | Task: all operations | `Tasks.ReadWrite.All` |
 | Trigger: New Channel | `Channel.ReadBasic.All` |
 | Trigger: New Channel Message | `ChannelMessage.Read.All` |
 | Trigger: New Team Member | `TeamMember.Read.All` |
 
 <!-- vale on -->
-
-{% hint style="info" %}
-**Reading Teams channel messages uses a metered API**
-
-Reading channel messages with this credential uses Microsoft's metered Teams API. Your tenant may need billing or evaluation-model configuration, and Microsoft returns HTTP 402 if it's missing. Refer to [Payment models for Microsoft Teams APIs](https://learn.microsoft.com/en-us/graph/teams-licenses) for details.
-{% endhint %}
 
 ## Operations not available with app-only access
 
@@ -161,7 +155,7 @@ Some Microsoft Graph operations only exist for a signed-in user. When you select
 
 - **Microsoft OneDrive**: File: Search and Folder: Search. Microsoft Graph only offers drive search to signed-in users.
 - **Microsoft Excel (OneDrive)**: Workbook: Get Many, and searching for a workbook by name in the **Workbook** field. Set the field to **By ID** instead.
-- **Microsoft Teams**: the whole Chat Message resource, Channel Message: Create, and Task: Get Many in Group Member mode.
+- **Microsoft Teams**: the whole Chat Member, Chat Message, and Online Meeting resources. Channel Message: Create and Reply. Task: Get Many in Group Member mode.
 - **Microsoft Teams Trigger**: the New Chat and New Chat Message events, and the watch-all options. Pick a specific team or channel instead.
 
 <!-- vale on -->


### PR DESCRIPTION
## Summary

The Microsoft Teams node gained two resources that the docs page never listed: **Online Meeting** (Create, Create or Get, Delete, Get, Update) and **Chat Member** (Add, Get Many). This PR adds them and makes Service Principal support explicit for every resource.

Linear: https://linear.app/n8n/issue/ENT-447

## Changes

`docs/integrations/builtin/app-nodes/n8n-nodes-base.microsoftteams.md`

- Add the Online Meeting and Chat Member resources to the Operations list.
- Add a **Feature availability** hint. Both resources and the Channel Message Get, Get Many Replies, and Reply operations are in n8n 2.39.0. Chat Member Add and Online Meeting Create or Get, Delete, and Update are in n8n 2.40.0.
- Replace the channel-message-only Service Principal hint with a **Service Principal credential support** section that states availability per resource (Channel, Channel Message, Chat Member, Chat Message, Online Meeting, Task), matching the node's current gating.
- Restructure the Credentials hint into the three-option list the Outlook and OneDrive pages use. Name the `OnlineMeetings.ReadWrite` and `Chat.ReadWrite` scopes, and tell users with a pre-2.39.0 Teams credential to reconnect it so the new scope is granted.
- Fix the page intro, which still described only channels, messages, and tasks.

`docs/integrations/builtin/credentials/microsoft.md`

- Add **Default scopes for Microsoft Teams** next to the Outlook, SharePoint, and OneDrive lists. The node's **Microsoft OAuth2 (Graph)** option tells users to "see the docs for the full scope string", and the docs didn't have it.

`docs/integrations/builtin/credentials/microsoftentraserviceprincipal.md`

- Teams permission table: the `ChannelMessage.Read.All` row now names Get and Get Many Replies alongside Get Many.
- "Operations not available with app-only access": the Teams bullet now lists Chat Member, Online Meeting, and Channel Message Reply.
- Correct the Task picker description: the Team picker is hidden, and Plan, Bucket, and Assigned To accept an ID only.
- Remove the "metered API" hint. Microsoft stopped metering the Teams APIs on August 25, 2025 and marked the linked article deprecated. The node still shows a matching notice on Channel Message reads under Service Principal, which is a small code follow-up.

## Merge timing

Four operations (Online Meeting Create or Get, Delete, Update; Chat Member Add) are on `master` but not in a tagged release yet. They missed the 2.39.0 cut on September 8 and land in 2.40.0. Labelled `status:awaiting-release`. If the version number changes, the only edit is the hint under Operations.

## Checks

- `vale`: no new warnings on changed lines (remaining ones are the pre-existing "Get Many" weasel-word and "US Government" hits).
- `.github/scripts/check_gitbook_syntax.py`: clean.
- `.github/scripts/check_internal_links.py --strict-anchors`: clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

