### PR TITLE
ci(lychee): show PR link report as a comment and send the weekly sweep to n8n (DOC-2307)

### DIFF
--- a/.github/scripts/lychee_report.py
+++ b/.github/scripts/lychee_report.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Send the weekly lychee external-link sweep to the DocOps n8n webhook.
+
+Called by .github/workflows/lychee.yml after lycheeverse/lychee-action has written its
+JSON report. lychee itself no longer fails that job (`fail: false`); this script turns the
+report into one payload for n8n, which alerts Slack, adds a dated tab to the
+"DocOps - Outbound Links" Google Sheet and stores the rows in Supabase (DOC-2307).
+
+Exit codes: 0 = report delivered (or no webhook configured); 1 = the report file is
+missing (lychee crashed) or the POST failed. Broken links alone never fail the job: n8n
+owns the alerting.
+
+Config comes from the environment (see the workflow):
+  REPORT (path to lychee JSON, default lychee/out.json), EXIT_CODE (lychee-action
+  exit_code output), RUN_URL, WEBHOOK_URL / WEBHOOK_USER / WEBHOOK_PASSWORD,
+  plus GITHUB_REPOSITORY / GITHUB_RUN_ID / GITHUB_SHA / GITHUB_STEP_SUMMARY set by Actions.
+"""
+
+import base64
+import json
+import os
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+# lychee renamed its failure map across versions; read every spelling we know.
+MAP_KEYS = ("error_map", "fail_map", "timeout_map")
+MAX_FAILURES = 500
+
+# --------------------------------------------------------------------- pure helpers
+# No I/O here so the tests can cover them.
+
+
+def parse_status(entry):
+    """Return (code or None, message) from a lychee failure entry.
+
+    lychee writes `status` either as an object ({"text": "...", "code": 404}) or, in
+    older versions, as a plain string like "404 Not Found"."""
+    status = entry.get("status") if isinstance(entry, dict) else None
+    if isinstance(status, dict):
+        code = status.get("code")
+        try:
+            code = int(code) if code is not None else None
+        except (TypeError, ValueError):
+            code = None
+        text = status.get("text") or status.get("details") or ""
+        return code, str(text)
+    if isinstance(status, str):
+        parts = status.split()
+        code = int(parts[0]) if parts and parts[0].isdigit() else None
+        return code, status
+    return None, ""
+
+
+def flatten_failures(stats):
+    """One flat, de-duplicated, sorted list of {page, url, status, message}."""
+    seen = set()
+    out = []
+    for key in MAP_KEYS:
+        failure_map = (stats or {}).get(key) or {}
+        if not isinstance(failure_map, dict):
+            continue
+        for page, entries in failure_map.items():
+            page = str(page)
+            if page.startswith("./"):
+                page = page[2:]
+            for entry in entries or []:
+                url = entry.get("url") if isinstance(entry, dict) else str(entry)
+                if not url or (page, url) in seen:
+                    continue
+                seen.add((page, url))
+                code, message = parse_status(entry)
+                out.append({"page": page, "url": url, "status": code, "message": message})
+    out.sort(key=lambda f: (f["page"], f["url"]))
+    return out
+
+
+def _int(value):
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def build_payload(stats, ctx):
+    """The contract between this Action and the n8n webhook. `stats` is the parsed
+    lychee JSON (or {} when the report is missing); `ctx` carries run metadata."""
+    stats = stats or {}
+    failures = flatten_failures(stats)
+    errors = stats.get("errors")
+    totals = {
+        "total": _int(stats.get("total")),
+        "successful": _int(stats.get("successful")),
+        "excluded": _int(stats.get("excludes", stats.get("excluded"))),
+        "timeouts": _int(stats.get("timeouts")),
+        "errors": _int(errors) if errors is not None else len(failures),
+    }
+    return {
+        "source": "lychee-weekly",
+        "repo": ctx.get("repo", ""),
+        "run_id": ctx.get("run_id", ""),
+        "run_url": ctx.get("run_url", ""),
+        "sha": ctx.get("sha", ""),
+        "checked_at": ctx.get("checked_at", ""),
+        "lychee_exit_code": ctx.get("exit_code"),
+        "report_found": bool(ctx.get("report_found", True)),
+        "totals": totals,
+        "failures": failures[:MAX_FAILURES],
+        "failures_truncated": len(failures) > MAX_FAILURES,
+    }
+
+
+def summary_markdown(payload):
+    """Short job summary so the run page is readable without opening n8n."""
+    t = payload["totals"]
+    lines = ["## Lychee external links", ""]
+    if not payload.get("report_found", True):
+        lines.append("Lychee did not produce a report "
+                     f"(exit code {payload.get('lychee_exit_code')}).")
+        return "\n".join(lines) + "\n"
+    lines.append(f"- Checked: {t['total']} (excluded {t['excluded']}, "
+                 f"successful {t['successful']}, timeouts {t['timeouts']})")
+    lines.append(f"- Broken: {t['errors']}")
+    pages = {}
+    for f in payload["failures"]:
+        pages[f["page"]] = pages.get(f["page"], 0) + 1
+    if pages:
+        lines.append("")
+        lines.append("| Page | Broken links |")
+        lines.append("|---|---|")
+        for page, count in sorted(pages.items(), key=lambda kv: (-kv[1], kv[0]))[:20]:
+            lines.append(f"| `{page}` | {count} |")
+    if payload.get("failures_truncated"):
+        lines.append("")
+        lines.append(f"Only the first {MAX_FAILURES} broken links were sent to n8n.")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------- I/O
+
+def post(url, payload, user, password):
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data,
+                                 headers={"content-type": "application/json"})
+    if user or password:
+        token = base64.b64encode(f"{user or ''}:{password or ''}".encode()).decode()
+        req.add_header("Authorization", f"Basic {token}")
+    urllib.request.urlopen(req, timeout=30).read()
+
+
+def main():
+    report = Path(os.environ.get("REPORT", "lychee/out.json"))
+    stats = None
+    if report.is_file():
+        try:
+            stats = json.loads(report.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            print(f"::error::lychee report at {report} is not valid JSON: {e}")
+    else:
+        print(f"::error::lychee report not found at {report} (did lychee crash?)")
+
+    exit_code = os.environ.get("EXIT_CODE", "")
+    ctx = {
+        "repo": os.environ.get("GITHUB_REPOSITORY", ""),
+        "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+        "run_url": os.environ.get("RUN_URL", ""),
+        "sha": os.environ.get("GITHUB_SHA", ""),
+        "checked_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "exit_code": int(exit_code) if exit_code.isdigit() else None,
+        "report_found": stats is not None,
+    }
+    payload = build_payload(stats, ctx)
+
+    summary = summary_markdown(payload)
+    print(summary)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as fh:
+            fh.write(summary)
+
+    url = os.environ.get("WEBHOOK_URL")
+    if not url:
+        print("::warning::WEBHOOK_URL not set; report not sent to n8n.")
+        return 0 if stats is not None else 1
+
+    try:
+        post(url, payload, os.environ.get("WEBHOOK_USER"), os.environ.get("WEBHOOK_PASSWORD"))
+    except Exception as e:  # noqa: BLE001 - any delivery failure must go red
+        print(f"::error::POST to the DocOps webhook failed: {e}")
+        return 1
+    print(f"Report sent to n8n: {payload['totals']['errors']} broken link(s), "
+          f"{len(payload['failures'])} rows.")
+    return 0 if stats is not None else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/fixtures/lychee/out.json
+++ b/.github/scripts/tests/fixtures/lychee/out.json
@@ -1,0 +1,54 @@
+{
+  "total": 120,
+  "successful": 100,
+  "unknown": 0,
+  "unsupported": 0,
+  "timeouts": 1,
+  "redirects": 0,
+  "excludes": 16,
+  "errors": 3,
+  "cached": 5,
+  "error_map": {
+    "./docs/integrations/builtin/credentials/airtable.md": [
+      {
+        "url": "https://support.airtable.com/hc/en-us/articles/203255215-Formula-Field-Reference",
+        "status": {
+          "text": "Network error: Not Found",
+          "code": 404
+        }
+      },
+      {
+        "url": "https://www.npmjs.com/package/pg",
+        "status": {
+          "text": "403 Forbidden: Forbidden",
+          "code": 403
+        }
+      }
+    ],
+    "./docs/integrations/builtin/credentials/wise.md": [
+      {
+        "url": "https://n8n.io/integrations/netscaler-adc",
+        "status": "404 Not Found"
+      }
+    ]
+  },
+  "timeout_map": {
+    "./docs/integrations/builtin/credentials/wise.md": [
+      {
+        "url": "https://n8n.io/integrations/netscaler-adc",
+        "status": "404 Not Found"
+      }
+    ],
+    "docs/hosting/index.md": [
+      {
+        "url": "https://slow.example.com/",
+        "status": {
+          "text": "Timeout"
+        }
+      }
+    ]
+  },
+  "suggestion_map": {},
+  "excluded_map": {},
+  "duration_secs": 390
+}

--- a/.github/scripts/tests/test_lychee_report.py
+++ b/.github/scripts/tests/test_lychee_report.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Network-free tests for the pure helpers in lychee_report.py.
+
+The POST and the GitHub environment are not exercised here; these cover how a lychee
+JSON report is flattened into the payload the n8n webhook expects.
+
+Run: python3 .github/scripts/tests/test_lychee_report.py
+"""
+import importlib.util
+import json
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "lychee_report.py"
+FIXTURE = HERE / "fixtures" / "lychee" / "out.json"
+
+spec = importlib.util.spec_from_file_location("lychee_report", SCRIPT)
+lr = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(lr)
+
+checks = []
+
+
+def check(name, cond):
+    checks.append((name, bool(cond)))
+
+
+stats = json.loads(FIXTURE.read_text(encoding="utf-8"))
+ctx = {
+    "repo": "n8n-io/n8n-docs", "run_id": "123", "run_url": "https://github.com/x/y/actions/runs/123",
+    "sha": "abc", "checked_at": "2026-09-14T07:20:00Z", "exit_code": 2, "report_found": True,
+}
+
+# --- flatten_failures -------------------------------------------------------------
+failures = lr.flatten_failures(stats)
+check("flatten: de-duplicates the same page+url across maps", len(failures) == 4)
+check("flatten: strips the leading ./ from pages",
+      all(not f["page"].startswith("./") for f in failures))
+check("flatten: sorted by page then url",
+      [f["page"] for f in failures] == sorted(f["page"] for f in failures))
+airtable = [f for f in failures if f["page"].endswith("airtable.md")]
+check("flatten: object status gives numeric code and text",
+      airtable[0]["status"] == 404 and "Not Found" in airtable[0]["message"])
+wise = [f for f in failures if f["page"].endswith("wise.md")][0]
+check("flatten: string status is parsed into a code", wise["status"] == 404 and wise["message"] == "404 Not Found")
+timeout = [f for f in failures if f["url"].startswith("https://slow.")][0]
+check("flatten: timeout without a code keeps status None", timeout["status"] is None and timeout["message"] == "Timeout")
+
+# --- parse_status -----------------------------------------------------------------
+check("parse_status: non-numeric code becomes None", lr.parse_status({"status": {"code": "x", "text": "?"}}) == (None, "?"))
+check("parse_status: missing status", lr.parse_status({}) == (None, ""))
+
+# --- build_payload ----------------------------------------------------------------
+payload = lr.build_payload(stats, ctx)
+check("payload: source and run metadata",
+      payload["source"] == "lychee-weekly" and payload["run_id"] == "123" and payload["sha"] == "abc")
+check("payload: totals map lychee 'excludes' to 'excluded'",
+      payload["totals"] == {"total": 120, "successful": 100, "excluded": 16, "timeouts": 1, "errors": 3})
+check("payload: failures included and not truncated",
+      len(payload["failures"]) == 4 and payload["failures_truncated"] is False)
+check("payload: exit code passed through", payload["lychee_exit_code"] == 2)
+
+# fallback to fail_map (older lychee) and errors derived from the map when the counter is absent
+old = {"total": 5, "fail_map": {"./docs/a.md": [{"url": "https://x/1", "status": "500 Internal Server Error"}]}}
+old_payload = lr.build_payload(old, ctx)
+check("payload: fail_map fallback is read", old_payload["failures"][0]["url"] == "https://x/1")
+check("payload: errors derived from failures when lychee has no counter", old_payload["totals"]["errors"] == 1)
+
+# missing report -> empty totals, still a valid payload
+missing = lr.build_payload(None, dict(ctx, report_found=False, exit_code=1))
+check("payload: missing report yields zero totals and report_found False",
+      missing["totals"]["total"] == 0 and missing["failures"] == [] and missing["report_found"] is False)
+
+# truncation cap
+big = {"error_map": {"./docs/big.md": [{"url": f"https://x/{i}", "status": "404"} for i in range(lr.MAX_FAILURES + 7)]}}
+big_payload = lr.build_payload(big, ctx)
+check("payload: caps failures at MAX_FAILURES and flags truncation",
+      len(big_payload["failures"]) == lr.MAX_FAILURES and big_payload["failures_truncated"] is True)
+
+# --- summary_markdown -------------------------------------------------------------
+summary = lr.summary_markdown(payload)
+check("summary: mentions counts", "Checked: 120" in summary and "Broken: 3" in summary)
+check("summary: lists pages with counts", "airtable.md` | 2" in summary)
+check("summary: missing report explained", "did not produce a report" in lr.summary_markdown(missing))
+
+# --- report ------------------------------------------------------------------------
+failed = [name for name, ok in checks if not ok]
+for name, ok in checks:
+    print(("PASS " if ok else "FAIL ") + name)
+print(f"\n{len(checks) - len(failed)}/{len(checks)} checks passed")
+raise SystemExit(1 if failed else 0)

