### PR TITLE
docs(changelog): Business and Enterprise got the error workflow quota change in 2.28

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -50,7 +50,7 @@ Until now each of those runs counted like any other execution. Handling a failur
 
 Attach an error workflow to a workflow in its **Workflow Settings** and its runs are excluded from the count. One error workflow can serve as many workflows as you like.
 
-On Cloud the change has been live since 2.38. On self-hosted it applies to Business and Enterprise instances from 2.28.0, or 1.123.60 if you're still on v1. If some of your workflows still run without an error workflow, refer to [Handle errors gracefully](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/flow-logic/handle-errors-gracefully) to set one up.
+The change applies on Cloud from 2.38, and on self-hosted Business and Enterprise instances from 2.28.0, or 1.123.60 if you're still on v1. If some of your workflows still run without an error workflow, refer to [Handle errors gracefully](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/flow-logic/handle-errors-gracefully) to set one up.
 
 ## Use AI models and tool services without setting up provider accounts or credentials
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -50,7 +50,7 @@ Until now each of those runs counted like any other execution. Handling a failur
 
 Attach an error workflow to a workflow in its **Workflow Settings** and its runs are excluded from the count. One error workflow can serve as many workflows as you like.
 
-On Cloud the change has been live since 2.28. On self-hosted it applies to Business and Enterprise instances from 2.28.0, or 1.123.60 if you're still on v1. If some of your workflows still run without an error workflow, refer to [Handle errors gracefully](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/flow-logic/handle-errors-gracefully) to set one up.
+On Cloud the change has been live since 2.38. On self-hosted it applies to Business and Enterprise instances from 2.28.0, or 1.123.60 if you're still on v1. If some of your workflows still run without an error workflow, refer to [Handle errors gracefully](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/flow-logic/handle-errors-gracefully) to set one up.
 
 ## Use AI models and tool services without setting up provider accounts or credentials
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -50,7 +50,7 @@ Until now each of those runs counted like any other execution. Handling a failur
 
 Attach an error workflow to a workflow in its **Workflow Settings** and its runs are excluded from the count. One error workflow can serve as many workflows as you like.
 
-On Cloud the change is already live. On self-hosted it applies from 2.38.0, or 1.123.60 if you're still on v1. If some of your workflows still run without an error workflow, refer to [Handle errors gracefully](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/flow-logic/handle-errors-gracefully) to set one up.
+On Cloud the change is already live. On self-hosted it applies to Business and Enterprise instances from 2.28.0, or 1.123.60 if you're still on v1, and to all other instances from 2.38.0. If some of your workflows still run without an error workflow, refer to [Handle errors gracefully](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/flow-logic/handle-errors-gracefully) to set one up.
 
 ## Use AI models and tool services without setting up provider accounts or credentials
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -50,7 +50,7 @@ Until now each of those runs counted like any other execution. Handling a failur
 
 Attach an error workflow to a workflow in its **Workflow Settings** and its runs are excluded from the count. One error workflow can serve as many workflows as you like.
 
-On Cloud the change is already live. On self-hosted it applies to Business and Enterprise instances from 2.28.0, or 1.123.60 if you're still on v1, and to all other instances from 2.38.0. If some of your workflows still run without an error workflow, refer to [Handle errors gracefully](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/flow-logic/handle-errors-gracefully) to set one up.
+On Cloud the change has been live since 2.28. On self-hosted it applies to Business and Enterprise instances from 2.28.0, or 1.123.60 if you're still on v1. If some of your workflows still run without an error workflow, refer to [Handle errors gracefully](https://app.gitbook.com/s/rPN1zU5jaYNvwH7RzxqA/flow-logic/handle-errors-gracefully) to set one up.
 
 ## Use AI models and tool services without setting up provider accounts or credentials
 


### PR DESCRIPTION
Follow-up to #5343. The last paragraph of the error workflow quota entry now says the change has been live on Cloud since 2.38, and on self-hosted applies to Business and Enterprise instances from 2.28.0 (1.123.60 on v1). The unconfirmed "all other instances from 2.38.0" clause is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)