### PR TITLE
docs: Update end-user credential documentation regarding which users can connect

### DIFF
--- a/docs/administer/manage-credentials/end-user-credentials.md
+++ b/docs/administer/manage-credentials/end-user-credentials.md
@@ -70,7 +70,7 @@ You can mix fixed and end-user credentials across nodes in one workflow. For exa
 3. Configure the connection. For OAuth credentials, include the **Client ID**, **Client Secret**, and **OAuth Redirect URL** to register with the service.
 4. Select **Save**.
 
-Users with project access can now connect their own account to this credential. When a user runs a workflow that uses the credential, n8n prompts them to connect if they haven't already. They can also connect from the n8n UI, by opening a node on the canvas or from the project's **Credentials** list.
+Users can now connect their own account to this credential. When a user runs a workflow that uses the credential, n8n prompts them to connect if they haven't already. Users with project access can also connect ahead of time from the n8n UI, by opening a node on the canvas or from the project's **Credentials** list.
 
 {% hint style="info" %}
 Some trigger nodes, such as the **MCP Server Trigger**, let you require that the triggering user has permission to execute the trigger. When you enable this, only users with a project role that allows workflow execution can trigger it. A user without that role can't connect their account.

--- a/docs/administer/manage-credentials/end-user-credentials.md
+++ b/docs/administer/manage-credentials/end-user-credentials.md
@@ -73,7 +73,7 @@ You can mix fixed and end-user credentials across nodes in one workflow. For exa
 Users can now connect their own account to this credential. When a user runs a workflow that uses the credential, n8n prompts them to connect if they haven't already. Users with project access can also connect ahead of time from the n8n UI, by opening a node on the canvas or from the project's **Credentials** list.
 
 {% hint style="info" %}
-Some trigger nodes, such as the **MCP Server Trigger**, let you require that the triggering user has permission to execute the trigger. When you enable this, only users with a project role that allows workflow execution can trigger it. A user without that role can't connect their account.
+Some trigger nodes, such as the **MCP Server Trigger**, **Chat Trigger**, and **Form Trigger**, let you require that the triggering user has permission to execute the trigger. When you enable this, only users with a project role that allows workflow execution can trigger it. A user without that role can't connect their account.
 {% endhint %}
 
 ## Connect your account


### PR DESCRIPTION
Previously the documentation stated that only users with project access could connect to end-user credentials in a workflow, but this is not accurate. With the recently added support for end-user credentials in other triggers, such as the form trigger and chat trigger, it is possible for users with no project access to connect their credentials when using the hosted pages of these nodes.
The documentation content as been updated to reflect this.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n-docs/pull/5379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