--- a/.github/workflows/lychee-pr-check.yml
+++ b/.github/workflows/lychee-pr-check.yml
@@ -1,10 +1,13 @@
 name: Lychee PR external linkcheck
+# Checks the external links in the markdown files a PR touches and posts the list of
+# broken ones as a PR comment. The comment is removed again once the links are fixed.
+# The job stays red while links are broken (it is a required check).
 on:
   pull_request:
     branches:
       - main
-permissions:  
-  contents: read 
+permissions:
+  contents: read
   pull-requests: write
 jobs:
   link-check:
@@ -25,13 +28,32 @@ jobs:
         if: steps.changed-markdown-files.outputs.any_changed == 'true'
         uses: lycheeverse/lychee-action@a99389aeff3c193ffb6f0741178e519569d3f404 # v2.3.0
         with:
-          args: --config lychee.toml ${{  steps.changed-markdown-files.outputs.all_changed_files }}
-      - name: PR comment with file
+          args: --config lychee.toml ${{ steps.changed-markdown-files.outputs.all_changed_files }}
+          # lychee-action writes its report here; it ignores `output` in lychee.toml.
+          output: lychee/out.md
+          # Don't fail inside the action, or the comment steps below never run.
+          # The last step fails the job explicitly when links are broken.
+          fail: false
+      - name: Comment broken links on the PR
+        if: steps.changed-markdown-files.outputs.any_changed == 'true' && steps.lychee.outputs.exit_code != '0'
+        # PRs from forks get a read-only token and cannot comment; the check still fails below.
+        continue-on-error: true
         uses: thollander/actions-comment-pull-request@e4a76dd2b0a3c2027c3fd84147a67c22ee4c90fa # v3.0.1
         with:
