### PR TITLE
Update latest and next version numbers

### DIFF
--- a/docs/reusable-content/.gitbook/includes/self-hosting/installation/latest-next-version.md
+++ b/docs/reusable-content/.gitbook/includes/self-hosting/installation/latest-next-version.md
@@ -6,6 +6,6 @@ title: latest-next-version
 
 n8n releases a new minor version most weeks. The `stable` version is for production use. `beta` is the most recent release. The `beta` version may be unstable. To report issues, use the [forum](https://community.n8n.io/c/questions/12).
 
-Current `stable`: 2.38.5
-Current `beta`: 2.39.1
+Current `stable`: 2.38.6
+Current `beta`: 2.39.2
 {% endhint %}


### PR DESCRIPTION
<!-- docops:automation=version-snippet -->

Automated stable/beta version-snippet update (npm dist-tags -> GitBook reusable content).

This PR is auto-merged once all required checks pass. A human is pinged only if something looks off: npm moved unexpectedly, or the PR changes more than the two version numbers.