### PR TITLE
docs: fix Docker Compose GitHub link

### DIFF
--- a/docs/deploy/host-n8n/install-options/install-using-docker-compose.md
+++ b/docs/deploy/host-n8n/install-options/install-using-docker-compose.md
@@ -82,7 +82,7 @@ search:
 
 This defines every service you're setting up: n8n itself, the sandbox stack that lets n8n Assistant safely run code, and SearXNG for web search.
 
-{% @github-files/github-code-block %}
+{% @github-files/github-code-block url="https://github.com/n8n-io/n8n/blob/master/docker/get-n8n-compose.yml" %}
 
 ## What you've just set up
 


### PR DESCRIPTION
## Summary

Fix the broken GitHub embed in Step 4 of the Docker Compose installation guide by adding the missing source URL.

Fixes #5371

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