-          file-path: _lychee/out.md
-          comment-tag: execution
+          file-path: lychee/out.md
+          comment-tag: lychee
           mode: recreate
-      - name: Report Status
-        if: failure()
-        run: echo "❌ Broken links detected. Please fix them!"
+      - name: Remove stale broken-links comment
+        if: steps.changed-markdown-files.outputs.any_changed == 'true' && steps.lychee.outputs.exit_code == '0'
+        continue-on-error: true
+        uses: thollander/actions-comment-pull-request@e4a76dd2b0a3c2027c3fd84147a67c22ee4c90fa # v3.0.1
+        with:
+          message: All external links resolve.
+          comment-tag: lychee
+          mode: delete
+          create-if-not-exists: false
+      - name: Fail on broken links
+        if: steps.changed-markdown-files.outputs.any_changed == 'true' && steps.lychee.outputs.exit_code != '0'
+        run: |
+          echo "❌ Broken external links detected. See the PR comment (or the lychee step above) for the list."
+          exit 1

--- a/.github/workflows/lychee-pr-check.yml
+++ b/.github/workflows/lychee-pr-check.yml
@@ -44,7 +44,9 @@ jobs:
           comment-tag: lychee
           mode: recreate
       - name: Remove stale broken-links comment
-        if: steps.changed-markdown-files.outputs.any_changed == 'true' && steps.lychee.outputs.exit_code == '0'
+        # Also runs when lychee was skipped (the PR no longer touches any markdown file),
+        # so an earlier failing comment never outlives the problem.
+        if: steps.changed-markdown-files.outputs.any_changed != 'true' || steps.lychee.outputs.exit_code == '0'
         continue-on-error: true
         uses: thollander/actions-comment-pull-request@e4a76dd2b0a3c2027c3fd84147a67c22ee4c90fa # v3.0.1
         with:

--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -1,8 +1,15 @@
 name: Lychee external linkcheck
+# Weekly sweep of every external link under docs/. The JSON report is POSTed to the
+# DocOps n8n webhook (secret DOCOPS_LYCHEE_WEBHOOK_URL), which alerts Slack, adds a dated
+# tab to the "DocOps - Outbound Links" Google Sheet and stores the rows in Supabase.
+# Broken links do not fail this job: the job is red only if lychee itself crashed or the
+# report could not be delivered (DOC-2307).
 on:
   schedule:
-    - cron: "18 7 * * 1"  
-  workflow_dispatch: 
+    - cron: "18 7 * * 1"
+  workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   link-check:
     runs-on: ubuntu-latest
@@ -11,10 +18,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run Lychee Link Checker
-        uses: lycheeverse/lychee-action@f796c8b7d468feb9b8c0a46da3fac0af6874d374 # v2.2.0
+        id: lychee
+        uses: lycheeverse/lychee-action@a99389aeff3c193ffb6f0741178e519569d3f404 # v2.3.0
         with:
           args: --config lychee.toml ./docs
+          format: json
+          output: lychee/out.json
+          fail: false
+          jobSummary: false
 
-      - name: Report Status
-        if: failure()
-        run: echo "❌ Broken links detected. Please fix them!"
+      - name: Send report to n8n
+        if: always()
+        env:
+          REPORT: lychee/out.json
+          EXIT_CODE: ${{ steps.lychee.outputs.exit_code }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WEBHOOK_URL: ${{ secrets.DOCOPS_LYCHEE_WEBHOOK_URL }}
+          WEBHOOK_USER: ${{ secrets.WEBHOOK_USER }}
+          WEBHOOK_PASSWORD: ${{ secrets.WEBHOOK_PASSWORD }}
+        run: python3 .github/scripts/lychee_report.py

--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -48,3 +48,12 @@ jobs:
         run: python3 .github/scripts/tests/test_check_version_snippet_pr.py
       - name: Run docops_auto_merge tests
         run: python3 .github/scripts/tests/test_docops_auto_merge.py
+
+  lychee-report:
+    name: runner / lychee-report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Run lychee_report tests
+        run: python3 .github/scripts/tests/test_lychee_report.py

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ yarn.lock
 output.csv
 _doctools/*.csv
 
+## lychee link-check reports written by the GitHub Actions workflows / local runs (repo root only)
+/lychee/
+/_lychee/
+
 ## Python bytecode from running .github/scripts helpers and their tests
 __pycache__/
 *.pyc

--- a/lychee.toml
+++ b/lychee.toml
@@ -7,8 +7,9 @@ verbose = "warn"
 # Don't show interactive progress bar while checking links.
 no_progress = true
 
-# Path to summary output file.
-output = "_lychee/output.md"
+# Path to summary output file. Note: lychee-action ignores this and writes to its own
+# `output` input (set in the workflows), so this only applies to local runs.
+output = "lychee/out.md"
 format = "markdown"
 
 #############################  Cache  ###############################
@@ -138,7 +139,7 @@ exclude = [
   ]
 
 # Exclude these filesystem paths from getting checked.
-exclude_path = ["file/path/to/Ignore", "./other/file/path/to/Ignore"]
+exclude_path = []
 
 # URLs to check (supports regex). Has preference over all excludes.
 # include = ['gist\.github\.com.*']


### PR DESCRIPTION
Linear: https://linear.app/n8n/issue/DOC-2307/lychee-post-pr-link-report-as-a-comment-and-send-the-weekly-sweep-to

## Why

lychee already checks our external links, but nobody sees the results.

- On PRs, the comment step read `_lychee/out.md`, an empty file committed to the repo. lychee-action writes to `lychee/out.md`. Every PR got a blank bot comment, and when links were broken the job failed before the comment step ran, so authors saw a red check and no list.
- The weekly full sweep has failed every Monday since August with about 35 broken links and only wrote a log line.

## What changes

**PR check** (`lychee-pr-check.yml`)
- Read the file lychee actually writes.
- Comment the broken-link list only when there are broken links; delete the comment once they are fixed.
- Keep the `link-check` job red on broken links (explicit last step), so the required check still blocks.

**Weekly sweep** (`lychee.yml`)
- Output JSON and post it to the DocOps n8n webhook with the new stdlib script `.github/scripts/lychee_report.py` (unit tests included, wired into `script-tests.yml`).
- n8n turns the report into a Slack alert in #alerts-docs-automation, a dated tab in the "DocOps - Outbound Links" Google Sheet, and rows in Supabase. DocFather can answer "which outbound links are broken?" from the same data.
- Broken links no longer fail the weekly job. It is red only if lychee crashed or the report could not be delivered.

**Hygiene**
- Remove the empty `_lychee/out.md`, ignore `/lychee/`, fix the `output` path and the placeholder `exclude_path` in `lychee.toml`.

## How to verify

- A test PR with a deliberately broken external link should get a bot comment listing it and a red `link-check`. Fixing the link removes the comment.
- `python3 .github/scripts/tests/test_lychee_report.py` passes (19 checks).
- Run "Lychee external linkcheck" manually from this branch: the job summary shows the counts and a Slack message appears in #alerts-docs-automation.

Follow-up (separate ticket): triage the current broken links. 404s are content fixes; 403s from bot-blocking sites go into the lychee.toml exclude list.